### PR TITLE
Supports opt-in argument logging

### DIFF
--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -8,6 +8,7 @@ from importlib.metadata import version
 
 __version__ = version("pydocket")
 
+from .annotations import Logged
 from .dependencies import CurrentDocket, CurrentExecution, CurrentWorker, Retry, TaskKey
 from .docket import Docket
 from .execution import Execution
@@ -22,5 +23,6 @@ __all__ = [
     "CurrentExecution",
     "TaskKey",
     "Retry",
+    "Logged",
     "__version__",
 ]

--- a/src/docket/annotations.py
+++ b/src/docket/annotations.py
@@ -1,0 +1,30 @@
+import abc
+import inspect
+from typing import Any, Iterable, Mapping, Self
+
+
+class Annotation(abc.ABC):
+    @classmethod
+    def annotated_parameters(cls, signature: inspect.Signature) -> Mapping[str, Self]:
+        annotated: dict[str, Self] = {}
+
+        for param_name, param in signature.parameters.items():
+            if param.annotation == inspect.Parameter.empty:
+                continue
+
+            try:
+                metadata: Iterable[Any] = param.annotation.__metadata__
+            except AttributeError:
+                continue
+
+            for arg_type in metadata:
+                if isinstance(arg_type, cls):
+                    annotated[param_name] = arg_type
+                elif isinstance(arg_type, type) and issubclass(arg_type, cls):
+                    annotated[param_name] = arg_type()
+
+        return annotated
+
+
+class Logged(Annotation):
+    """Instructs docket to include arguments to this parameter in the log."""


### PR DESCRIPTION
The tests have a good illustration of this:

```
async def test_tasks_can_opt_into_argument_logging(
    docket: Docket, worker: Worker, caplog: pytest.LogCaptureFixture
):
    """Tasks can opt into argument logging for specific arguments"""

    async def the_task(
        a: Annotated[str, Logged],
        b: str,
        c: Annotated[str, Logged()] = "c",
        d: Annotated[str, "nah chief"] = "d",
        docket: Docket = CurrentDocket(),
    ):
        pass

    await docket.add(the_task)("value-a", b="value-b", c="value-c", d="value-d")

    with caplog.at_level(logging.INFO):
        await worker.run_until_finished()

        assert "the_task('value-a', b=..., c='value-c', d=...)" in caplog.text
        assert "value-b" not in caplog.text
        assert "value-d" not in caplog.text
```

Here, the log line mostly looks like what the equivalent Python call would, but unlogged arguments are represented with `...`, and arguments that aren't provided (like automatic dependencies) are omitted.

Closes #27
