### PR TITLE
Adds metrics for all activities, in OpenTelemetry and Prometheus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "cloudpickle>=3.1.1",
     "opentelemetry-api>=1.30.0",
+    "opentelemetry-exporter-prometheus>=0.51b0",
     "prometheus-client>=0.21.1",
     "redis>=5.2.1",
     "typer>=0.15.1",

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -13,7 +13,7 @@ app: typer.Typer = typer.Typer(
     help="Start a worker to process tasks",
 )
 def worker() -> None:
-    print("TODO: start the worker")
+    print("TODO: Configure and start a worker")
 
 
 @app.command(

--- a/src/docket/instrumentation.py
+++ b/src/docket/instrumentation.py
@@ -1,4 +1,79 @@
+from opentelemetry import metrics
 from opentelemetry.propagators.textmap import Getter, Setter
+
+meter: metrics.Meter = metrics.get_meter("docket")
+
+TASKS_ADDED = meter.create_counter(
+    "docket_tasks_added",
+    description="How many tasks added to the docket",
+    unit="1",
+)
+
+TASKS_REPLACED = meter.create_counter(
+    "docket_tasks_replaced",
+    description="How many tasks replaced on the docket",
+    unit="1",
+)
+
+TASKS_SCHEDULED = meter.create_counter(
+    "docket_tasks_scheduled",
+    description="How many tasks added or replaced on the docket",
+    unit="1",
+)
+
+TASKS_CANCELLED = meter.create_counter(
+    "docket_tasks_cancelled",
+    description="How many tasks cancelled from the docket",
+    unit="1",
+)
+
+TASKS_STARTED = meter.create_counter(
+    "docket_tasks_started",
+    description="How many tasks started",
+    unit="1",
+)
+
+TASKS_COMPLETED = meter.create_counter(
+    "docket_tasks_completed",
+    description="How many tasks that have completed in any state",
+    unit="1",
+)
+
+TASKS_FAILED = meter.create_counter(
+    "docket_tasks_failed",
+    description="How many tasks that have failed",
+    unit="1",
+)
+
+TASKS_SUCCEEDED = meter.create_counter(
+    "docket_tasks_succeeded",
+    description="How many tasks that have succeeded",
+    unit="1",
+)
+
+TASKS_RETRIED = meter.create_counter(
+    "docket_tasks_retried",
+    description="How many tasks that have been retried",
+    unit="1",
+)
+
+TASK_DURATION = meter.create_histogram(
+    "docket_task_duration",
+    description="How long tasks take to complete",
+    unit="s",
+)
+
+TASK_PUNCTUALITY = meter.create_histogram(
+    "docket_task_punctuality",
+    description="How close a task was to its scheduled time",
+    unit="s",
+)
+
+TASKS_RUNNING = meter.create_up_down_counter(
+    "docket_tasks_running",
+    description="How many tasks that are currently running",
+    unit="1",
+)
 
 Message = dict[bytes, bytes]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from functools import partial
 from typing import AsyncGenerator, Callable
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -39,3 +40,10 @@ async def docket(redis_server: RedisContainer) -> AsyncGenerator[Docket, None]:
 async def worker(docket: Docket) -> AsyncGenerator[Worker, None]:
     async with Worker(docket) as worker:
         yield worker
+
+
+@pytest.fixture
+def the_task() -> AsyncMock:
+    task = AsyncMock()
+    task.__name__ = "the_task"
+    return task

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,8 +1,15 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import Span, TracerProvider
 
 from docket import Docket, Worker
+from docket.dependencies import Retry
+from docket.instrumentation import message_getter, message_setter
 
 tracer = trace.get_tracer(__name__)
 
@@ -81,7 +88,6 @@ async def test_task_spans_are_linked_to_the_originating_span(
 
 async def test_message_getter_returns_none_for_missing_key():
     """Should return None when a key is not present in the message."""
-    from docket.instrumentation import message_getter
 
     message = {b"existing_key": b"value"}
     result = message_getter.get(message, "missing_key")
@@ -91,7 +97,6 @@ async def test_message_getter_returns_none_for_missing_key():
 
 async def test_message_getter_returns_decoded_value():
     """Should return a list with the decoded value when a key is present."""
-    from docket.instrumentation import message_getter
 
     message = {b"key": b"value"}
     result = message_getter.get(message, "key")
@@ -101,7 +106,6 @@ async def test_message_getter_returns_decoded_value():
 
 async def test_message_getter_keys_returns_decoded_keys():
     """Should return a list of all keys in the message as decoded strings."""
-    from docket.instrumentation import message_getter
 
     message = {b"key1": b"value1", b"key2": b"value2"}
     result = message_getter.keys(message)
@@ -111,7 +115,6 @@ async def test_message_getter_keys_returns_decoded_keys():
 
 async def test_message_setter_encodes_key_and_value():
     """Should encode both key and value when setting a value in the message."""
-    from docket.instrumentation import message_setter
 
     message: dict[bytes, bytes] = {}
     message_setter.set(message, "key", "value")
@@ -121,9 +124,333 @@ async def test_message_setter_encodes_key_and_value():
 
 async def test_message_setter_overwrites_existing_value():
     """Should overwrite an existing value when setting a value for an existing key."""
-    from docket.instrumentation import message_setter
 
     message = {b"key": b"old_value"}
     message_setter.set(message, "key", "new_value")
 
     assert message == {b"key": b"new_value"}
+
+
+@pytest.fixture
+def docket_labels(docket: Docket, the_task: AsyncMock) -> dict[str, str]:
+    """Create labels dictionary for the Docket client-side metrics."""
+    return {"docket": docket.name, "task": the_task.__name__}
+
+
+@pytest.fixture
+def TASKS_ADDED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_ADDED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_ADDED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_REPLACED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_REPLACED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_REPLACED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_SCHEDULED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_SCHEDULED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_SCHEDULED.add", mock)
+    return mock
+
+
+async def test_adding_a_task_increments_counter(
+    docket: Docket,
+    the_task: AsyncMock,
+    docket_labels: dict[str, str],
+    TASKS_ADDED: Mock,
+    TASKS_REPLACED: Mock,
+    TASKS_SCHEDULED: Mock,
+):
+    """Should increment the appropriate counters when adding a task."""
+    await docket.add(the_task)()
+
+    TASKS_ADDED.assert_called_once_with(1, docket_labels)
+    TASKS_REPLACED.assert_not_called()
+    TASKS_SCHEDULED.assert_called_once_with(1, docket_labels)
+
+
+async def test_replacing_a_task_increments_counter(
+    docket: Docket,
+    the_task: AsyncMock,
+    docket_labels: dict[str, str],
+    TASKS_ADDED: Mock,
+    TASKS_REPLACED: Mock,
+    TASKS_SCHEDULED: Mock,
+):
+    """Should increment the appropriate counters when replacing a task."""
+    when = datetime.now(timezone.utc) + timedelta(minutes=5)
+    key = "test-replace-key"
+
+    await docket.replace(the_task, when, key)()
+
+    TASKS_ADDED.assert_not_called()
+    TASKS_REPLACED.assert_called_once_with(1, docket_labels)
+    TASKS_SCHEDULED.assert_called_once_with(1, docket_labels)
+
+
+@pytest.fixture
+def TASKS_CANCELLED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_CANCELLED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_CANCELLED.add", mock)
+    return mock
+
+
+async def test_cancelling_a_task_increments_counter(
+    docket: Docket,
+    the_task: AsyncMock,
+    docket_labels: dict[str, str],
+    TASKS_CANCELLED: Mock,
+):
+    """Should increment the TASKS_CANCELLED counter when cancelling a task."""
+    when = datetime.now(timezone.utc) + timedelta(minutes=5)
+    key = "test-cancel-key"
+    await docket.add(the_task, when=when, key=key)()
+
+    await docket.cancel(key)
+
+    TASKS_CANCELLED.assert_called_once_with(1, {"docket": docket.name})
+
+
+@pytest.fixture
+def worker_labels(
+    docket: Docket, worker: Worker, the_task: AsyncMock
+) -> dict[str, str]:
+    """Create labels dictionary for worker-side metrics."""
+    return {"docket": docket.name, "worker": worker.name, "task": the_task.__name__}
+
+
+@pytest.fixture
+def TASKS_STARTED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_STARTED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_STARTED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_COMPLETED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_COMPLETED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_COMPLETED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_SUCCEEDED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_SUCCEEDED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_SUCCEEDED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_FAILED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_FAILED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_FAILED.add", mock)
+    return mock
+
+
+@pytest.fixture
+def TASKS_RETRIED(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_RETRIED counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_RETRIED.add", mock)
+    return mock
+
+
+async def test_worker_execution_increments_task_counters(
+    docket: Docket,
+    worker: Worker,
+    the_task: AsyncMock,
+    worker_labels: dict[str, str],
+    TASKS_STARTED: Mock,
+    TASKS_COMPLETED: Mock,
+    TASKS_SUCCEEDED: Mock,
+    TASKS_FAILED: Mock,
+    TASKS_RETRIED: Mock,
+):
+    """Should increment the appropriate task counters when a worker executes a task."""
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    TASKS_STARTED.assert_called_once_with(1, worker_labels)
+    TASKS_COMPLETED.assert_called_once_with(1, worker_labels)
+    TASKS_SUCCEEDED.assert_called_once_with(1, worker_labels)
+    TASKS_FAILED.assert_not_called()
+    TASKS_RETRIED.assert_not_called()
+
+
+async def test_failed_task_increments_failure_counter(
+    docket: Docket,
+    worker: Worker,
+    the_task: AsyncMock,
+    worker_labels: dict[str, str],
+    TASKS_STARTED: Mock,
+    TASKS_COMPLETED: Mock,
+    TASKS_SUCCEEDED: Mock,
+    TASKS_FAILED: Mock,
+    TASKS_RETRIED: Mock,
+):
+    """Should increment the TASKS_FAILED counter when a task fails."""
+    the_task.side_effect = ValueError("Womp")
+
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    TASKS_STARTED.assert_called_once_with(1, worker_labels)
+    TASKS_COMPLETED.assert_called_once_with(1, worker_labels)
+    TASKS_FAILED.assert_called_once_with(1, worker_labels)
+    TASKS_SUCCEEDED.assert_not_called()
+    TASKS_RETRIED.assert_not_called()
+
+
+async def test_retried_task_increments_retry_counter(
+    docket: Docket,
+    worker: Worker,
+    worker_labels: dict[str, str],
+    TASKS_STARTED: Mock,
+    TASKS_COMPLETED: Mock,
+    TASKS_SUCCEEDED: Mock,
+    TASKS_FAILED: Mock,
+    TASKS_RETRIED: Mock,
+):
+    """Should increment the TASKS_RETRIED counter when a task is retried."""
+
+    async def the_task(retry: Retry = Retry(attempts=2)):
+        raise ValueError("First attempt fails")
+
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    assert TASKS_STARTED.call_count == 2
+    assert TASKS_COMPLETED.call_count == 2
+    assert TASKS_FAILED.call_count == 2
+    assert TASKS_RETRIED.call_count == 1
+    TASKS_SUCCEEDED.assert_not_called()
+
+
+async def test_exhausted_retried_task_increments_retry_counter(
+    docket: Docket,
+    worker: Worker,
+    worker_labels: dict[str, str],
+    TASKS_STARTED: Mock,
+    TASKS_COMPLETED: Mock,
+    TASKS_SUCCEEDED: Mock,
+    TASKS_FAILED: Mock,
+    TASKS_RETRIED: Mock,
+):
+    """Should increment the appropriate counters when retries are exhausted."""
+
+    async def the_task(retry: Retry = Retry(attempts=1)):
+        raise ValueError("First attempt fails")
+
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    TASKS_STARTED.assert_called_once_with(1, worker_labels)
+    TASKS_COMPLETED.assert_called_once_with(1, worker_labels)
+    TASKS_FAILED.assert_called_once_with(1, worker_labels)
+    TASKS_RETRIED.assert_not_called()
+    TASKS_SUCCEEDED.assert_not_called()
+
+
+@pytest.fixture
+def TASK_DURATION(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASK_DURATION histogram."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASK_DURATION.record", mock)
+    return mock
+
+
+async def test_task_duration_is_measured(
+    docket: Docket, worker: Worker, worker_labels: dict[str, str], TASK_DURATION: Mock
+):
+    """Should record the duration of task execution in the TASK_DURATION histogram."""
+
+    async def the_task():
+        await asyncio.sleep(0.1)
+
+    await docket.add(the_task)()
+    await worker.run_until_current()
+
+    # We can't check the exact value since it depends on actual execution time
+    TASK_DURATION.assert_called_once_with(mock.ANY, worker_labels)
+    duration: float = TASK_DURATION.call_args.args[0]
+    assert isinstance(duration, float)
+    assert 0.1 <= duration <= 0.2
+
+
+@pytest.fixture
+def TASK_PUNCTUALITY(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASK_PUNCTUALITY histogram."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASK_PUNCTUALITY.record", mock)
+    return mock
+
+
+async def test_task_punctuality_is_measured(
+    docket: Docket,
+    worker: Worker,
+    the_task: AsyncMock,
+    worker_labels: dict[str, str],
+    TASK_PUNCTUALITY: Mock,
+):
+    """Should record TASK_PUNCTUALITY values for scheduled tasks."""
+    when = datetime.now(timezone.utc) + timedelta(seconds=0.1)
+    await docket.add(the_task, when=when)()
+    await asyncio.sleep(0.4)
+    await worker.run_until_current()
+
+    # We can't check the exact value since it depends on actual timing
+    TASK_PUNCTUALITY.assert_called_once_with(mock.ANY, worker_labels)
+    punctuality: float = TASK_PUNCTUALITY.call_args.args[0]
+    assert isinstance(punctuality, float)
+    assert 0.3 <= punctuality <= 0.5
+
+
+@pytest.fixture
+def TASKS_RUNNING(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock for the TASKS_RUNNING up-down counter."""
+    mock = Mock()
+    monkeypatch.setattr("docket.instrumentation.TASKS_RUNNING.add", mock)
+    return mock
+
+
+async def test_task_running_gauge_is_incremented(
+    docket: Docket, worker: Worker, worker_labels: dict[str, str], TASKS_RUNNING: Mock
+):
+    """Should increment and decrement the TASKS_RUNNING gauge appropriately."""
+    inside_task = False
+
+    async def the_task():
+        nonlocal inside_task
+        inside_task = True
+
+        TASKS_RUNNING.assert_called_once_with(1, worker_labels)
+
+    await docket.add(the_task)()
+
+    await worker.run_until_current()
+
+    assert inside_task is True
+
+    TASKS_RUNNING.assert_has_calls(
+        [
+            mock.call(1, worker_labels),
+            mock.call(-1, worker_labels),
+        ]
+    )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18,13 +18,6 @@ async def test_worker_aenter_propagates_connection_errors():
         await worker.__aenter__()
 
 
-@pytest.fixture
-def the_task() -> AsyncMock:
-    task = AsyncMock()
-    task.__name__ = "the_task"
-    return task
-
-
 async def test_worker_acknowledges_messages(
     docket: Docket, worker: Worker, the_task: AsyncMock
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -415,6 +416,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.51b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/6d/2a56355c00a8e225b0bbb85f2ca2e8fe963270d4314f9dee4576e49492fa/opentelemetry_exporter_prometheus-0.51b0.tar.gz", hash = "sha256:25673d79d3b0b864133ee8df789fc6fb408c51e64b3cb775c20526c10bb93d05", size = 14613 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/83/e2f5b986641cc13bae727598480d463140a2e1930c1bedb23ab60aea250c/opentelemetry_exporter_prometheus-0.51b0-py3-none-any.whl", hash = "sha256:5c5c45b254e08c19564ab033f44a941a07fb6a33ea441b75ad203c70997a8f25", size = 12920 },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.51b0"
 source = { registry = "https://pypi.org/simple" }
@@ -568,6 +583,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-prometheus" },
     { name = "prometheus-client" },
     { name = "redis" },
     { name = "typer" },
@@ -597,6 +613,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-prometheus", specifier = ">=0.51b0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "redis", specifier = ">=5.2.1" },
     { name = "typer", specifier = ">=0.15.1" },


### PR DESCRIPTION
Here we use the OpenTelemetry metric objects to implement docket actions
like adding, cancelling, starting, or retrying tasks.  Using this
approach with the OpenTelemetry metrics gives us Prometheus support for
virtually free by using `opentelemetry-exporter-prometheus`, which will
automatically start a webserver when used with
`opentelemetry-instrument`.  When we work on configuring and starting
the worker, we can also bring in the couple lines of OTEL object setup
that would require.

Closes #11
