### PR TITLE
Adds support for type coercion for the strike/restore CLI tasks

### DIFF
--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -11,7 +11,6 @@ from typing import (
     Callable,
     Hashable,
     Iterable,
-    Literal,
     NoReturn,
     ParamSpec,
     Self,
@@ -27,6 +26,7 @@ from redis.asyncio import Redis
 
 from .execution import (
     Execution,
+    LiteralOperator,
     Operator,
     Restore,
     Strike,
@@ -297,11 +297,13 @@ class Docket:
         self,
         function: Callable[P, Awaitable[R]] | str | None = None,
         parameter: str | None = None,
-        operator: Operator = "==",
+        operator: Operator | LiteralOperator = "==",
         value: Hashable | None = None,
     ) -> None:
         if not isinstance(function, (str, type(None))):
             function = function.__name__
+
+        operator = Operator(operator)
 
         strike = Strike(function, parameter, operator, value)
         return await self._send_strike_instruction(strike)
@@ -310,11 +312,13 @@ class Docket:
         self,
         function: Callable[P, Awaitable[R]] | str | None = None,
         parameter: str | None = None,
-        operator: Literal["==", "!=", ">", ">=", "<", "<=", "between"] = "==",
+        operator: Operator | LiteralOperator = "==",
         value: Hashable | None = None,
     ) -> None:
         if not isinstance(function, (str, type(None))):
             function = function.__name__
+
+        operator = Operator(operator)
 
         restore = Restore(function, parameter, operator, value)
         return await self._send_strike_instruction(restore)

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -1,4 +1,5 @@
 import abc
+import enum
 import inspect
 import logging
 from datetime import datetime
@@ -79,7 +80,17 @@ class Execution:
         return f"{function_name}({', '.join(arguments)}){{{self.key}}}"
 
 
-Operator = Literal["==", "!=", ">", ">=", "<", "<=", "between"]
+class Operator(enum.StrEnum):
+    EQUAL = "=="
+    NOT_EQUAL = "!="
+    GREATER_THAN = ">"
+    GREATER_THAN_OR_EQUAL = ">="
+    LESS_THAN = "<"
+    LESS_THAN_OR_EQUAL = "<="
+    BETWEEN = "between"
+
+
+LiteralOperator = Literal["==", "!=", ">", ">=", "<", "<=", "between"]
 
 
 class StrikeInstruction(abc.ABC):

--- a/tests/cli/test_striking.py
+++ b/tests/cli/test_striking.py
@@ -1,7 +1,13 @@
 import asyncio
+import decimal
 import subprocess
-from uuid import uuid4
+from datetime import timedelta
+from typing import Any
+from uuid import UUID, uuid4
 
+import pytest
+
+from docket.cli import interpret_python_value
 from docket.docket import Docket
 
 
@@ -54,3 +60,142 @@ async def test_restore(redis_url: str):
         await asyncio.sleep(0.25)
 
         assert "example_task" not in docket.strike_list.task_strikes
+
+
+async def test_task_only_strike(redis_url: str):
+    """Should strike a task"""
+    async with Docket(name=f"test-docket-{uuid4()}", url=redis_url) as docket:
+        process = await asyncio.create_subprocess_exec(
+            "docket",
+            "strike",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "example_task",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert await process.wait() == 0
+
+        await asyncio.sleep(0.25)
+
+        assert "example_task" in docket.strike_list.task_strikes
+
+        process = await asyncio.create_subprocess_exec(
+            "docket",
+            "restore",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "example_task",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert await process.wait() == 0
+
+        await asyncio.sleep(0.25)
+
+        assert "example_task" not in docket.strike_list.task_strikes
+
+
+async def test_parameter_only_strike(redis_url: str):
+    """Should strike a task with only a parameter"""
+    async with Docket(name=f"test-docket-{uuid4()}", url=redis_url) as docket:
+        await docket.strike("example_task", "some_parameter", "==", "some_value")
+        assert "example_task" in docket.strike_list.task_strikes
+
+        process = await asyncio.create_subprocess_exec(
+            "docket",
+            "strike",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "*",
+            "some_parameter",
+            "==",
+            "some_value",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert await process.wait() == 0
+
+        await asyncio.sleep(0.25)
+
+        assert "*" not in docket.strike_list.task_strikes
+        assert "some_parameter" in docket.strike_list.parameter_strikes
+
+        process = await asyncio.create_subprocess_exec(
+            "docket",
+            "restore",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "*",
+            "some_parameter",
+            "==",
+            "some_value",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert await process.wait() == 0
+
+        await asyncio.sleep(0.25)
+
+        assert "*" not in docket.strike_list.task_strikes
+        assert "" not in docket.strike_list.task_strikes
+        assert None not in docket.strike_list.task_strikes
+        assert "some_parameter" not in docket.strike_list.parameter_strikes
+
+
+@pytest.mark.parametrize("operation", ["strike", "restore"])
+async def test_strike_with_no_function_or_parameter(redis_url: str, operation: str):
+    """Should return an error when neither a function nor a parameter are specified"""
+    async with Docket(name=f"test-docket-{uuid4()}", url=redis_url) as docket:
+        process = await asyncio.create_subprocess_exec(
+            "docket",
+            operation,
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            "",
+            "",
+            "==",
+            "some_value",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert await process.wait() != 0
+
+        _, stderr = await process.communicate()
+
+        assert b"Must provide either a function and/or a parameter" in stderr
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_result",
+    [
+        (None, None),
+        ("hello", "hello"),
+        ("int:42", 42),
+        ("float:3.14", 3.14),
+        ("decimal.Decimal:3.14", decimal.Decimal("3.14")),
+        ("bool:True", True),
+        ("bool:False", False),
+        ("datetime.timedelta:10", timedelta(seconds=10)),
+        (
+            "uuid.UUID:123e4567-e89b-12d3-a456-426614174000",
+            UUID("123e4567-e89b-12d3-a456-426614174000"),
+        ),
+    ],
+)
+async def test_interpret_python_value(input_value: str | None, expected_result: Any):
+    """Should interpret Python values correctly based on type hints"""
+    result = interpret_python_value(input_value)
+
+    assert isinstance(result, type(expected_result))
+    assert result == expected_result


### PR DESCRIPTION
This lets you say things like:

```
docket strike my_task my_arg == hello    # defaults to a string
docket strike my_task my_arg == int:123
docket strike my_task my_arg == float:123
docket strike my_task my_arg == uuid.UUID:4d071723-60ae-4897-93d2-b2ee27b16b43
docket strike my_task my_arg == pendulum.parse:2025-01-02
```

Closes #35
