### PR TITLE
Adds support for concurrent execution of tasks

### DIFF
--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -153,11 +153,11 @@ def worker(
             callback=set_logging_format,
         ),
     ] = LogFormat.RICH if sys.stdout.isatty() else LogFormat.PLAIN,
-    prefetch_count: Annotated[
+    concurrency: Annotated[
         int,
         typer.Option(
-            help="The number of tasks to request from the docket at a time",
-            envvar="DOCKET_WORKER_PREFETCH_COUNT",
+            help="The maximum number of tasks to process concurrently",
+            envvar="DOCKET_WORKER_CONCURRENCY",
         ),
     ] = 10,
     redelivery_timeout: Annotated[
@@ -192,7 +192,7 @@ def worker(
             docket_name=docket_,
             url=url,
             name=name,
-            prefetch_count=prefetch_count,
+            concurrency=concurrency,
             redelivery_timeout=redelivery_timeout,
             reconnection_delay=reconnection_delay,
             until_finished=until_finished,

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -26,7 +26,14 @@ import redis.exceptions
 from opentelemetry import propagate, trace
 from redis.asyncio import Redis
 
-from .execution import Execution, Restore, Strike, StrikeInstruction, StrikeList
+from .execution import (
+    Execution,
+    Operator,
+    Restore,
+    Strike,
+    StrikeInstruction,
+    StrikeList,
+)
 from .instrumentation import (
     TASKS_ADDED,
     TASKS_CANCELLED,
@@ -47,7 +54,8 @@ TaskCollection = Iterable[Callable[..., Awaitable[Any]]]
 RedisStreamID = bytes
 RedisMessageID = bytes
 RedisMessage = dict[bytes, bytes]
-RedisStream = tuple[RedisStreamID, Sequence[tuple[RedisMessageID, RedisMessage]]]
+RedisMessages = Sequence[tuple[RedisMessageID, RedisMessage]]
+RedisStream = tuple[RedisStreamID, RedisMessages]
 RedisReadGroupResponse = Sequence[RedisStream]
 
 
@@ -321,7 +329,7 @@ class Docket:
         self,
         function: Callable[P, Awaitable[R]] | str | None = None,
         parameter: str | None = None,
-        operator: Literal["==", "!=", ">", ">=", "<", "<=", "between"] = "==",
+        operator: Operator = "==",
         value: Hashable | None = None,
     ) -> None:
         if not isinstance(function, (str, type(None))):

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -270,7 +270,7 @@ async def test_supports_simple_linear_retries_with_delay(
     await worker.run_until_finished()
 
     total_delay = now() - start
-    assert total_delay >= timedelta(milliseconds=300)
+    assert total_delay >= timedelta(milliseconds=200)
 
     assert calls == 3
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,6 +7,7 @@ from redis import RedisError
 from redis.exceptions import ConnectionError
 
 from docket import CurrentWorker, Docket, Worker
+from docket.docket import RedisMessage
 
 
 async def test_worker_aenter_propagates_connection_errors():
@@ -69,7 +70,7 @@ async def test_worker_reconnects_when_connection_is_lost(
     worker = Worker(docket, reconnection_delay=timedelta(milliseconds=100))
 
     # Mock the _worker_loop method to fail once then succeed
-    original_worker_loop = worker._worker_loop
+    original_worker_loop = worker._worker_loop  # type: ignore[protected-access]
     call_count = 0
 
     async def mock_worker_loop(forever: bool = False):
@@ -87,5 +88,117 @@ async def test_worker_reconnects_when_connection_is_lost(
         await worker.run_until_finished()
 
     assert call_count == 2
-
     the_task.assert_called_once()
+
+
+async def test_worker_respects_concurrency_limit(docket: Docket, worker: Worker):
+    """Worker should not exceed its configured concurrency limit"""
+
+    task_results: set[int] = set()
+
+    currently_running = 0
+    max_concurrency_observed = 0
+
+    async def concurrency_tracking_task(index: int):
+        nonlocal currently_running, max_concurrency_observed
+
+        currently_running += 1
+        max_concurrency_observed = max(max_concurrency_observed, currently_running)
+
+        await asyncio.sleep(0.01)
+        task_results.add(index)
+
+        currently_running -= 1
+
+    for i in range(50):
+        await docket.add(concurrency_tracking_task)(index=i)
+
+    worker.concurrency = 5
+    await worker.run_until_finished()
+
+    assert task_results == set(range(50))
+
+    assert 1 < max_concurrency_observed <= 5
+
+
+async def test_worker_handles_redeliveries_from_abandoned_workers(
+    docket: Docket, the_task: AsyncMock
+):
+    """The worker should handle redeliveries from abandoned workers"""
+
+    await docket.add(the_task)()
+
+    async with Worker(
+        docket, redelivery_timeout=timedelta(milliseconds=100)
+    ) as worker_a:
+        worker_a._execute = AsyncMock(side_effect=Exception("Nope"))  # type: ignore[protected-access]
+        with pytest.raises(Exception, match="Nope"):
+            await worker_a.run_until_finished()
+
+    the_task.assert_not_called()
+
+    async with Worker(
+        docket, redelivery_timeout=timedelta(milliseconds=100)
+    ) as worker_b:
+        async with docket.redis() as redis:
+            pending_info = await redis.xpending(
+                docket.stream_key,
+                worker_b.consumer_group_name,
+            )
+            assert pending_info["pending"] == 1, (
+                "Expected one pending task in the stream"
+            )
+
+        await asyncio.sleep(0.125)  # longer than the redelivery timeout
+
+        await worker_b.run_until_finished()
+
+    the_task.assert_awaited_once_with()
+
+
+async def test_redeliveries_abide_by_concurrency_limits(docket: Docket, worker: Worker):
+    task_results: set[int] = set()
+
+    currently_running = 0
+    max_concurrency_observed = 0
+
+    async def concurrency_tracking_task(index: int):
+        nonlocal currently_running, max_concurrency_observed
+
+        currently_running += 1
+        max_concurrency_observed = max(max_concurrency_observed, currently_running)
+
+        await asyncio.sleep(0.01)
+        task_results.add(index)
+
+        currently_running -= 1
+
+    for i in range(50):
+        await docket.add(concurrency_tracking_task)(index=i)
+
+    async with Worker(
+        docket, concurrency=5, redelivery_timeout=timedelta(milliseconds=100)
+    ) as bad_worker:
+        original_execute = bad_worker._execute  # type: ignore[protected-access]
+
+        async def die_after_10_tasks(message: RedisMessage):
+            if len(task_results) >= 10:
+                raise Exception("Nope")
+            return await original_execute(message)
+
+        bad_worker._execute = die_after_10_tasks  # type: ignore[protected-access]
+        with pytest.raises(Exception, match="Nope"):
+            await bad_worker.run_until_finished()
+
+    assert 1 < max_concurrency_observed <= 5
+    assert len(task_results) == 10
+
+    await asyncio.sleep(0.125)  # longer than the redelivery timeout
+
+    worker.concurrency = 5
+    worker.redelivery_timeout = timedelta(milliseconds=100)
+    await worker.run_until_finished()
+
+    assert task_results == set(range(50))
+
+    assert 1 < max_concurrency_observed <= 5


### PR DESCRIPTION
The `prefetch_count` parameter has been replaced with a new
`concurrency` parameter that governs the maximum number of tasks that
are allowed to run concurrently, as well as how much if retriveed from
the Redis stream on each pass.

Big thanks to `claude-3.7-thinking` for the careful implementation.  I
did have to clean this up a good bit, but it got the framework down.

Closes #39
