### PR TITLE
Adds a chaos testing suite

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -1,0 +1,32 @@
+name: Docket Chaos Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+jobs:
+  test:
+    name: Test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv and set Python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run chaos tests
+        run: python -m chaos.driver

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -9,11 +9,8 @@ on:
 
 jobs:
   test:
-    name: Test Python ${{ matrix.python-version }}
+    name: Test Python 3.12
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +18,7 @@ jobs:
       - name: Install uv and set Python version
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.12
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Test Python 3.12
+    name: Chaos tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,6 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
 
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4

--- a/chaos/README.md
+++ b/chaos/README.md
@@ -1,0 +1,6 @@
+This directory includes a chaos and load testing suite that can verify `docket` under
+more real-world conditions.
+
+This test suite should have a mode that can run in under a minute or two for use in CI,
+but longer tests for performance are totally fine.  Everything should be self-contained,
+reproducable, and verifiable.

--- a/chaos/README.md
+++ b/chaos/README.md
@@ -3,4 +3,4 @@ more real-world conditions.
 
 This test suite should have a mode that can run in under a minute or two for use in CI,
 but longer tests for performance are totally fine.  Everything should be self-contained,
-reproducable, and verifiable.
+reproducible, and verifiable.

--- a/chaos/driver.py
+++ b/chaos/driver.py
@@ -1,0 +1,166 @@
+import asyncio
+import random
+import sys
+from asyncio import subprocess
+from asyncio.subprocess import Process
+from datetime import timedelta
+from typing import Any, Literal, Sequence
+from uuid import uuid4
+
+import redis.exceptions
+from testcontainers.redis import RedisContainer
+
+from docket import Docket
+
+from .tasks import toxic
+
+
+async def main(
+    mode: Literal["chaos", "performance"] = "chaos",
+    tasks: int = 10000,
+    producers: int = 5,
+    workers: int = 10,
+):
+    with RedisContainer("redis:7.4.2") as redis_server:
+        docket = Docket(
+            name=f"test-docket-{uuid4()}",
+            host=redis_server.get_container_host_ip(),
+            port=redis_server.get_exposed_port(6379),
+            db=0,
+        )
+        environment = {
+            "CHAOS_DOCKET_NAME": docket.name,
+            "CHAOS_REDIS_HOST": docket.host,
+            "CHAOS_REDIS_PORT": str(docket.port),
+            "CHAOS_REDIS_DB": str(docket.db),
+        }
+
+        if tasks % producers != 0:
+            raise ValueError("total_tasks must be divisible by total_producers")
+
+        tasks_per_producer = tasks // producers
+
+        print(f"Spawning {producers} producers with {tasks_per_producer} tasks each...")
+
+        async def spawn_producer() -> Process:
+            return await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "chaos.producer",
+                str(tasks_per_producer),
+                env=environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+        producer_processes: list[Process] = []
+        for _ in range(producers):
+            producer_processes.append(await spawn_producer())
+
+        print(f"Spawning {workers} workers...")
+
+        async def spawn_worker() -> Process:
+            return await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "chaos.worker",
+                env=environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+        worker_processes: list[Process] = []
+        for _ in range(workers):
+            worker_processes.append(await spawn_worker())
+
+        while True:
+            try:
+                async with docket.redis() as r:
+                    info: dict[str, Any] = await r.info()
+                    connected_clients = int(info.get("connected_clients", 0))
+
+                    sent_tasks = await r.zcard("hello:sent")
+                    received_tasks = await r.zcard("hello:received")
+
+                    print(
+                        f"sent: {sent_tasks}, "
+                        f"received: {received_tasks}, "
+                        f"clients: {connected_clients}"
+                    )
+                    if sent_tasks >= tasks:
+                        break
+            except redis.exceptions.ConnectionError as e:
+                print(f"driver: Redis connection error ({e}), retrying in 5s...")
+                await asyncio.sleep(5)
+
+            # Now apply some chaos to the system:
+
+            if mode == "chaos":
+                chaos_chance = random.random()
+                if chaos_chance < 0.01:
+                    print("CHAOS: Killing redis server...")
+                    redis_server.stop()
+
+                    await asyncio.sleep(5)
+
+                    print("CHAOS: Starting redis server...")
+                    while True:
+                        try:
+                            redis_server.start()
+                            break
+                        except Exception:
+                            print("  Redis server failed, retrying in 5s...")
+                            await asyncio.sleep(5)
+
+                elif chaos_chance < 0.10:
+                    worker_index = random.randrange(len(worker_processes))
+                    worker_to_kill = worker_processes.pop(worker_index)
+
+                    print(f"CHAOS: Killing worker {worker_index}...")
+                    try:
+                        worker_to_kill.terminate()
+                    except ProcessLookupError:
+                        print("  What is dead may never die!")
+
+                    print(f"CHAOS: Replacing worker {worker_index}...")
+                    worker_processes.append(await spawn_worker())
+                elif chaos_chance < 0.15:
+                    print("CHAOS: Queuing a toxic task...")
+                    try:
+                        async with docket:
+                            await docket.add(toxic)()
+                    except redis.exceptions.ConnectionError:
+                        pass
+
+            await asyncio.sleep(0.25)
+
+        async with docket.redis() as r:
+            first_entries: Sequence[tuple[bytes, float]] = await r.zrange(
+                "hello:received", 0, 0, withscores=True
+            )
+            last_entries: Sequence[tuple[bytes, float]] = await r.zrange(
+                "hello:received", -1, -1, withscores=True
+            )
+
+            _, min_score = first_entries[0]
+            _, max_score = last_entries[0]
+            total_time = timedelta(seconds=max_score - min_score)
+
+            print(
+                f"Processed {tasks} tasks in {total_time}, "
+                f"averaging {tasks / total_time.total_seconds():.2f}/s"
+            )
+
+        for process in producer_processes + worker_processes:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                continue
+            await process.wait()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "performance":
+        asyncio.run(main(mode="performance"))
+    else:
+        asyncio.run(main())

--- a/chaos/producer.py
+++ b/chaos/producer.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import sys
+import time
+
+import redis.exceptions
+
+from docket import Docket
+
+from .tasks import hello
+
+
+async def main(tasks_to_produce: int):
+    docket = Docket(
+        name=os.environ["CHAOS_DOCKET_NAME"],
+        host=os.environ["CHAOS_REDIS_HOST"],
+        port=int(os.environ["CHAOS_REDIS_PORT"]),
+        db=int(os.environ["CHAOS_REDIS_DB"]),
+    )
+    tasks_sent = 0
+    while tasks_sent < tasks_to_produce:
+        try:
+            async with docket:
+                async with docket.redis() as r:
+                    for _ in range(tasks_sent, tasks_to_produce):
+                        execution = await docket.add(hello)()
+                        await r.zadd("hello:sent", {execution.key: time.time()})
+                        tasks_sent += 1
+        except redis.exceptions.ConnectionError:
+            print(
+                "producer: Redis connection error, retrying in 5s... "
+                f"({tasks_sent}/{tasks_to_produce} tasks sent)"
+            )
+            await asyncio.sleep(5)
+
+
+if __name__ == "__main__":
+    tasks = int(sys.argv[1])
+    asyncio.run(main(tasks))

--- a/chaos/tasks.py
+++ b/chaos/tasks.py
@@ -1,0 +1,17 @@
+import sys
+import time
+
+from docket import CurrentDocket, Docket, Retry, TaskKey
+
+
+async def hello(
+    key: str = TaskKey(),
+    docket: Docket = CurrentDocket(),
+    retry: Retry = Retry(attempts=sys.maxsize),
+):
+    async with docket.redis() as redis:
+        await redis.zadd("hello:received", {key: time.time()})
+
+
+async def toxic():
+    sys.exit(42)

--- a/chaos/worker.py
+++ b/chaos/worker.py
@@ -1,0 +1,26 @@
+import asyncio
+import os
+from datetime import timedelta
+
+from docket import Docket, Worker
+
+from .tasks import hello, toxic
+
+
+async def main():
+    docket = Docket(
+        name=os.environ["CHAOS_DOCKET_NAME"],
+        host=os.environ["CHAOS_REDIS_HOST"],
+        port=int(os.environ["CHAOS_REDIS_PORT"]),
+        db=int(os.environ["CHAOS_REDIS_DB"]),
+    )
+    async with docket:
+        docket.register(hello)
+        docket.register(toxic)
+
+        async with Worker(docket, redelivery_timeout=timedelta(seconds=5)) as worker:
+            await worker.run_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import version
 
 __version__ = version("pydocket")
 
-from .dependencies import CurrentDocket, CurrentWorker, Retry
+from .dependencies import CurrentDocket, CurrentExecution, CurrentWorker, Retry, TaskKey
 from .docket import Docket
 from .execution import Execution
 from .worker import Worker
@@ -19,6 +19,8 @@ __all__ = [
     "Execution",
     "CurrentDocket",
     "CurrentWorker",
+    "CurrentExecution",
+    "TaskKey",
     "Retry",
     "__version__",
 ]

--- a/src/docket/dependencies.py
+++ b/src/docket/dependencies.py
@@ -35,6 +35,26 @@ def CurrentDocket() -> Docket:
     return cast(Docket, _CurrentDocket())
 
 
+class _CurrentExecution(Dependency):
+    def __call__(
+        self, docket: Docket, worker: Worker, execution: Execution
+    ) -> Execution:
+        return execution
+
+
+def CurrentExecution() -> Execution:
+    return cast(Execution, _CurrentExecution())
+
+
+class _TaskKey(Dependency):
+    def __call__(self, docket: Docket, worker: Worker, execution: Execution) -> str:
+        return execution.key
+
+
+def TaskKey() -> str:
+    return cast(str, _TaskKey())
+
+
 class Retry(Dependency):
     single: bool = True
 

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -57,7 +57,6 @@ class Docket:
             port=self.port,
             db=self.db,
             password=self.password,
-            single_connection_client=True,
         ) as redis:
             yield redis
 

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -12,7 +12,16 @@ from uuid import uuid4
 
 import pytest
 
-from docket import CurrentDocket, CurrentWorker, Docket, Retry, Worker
+from docket import (
+    CurrentDocket,
+    CurrentExecution,
+    CurrentWorker,
+    Docket,
+    Execution,
+    Retry,
+    TaskKey,
+    Worker,
+)
 
 
 @pytest.fixture
@@ -298,6 +307,52 @@ async def test_supports_requesting_current_worker(
         called = True
 
     await docket.add(the_task)("a", b="c")
+
+    await worker.run_until_current()
+
+    assert called
+
+
+async def test_supports_requesting_current_execution(
+    docket: Docket, worker: Worker, now: Callable[[], datetime]
+):
+    """docket should support providing the current execution to a task"""
+
+    called = False
+
+    async def the_task(a: str, b: str, this_execution: Execution = CurrentExecution()):
+        assert a == "a"
+        assert b == "c"
+
+        assert isinstance(this_execution, Execution)
+        assert this_execution.key == "my-cool-task:123"
+
+        nonlocal called
+        called = True
+
+    await docket.add(the_task, key="my-cool-task:123")("a", b="c")
+
+    await worker.run_until_current()
+
+    assert called
+
+
+async def test_supports_requesting_current_task_key(
+    docket: Docket, worker: Worker, now: Callable[[], datetime]
+):
+    """docket should support providing the current task key to a task"""
+
+    called = False
+
+    async def the_task(a: str, b: str, this_key: str = TaskKey()):
+        assert a == "a"
+        assert b == "c"
+        assert this_key == "my-cool-task:123"
+
+        nonlocal called
+        called = True
+
+    await docket.add(the_task, key="my-cool-task:123")("a", b="c")
 
     await worker.run_until_current()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,8 +1,10 @@
 import asyncio
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
 from redis import RedisError
+from redis.exceptions import ConnectionError
 
 from docket import CurrentWorker, Docket, Worker
 
@@ -65,3 +67,32 @@ async def test_two_workers_split_work(docket: Docket):
     assert call_counts[worker1] + call_counts[worker2] == 100
     assert call_counts[worker1] > 40
     assert call_counts[worker2] > 40
+
+
+async def test_worker_reconnects_when_connection_is_lost(
+    docket: Docket, the_task: AsyncMock
+):
+    """The worker should reconnect when the connection is lost"""
+    worker = Worker(docket, reconnection_delay=timedelta(milliseconds=100))
+
+    # Mock the _worker_loop method to fail once then succeed
+    original_worker_loop = worker._worker_loop
+    call_count = 0
+
+    async def mock_worker_loop(forever: bool = False):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("Simulated connection error")
+        return await original_worker_loop(forever=forever)
+
+    worker._worker_loop = mock_worker_loop
+
+    await docket.add(the_task)()
+
+    async with worker:
+        await worker.run_until_current()
+
+    assert call_count == 2
+
+    the_task.assert_called_once()


### PR DESCRIPTION
This suite gives us a way to test some of the resiliency features of
`docket` in ways that are challenging to the unit test suite.  Here we
can run many processes, crash them, even restart the redis server in
order to see how the system behaves.

As a fun side note, I got some extra help with chaos testing here
because on my system I would often overload the proxy started by
`testcontainers` and cause errors connecting to redis throughout.  This
gave me a lot of real-world examples of places to handle errors in a
safer way.

This also required implementing `Worker.run_forever`, which is now in
place, if a little kludgey.

Closes #16
Part of #8
