### PR TITLE
Sets up `rich`, plain, and JSON logging for the worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
     "opentelemetry-api>=1.30.0",
     "opentelemetry-exporter-prometheus>=0.51b0",
     "prometheus-client>=0.21.1",
+    "python-json-logger>=3.2.1",
     "redis>=5.2.1",
+    "rich>=13.9.4",
     "typer>=0.15.1",
 ]
 

--- a/tests/cli/test_trace.py
+++ b/tests/cli/test_trace.py
@@ -1,0 +1,66 @@
+import asyncio
+import logging
+
+import pytest
+from typer.testing import CliRunner
+
+from docket.cli import app
+from docket.docket import Docket
+from docket.worker import Worker
+
+
+def test_trace_command(
+    runner: CliRunner,
+    docket: Docket,
+    worker: Worker,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Should add a trace task to the docket"""
+    result = runner.invoke(
+        app,
+        [
+            "trace",
+            "hiya!",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Added trace task" in result.stdout.strip()
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(worker.run_until_finished())
+
+    assert "hiya!" in caplog.text
+    assert "ERROR" not in caplog.text
+
+
+def test_trace_command_with_error(
+    runner: CliRunner,
+    docket: Docket,
+    worker: Worker,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Should add a trace task to the docket"""
+    result = runner.invoke(
+        app,
+        [
+            "trace",
+            "hiya!",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "--error",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Added fail task" in result.stdout.strip()
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(worker.run_until_finished())
+
+    assert "hiya!" in caplog.text
+    assert "ERROR" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -585,7 +584,9 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "prometheus-client" },
+    { name = "python-json-logger" },
     { name = "redis" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -615,7 +616,9 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.51b0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
+    { name = "python-json-logger", specifier = ">=3.2.1" },
     { name = "redis", specifier = ">=5.2.1" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 
@@ -721,6 +724,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
 ]
 
 [[package]]


### PR DESCRIPTION
`rich` is doing most of the heavy lifting here for making the logging
output delightful.  I came up with a compact notation for showing the
start, end, and retry status of tasks using Unicode arrows, totally open
to feedback on that.

The plain format may need to be even plainer, but I just started there
as a starting point.

With the JSON format, I wasn't entirely sure which standard library
fields folks would want so I'm keeping it just to the level and time.

Closes #23

Rich:
![image](https://github.com/user-attachments/assets/b5508d0f-1b91-40bd-8144-8b0ad249ebc8)

Plain (automatically picked because `| cat` means not in an interactive TTY):
![image](https://github.com/user-attachments/assets/e67af56d-ec7f-4db0-8ce6-f807fcf4f758)

JSON:

![image](https://github.com/user-attachments/assets/4d27d279-702e-4db0-bb4f-baae3ccc2f40)
