### PR TITLE
Splits off a `replace` that reschedules tasks from the idempotent `add`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest tests/
+        run: uv run pytest --cov-branch --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
     name: Pre-commit checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ source = "vcs"
 packages = ["src/docket"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/docket --cov=tests --cov-report=term-missing"
+addopts = "--cov=src/docket --cov=tests --cov-report=term-missing --cov-branch"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -73,7 +73,7 @@ class Docket:
         function: Callable[P, Awaitable[R]],
         when: datetime | None = None,
         key: str | None = None,
-    ) -> Callable[P, Awaitable[Execution]]: ...
+    ) -> Callable[P, Awaitable[Execution]]: ...  # pragma: no cover
 
     @overload
     def add(
@@ -81,7 +81,7 @@ class Docket:
         function: str,
         when: datetime | None = None,
         key: str | None = None,
-    ) -> Callable[..., Awaitable[Execution]]: ...
+    ) -> Callable[..., Awaitable[Execution]]: ...  # pragma: no cover
 
     def add(
         self,
@@ -113,7 +113,7 @@ class Docket:
         function: Callable[P, Awaitable[R]],
         when: datetime,
         key: str,
-    ) -> Callable[P, Awaitable[Execution]]: ...
+    ) -> Callable[P, Awaitable[Execution]]: ...  # pragma: no cover
 
     @overload
     def replace(
@@ -121,7 +121,7 @@ class Docket:
         function: str,
         when: datetime,
         key: str,
-    ) -> Callable[..., Awaitable[Execution]]: ...
+    ) -> Callable[..., Awaitable[Execution]]: ...  # pragma: no cover
 
     def replace(
         self,

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -22,7 +22,7 @@ RedisReadGroupResponse = Sequence[RedisStream]
 class _stream_due_tasks(Protocol):
     async def __call__(
         self, keys: list[str], args: list[str | float]
-    ) -> tuple[int, int]: ...
+    ) -> tuple[int, int]: ...  # pragma: no cover
 
 
 class Worker:
@@ -194,7 +194,7 @@ class Worker:
             if not isinstance(param.default, Modifier):
                 continue
 
-            if isinstance(param.default, Retry):
+            if isinstance(param.default, Retry):  # pragma: no branch
                 retry_definition = param.default
                 retry = Retry(
                     attempts=retry_definition.attempts,

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -218,7 +218,7 @@ class Worker:
             retry = modifier
 
             if execution.attempt < retry.attempts:
-                execution.when += retry.delay
+                execution.when = datetime.now(timezone.utc) + retry.delay
                 execution.attempt += 1
                 await self.docket.schedule(execution)
                 return True


### PR DESCRIPTION
We want to have some optionality about rescheduling future work, so that
we can either leave an already task scheduled with `add` alone, or we
can `replace` it with a new schedule and parameters.
