### PR TITLE
Handles cases where bad user data could crash a worker

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -307,10 +307,15 @@ class Worker:
                     await process_completed_tasks()
 
     async def _execute(self, message: RedisMessage) -> None:
-        execution = Execution.from_message(
-            self.docket.tasks[message[b"function"].decode()],
-            message,
-        )
+        function_name = message[b"function"].decode()
+        function = self.docket.tasks.get(function_name)
+        if function is None:
+            logger.warning(
+                "Task function %r not found", function_name, extra=self._log_context
+            )
+            return
+
+        execution = Execution.from_message(function, message)
         name = execution.function.__name__
         key = execution.key
 

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -792,3 +792,29 @@ async def test_striking_tasks_for_specific_parameters(
             call("d", b=3),
         ]
     )
+
+
+async def test_adding_task_by_name_when_not_registered(docket: Docket):
+    """docket should raise an error when attempting to add a task by name that isn't registered"""
+
+    with pytest.raises(KeyError, match="unregistered_task"):
+        await docket.add("unregistered_task")()
+
+
+async def test_adding_task_with_unbindable_arguments(
+    docket: Docket,
+    worker: Worker,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Should not raise an error when a task is scheduled or executed with
+    incorrect arguments."""
+
+    async def task_with_specific_args(a: str, b: int, c: bool = False) -> None:
+        pass  # pragma: no cover
+
+    await docket.add(task_with_specific_args)("a", 2, d="unexpected")  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.ERROR):
+        await worker.run_until_finished()
+
+    assert "got an unexpected keyword argument 'd'" in caplog.text


### PR DESCRIPTION
Here we add tests showing that a few user-driven errors from passing
bad arguments and strike values could cause crashes.

Closes #38
