### PR TITLE
Introduces a more formalized `Dependency` approach

### DIFF
--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -8,7 +8,17 @@ from importlib.metadata import version
 
 __version__ = version("docket")
 
+from .dependencies import CurrentDocket, CurrentWorker, Retry
 from .docket import Docket
+from .execution import Execution
 from .worker import Worker
 
-__all__ = ["Docket", "Worker", "__version__"]
+__all__ = [
+    "Docket",
+    "Worker",
+    "Execution",
+    "CurrentDocket",
+    "CurrentWorker",
+    "Retry",
+    "__version__",
+]

--- a/src/docket/dependencies.py
+++ b/src/docket/dependencies.py
@@ -1,0 +1,77 @@
+import abc
+import inspect
+from datetime import timedelta
+from typing import Any, Awaitable, Callable, Counter, cast
+
+from .docket import Docket
+from .execution import Execution
+from .worker import Worker
+
+
+class Dependency(abc.ABC):
+    single: bool = False
+
+    @abc.abstractmethod
+    def __call__(
+        self, docket: Docket, worker: Worker, execution: Execution
+    ) -> Any: ...  # pragma: no cover
+
+
+class _CurrentWorker(Dependency):
+    def __call__(self, docket: Docket, worker: Worker, execution: Execution) -> Worker:
+        return worker
+
+
+def CurrentWorker() -> Worker:
+    return cast(Worker, _CurrentWorker())
+
+
+class _CurrentDocket(Dependency):
+    def __call__(self, docket: Docket, worker: Worker, execution: Execution) -> Docket:
+        return docket
+
+
+def CurrentDocket() -> Docket:
+    return cast(Docket, _CurrentDocket())
+
+
+class Retry(Dependency):
+    single: bool = True
+
+    def __init__(self, attempts: int = 1, delay: timedelta = timedelta(0)) -> None:
+        self.attempts = attempts
+        self.delay = delay
+        self.attempt = 1
+
+    def __call__(self, docket: Docket, worker: Worker, execution: Execution) -> "Retry":
+        retry = Retry(attempts=self.attempts, delay=self.delay)
+        retry.attempt = execution.attempt
+        return retry
+
+
+def get_dependency_parameters(
+    function: Callable[..., Awaitable[Any]],
+) -> dict[str, Dependency]:
+    dependencies: dict[str, Any] = {}
+
+    signature = inspect.signature(function)
+
+    for param_name, param in signature.parameters.items():
+        if not isinstance(param.default, Dependency):
+            continue
+
+        dependencies[param_name] = param.default
+
+    return dependencies
+
+
+def validate_dependencies(function: Callable[..., Awaitable[Any]]) -> None:
+    parameters = get_dependency_parameters(function)
+
+    counts = Counter(type(dependency) for dependency in parameters.values())
+
+    for dependency_type, count in counts.items():
+        if dependency_type.single and count > 1:
+            raise ValueError(
+                f"Only one {dependency_type.__name__} dependency is allowed per task"
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from functools import partial
 from typing import AsyncGenerator, Callable
+from uuid import uuid4
 
 import pytest
 from testcontainers.redis import RedisContainer
@@ -26,7 +27,7 @@ async def redis_server() -> AsyncGenerator[RedisContainer, None]:
 @pytest.fixture
 async def docket(redis_server: RedisContainer) -> AsyncGenerator[Docket, None]:
     async with Docket(
-        name="test-docket",
+        name=f"test-docket-{uuid4()}",
         host=redis_server.get_container_host_ip(),
         port=redis_server.get_exposed_port(6379),
         db=0,

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,93 @@
+import pytest
+
+from docket import CurrentDocket, CurrentWorker, Docket, Worker
+from docket.dependencies import Retry
+
+
+async def test_dependencies_may_be_duplicated(docket: Docket, worker: Worker):
+    called = False
+
+    async def the_task(
+        a: str,
+        b: str,
+        docketA: Docket = CurrentDocket(),
+        docketB: Docket = CurrentDocket(),
+        workerA: Worker = CurrentWorker(),
+        workerB: Worker = CurrentWorker(),
+    ):
+        assert a == "a"
+        assert b == "b"
+        assert docketA is docket
+        assert docketB is docket
+        assert workerA is worker
+        assert workerB is worker
+
+        nonlocal called
+        called = True
+
+    await docket.add(the_task)("a", "b")
+
+    await worker.run_until_current()
+
+    assert called
+
+
+async def test_retries_must_be_unique(docket: Docket, worker: Worker):
+    async def the_task(
+        a: str,
+        retryA: Retry = Retry(attempts=3),
+        retryB: Retry = Retry(attempts=5),
+    ):
+        pass  # pragma: no cover
+
+    with pytest.raises(
+        ValueError,
+        match="Only one Retry dependency is allowed per task",
+    ):
+        await docket.add(the_task)("a")
+
+
+async def test_users_can_provide_dependencies_directly(docket: Docket, worker: Worker):
+    called = False
+
+    async def the_task(
+        a: str,
+        b: str,
+        retry: Retry = Retry(attempts=3),
+    ):
+        assert a == "a"
+        assert b == "b"
+        assert retry.attempts == 42
+
+        nonlocal called
+        called = True
+
+    await docket.add(the_task)("a", "b", retry=Retry(attempts=42))
+
+    await worker.run_until_current()
+
+    assert called
+
+
+async def test_user_provide_retries_are_used(docket: Docket, worker: Worker):
+    calls = 0
+
+    async def the_task(
+        a: str,
+        b: str,
+        retry: Retry = Retry(attempts=42),
+    ):
+        assert a == "a"
+        assert b == "b"
+        assert retry.attempts == 2
+
+        nonlocal calls
+        calls += 1
+
+        raise Exception("womp womp")
+
+    await docket.add(the_task)("a", "b", retry=Retry(attempts=2))
+
+    await worker.run_until_current()
+
+    assert calls == 2

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,8 +1,10 @@
+import asyncio
+from unittest.mock import AsyncMock
+
 import pytest
 from redis import RedisError
 
-from docket.docket import Docket
-from docket.worker import Worker
+from docket import CurrentWorker, Docket, Worker
 
 
 async def test_worker_aenter_propagates_connection_errors():
@@ -12,3 +14,54 @@ async def test_worker_aenter_propagates_connection_errors():
     worker = Worker(docket)
     with pytest.raises(RedisError):
         await worker.__aenter__()
+
+
+@pytest.fixture
+def the_task() -> AsyncMock:
+    task = AsyncMock()
+    task.__name__ = "the_task"
+    return task
+
+
+async def test_worker_acknowledges_messages(
+    docket: Docket, worker: Worker, the_task: AsyncMock
+):
+    """The worker should acknowledge and drain messages as they're processed"""
+
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    async with docket.redis() as redis:
+        pending_info = await redis.xpending(
+            name=docket.stream_key,
+            groupname=worker.consumer_group_name,
+        )
+        assert pending_info["pending"] == 0
+
+        assert await redis.xlen(docket.stream_key) == 0
+
+
+async def test_two_workers_split_work(docket: Docket):
+    """Two workers should split the workload"""
+
+    worker1 = Worker(docket)
+    worker2 = Worker(docket)
+
+    call_counts = {
+        worker1: 0,
+        worker2: 0,
+    }
+
+    async def the_task(worker: Worker = CurrentWorker()):
+        call_counts[worker] += 1
+
+    for _ in range(100):
+        await docket.add(the_task)()
+
+    async with worker1, worker2:
+        await asyncio.gather(worker1.run_until_current(), worker2.run_until_current())
+
+    assert call_counts[worker1] + call_counts[worker2] == 100
+    assert call_counts[worker1] > 40
+    assert call_counts[worker2] > 40


### PR DESCRIPTION
Here I'm formalizing the idea of the `Dependency` task parameters, with
a convention that dependency subclasses are callable to return the
actual value they will give the to the task at runtime.  They are given
the current docket, worker, and execution as context, but they can
return any value.

I've introduced `CurrentDocket` and `CurrentWorker`, and I've reworked
`Retry` to this framework.
