### PR TITLE
Adds a `docket snapshot` command to print the state of the docket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 dev = [
     "codespell>=2.4.1",
     "docker>=7.1.0",
+    "ipython>=9.0.1",
     "mypy>=1.14.1",
     "opentelemetry-distro>=0.51b0",
     "opentelemetry-exporter-otlp>=1.30.0",

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -468,7 +468,7 @@ def fail(
     asyncio.run(run())
 
 
-@tasks_app.command(help="Adds a trace task to the Docket")
+@tasks_app.command(help="Adds a sleep task to the Docket")
 def sleep(
     docket_: Annotated[
         str,

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -551,12 +551,15 @@ def snapshot(
 
     console = Console()
 
-    summary_line = (
-        f"Docket: {docket_!r} as of {local_time(snapshot.taken)}\n"
-        f"{len(snapshot.workers)} workers, "
-        f"{len(snapshot.running)}/{snapshot.total_tasks} running"
-    )
-    table = Table(title=summary_line)
+    summary_lines = [
+        f"Docket: {docket_!r}",
+        f"as of {local_time(snapshot.taken)}",
+        (
+            f"{len(snapshot.workers)} workers, "
+            f"{len(snapshot.running)}/{snapshot.total_tasks} running"
+        ),
+    ]
+    table = Table(title="\n".join(summary_lines))
     table.add_column("When", style="green")
     table.add_column("Function", style="cyan")
     table.add_column("Key", style="cyan")

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -585,7 +585,7 @@ def snapshot(
 
 
 workers_app: typer.Typer = typer.Typer(
-    help="Look a the the workers on a docket", no_args_is_help=True
+    help="Look at the workers on a docket", no_args_is_help=True
 )
 app.add_typer(workers_app, name="workers")
 

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -623,7 +623,7 @@ def print_workers(
     console.print(table)
 
 
-@workers_app.command(name="ls", help="List the workers in the Docket")
+@workers_app.command(name="ls", help="List all workers on the docket")
 def list_workers(
     docket_: Annotated[
         str,
@@ -650,7 +650,10 @@ def list_workers(
     print_workers(docket_, workers)
 
 
-@workers_app.command(name="for-task", help="List the workers in the Docket")
+@workers_app.command(
+    name="for-task",
+    help="List the workers on the docket that can process a certain task",
+)
 def workers_for_task(
     task: Annotated[
         str,

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -6,6 +6,7 @@ import os
 import socket
 import sys
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from typing import Annotated, Any, Collection
 
 import typer
@@ -13,7 +14,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__, tasks
-from .docket import Docket, WorkerInfo
+from .docket import Docket, DocketSnapshot, WorkerInfo
 from .execution import Operator
 from .worker import Worker
 
@@ -36,6 +37,10 @@ class LogFormat(enum.StrEnum):
     RICH = "rich"
     PLAIN = "plain"
     JSON = "json"
+
+
+def local_time(when: datetime) -> str:
+    return when.astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
 
 
 def default_worker_name() -> str:
@@ -135,6 +140,13 @@ def interpret_python_value(value: str | None) -> Any:
         return value.lower() == "true"
     else:
         return member(value)
+
+
+@app.command(
+    help="Print the version of docket",
+)
+def version() -> None:
+    print(__version__)
 
 
 @app.command(
@@ -238,7 +250,7 @@ def worker(
     )
 
 
-@app.command(help="Strikes a task or parameters from the Docket")
+@app.command(help="Strikes a task or parameters from the docket")
 def strike(
     function: Annotated[
         str,
@@ -364,7 +376,13 @@ def restore(
     asyncio.run(run())
 
 
-@app.command(help="Adds a trace task to the Docket")
+tasks_app: typer.Typer = typer.Typer(
+    help="Run docket's built-in tasks", no_args_is_help=True
+)
+app.add_typer(tasks_app, name="tasks")
+
+
+@tasks_app.command(help="Adds a trace task to the Docket")
 def trace(
     docket_: Annotated[
         str,
@@ -387,21 +405,18 @@ def trace(
             help="The message to print",
         ),
     ] = "Howdy!",
-    error: Annotated[
-        bool,
+    delay: Annotated[
+        timedelta,
         typer.Option(
-            "--error",
-            help="Intentionally raise an error",
+            parser=duration,
+            help="The delay before the task is added to the docket",
         ),
-    ] = False,
+    ] = timedelta(seconds=0),
 ) -> None:
     async def run() -> None:
         async with Docket(name=docket_, url=url) as docket:
-            if error:
-                execution = await docket.add(tasks.fail)(message)
-            else:
-                execution = await docket.add(tasks.trace)(message)
-
+            when = datetime.now(timezone.utc) + delay
+            execution = await docket.add(tasks.trace, when)(message)
             print(
                 f"Added {execution.function.__name__} task {execution.key!r} to "
                 f"the docket {docket.name!r}"
@@ -410,15 +425,167 @@ def trace(
     asyncio.run(run())
 
 
-@app.command(
-    help="Print the version of Docket",
-)
-def version() -> None:
-    print(__version__)
+@tasks_app.command(help="Adds a fail task to the Docket")
+def fail(
+    docket_: Annotated[
+        str,
+        typer.Option(
+            "--docket",
+            help="The name of the docket",
+            envvar="DOCKET_NAME",
+        ),
+    ] = "docket",
+    url: Annotated[
+        str,
+        typer.Option(
+            help="The URL of the Redis server",
+            envvar="DOCKET_URL",
+        ),
+    ] = "redis://localhost:6379/0",
+    message: Annotated[
+        str,
+        typer.Argument(
+            help="The message to print",
+        ),
+    ] = "Howdy!",
+    delay: Annotated[
+        timedelta,
+        typer.Option(
+            parser=duration,
+            help="The delay before the task is added to the docket",
+        ),
+    ] = timedelta(seconds=0),
+) -> None:
+    async def run() -> None:
+        async with Docket(name=docket_, url=url) as docket:
+            when = datetime.now(timezone.utc) + delay
+            execution = await docket.add(tasks.fail, when)(message)
+            print(
+                f"Added {execution.function.__name__} task {execution.key!r} to "
+                f"the docket {docket.name!r}"
+            )
+
+    asyncio.run(run())
+
+
+@tasks_app.command(help="Adds a trace task to the Docket")
+def sleep(
+    docket_: Annotated[
+        str,
+        typer.Option(
+            "--docket",
+            help="The name of the docket",
+            envvar="DOCKET_NAME",
+        ),
+    ] = "docket",
+    url: Annotated[
+        str,
+        typer.Option(
+            help="The URL of the Redis server",
+            envvar="DOCKET_URL",
+        ),
+    ] = "redis://localhost:6379/0",
+    seconds: Annotated[
+        float,
+        typer.Argument(
+            help="The number of seconds to sleep",
+        ),
+    ] = 1,
+    delay: Annotated[
+        timedelta,
+        typer.Option(
+            parser=duration,
+            help="The delay before the task is added to the docket",
+        ),
+    ] = timedelta(seconds=0),
+) -> None:
+    async def run() -> None:
+        async with Docket(name=docket_, url=url) as docket:
+            when = datetime.now(timezone.utc) + delay
+            execution = await docket.add(tasks.sleep, when)(seconds)
+            print(
+                f"Added {execution.function.__name__} task {execution.key!r} to "
+                f"the docket {docket.name!r}"
+            )
+
+    asyncio.run(run())
+
+
+def relative_time(now: datetime, when: datetime) -> str:
+    delta = now - when
+    if delta < -timedelta(minutes=30):
+        return f"at {local_time(when)}"
+    elif delta < timedelta(0):
+        return f"in {-delta}"
+    elif delta < timedelta(minutes=30):
+        return f"{delta} ago"
+    else:
+        return f"at {local_time(when)}"
+
+
+@app.command(help="Shows a snapshot of what's on the docket right now")
+def snapshot(
+    docket_: Annotated[
+        str,
+        typer.Option(
+            "--docket",
+            help="The name of the docket",
+            envvar="DOCKET_NAME",
+        ),
+    ] = "docket",
+    url: Annotated[
+        str,
+        typer.Option(
+            help="The URL of the Redis server",
+            envvar="DOCKET_URL",
+        ),
+    ] = "redis://localhost:6379/0",
+) -> None:
+    async def run() -> DocketSnapshot:
+        async with Docket(name=docket_, url=url) as docket:
+            return await docket.snapshot()
+
+    snapshot = asyncio.run(run())
+
+    relative = partial(relative_time, snapshot.taken)
+
+    console = Console()
+
+    summary_line = (
+        f"Docket: {docket_!r} as of {local_time(snapshot.taken)}\n"
+        f"{len(snapshot.workers)} workers, "
+        f"{len(snapshot.running)}/{snapshot.total_tasks} running"
+    )
+    table = Table(title=summary_line)
+    table.add_column("When", style="green")
+    table.add_column("Function", style="cyan")
+    table.add_column("Key", style="cyan")
+    table.add_column("Worker", style="yellow")
+    table.add_column("Started", style="green")
+
+    for execution in snapshot.running:
+        table.add_row(
+            relative(execution.when),
+            execution.function.__name__,
+            execution.key,
+            execution.worker,
+            relative(execution.started),
+        )
+
+    for execution in snapshot.future:
+        table.add_row(
+            relative(execution.when),
+            execution.function.__name__,
+            execution.key,
+            "",
+            "",
+        )
+
+    console.print(table)
 
 
 workers_app: typer.Typer = typer.Typer(
-    help="Worker management commands", no_args_is_help=True
+    help="Look a the the workers on a docket", no_args_is_help=True
 )
 app.add_typer(workers_app, name="workers")
 

--- a/src/docket/tasks.py
+++ b/src/docket/tasks.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -44,7 +45,13 @@ async def fail(
     )
 
 
+async def sleep(seconds: float) -> None:
+    logger.info("Sleeping for %s seconds", seconds)
+    await asyncio.sleep(seconds)
+
+
 standard_tasks: TaskCollection = [
     trace,
     fail,
+    sleep,
 ]

--- a/tests/cli/test_snapshot.py
+++ b/tests/cli/test_snapshot.py
@@ -1,0 +1,205 @@
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pytest import MonkeyPatch
+
+from docket import tasks
+from docket.cli import relative_time
+from docket.docket import Docket
+from docket.worker import Worker
+
+
+@pytest.fixture(autouse=True)
+async def empty_docket(docket: Docket):
+    """Ensure that the docket has been created"""
+    future = datetime.now(timezone.utc) + timedelta(seconds=60)
+    await docket.add(tasks.trace, key="initial", when=future)("hi")
+    await docket.cancel("initial")
+
+
+async def test_snapshot_empty_docket(docket: Docket):
+    """Should show an empty snapshot when no tasks are scheduled"""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "docket",
+        "snapshot",
+        "--url",
+        docket.url,
+        "--docket",
+        docket.name,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await process.wait()
+
+    assert process.stderr
+    stderr = await process.stderr.read()
+    assert process.returncode == 0, stderr.decode()
+
+    assert process.stdout
+    output = await process.stdout.read()
+    output_text = output.decode()
+
+    assert "0 workers, 0/0 running" in output_text
+
+
+async def test_snapshot_with_scheduled_tasks(docket: Docket):
+    """Should show scheduled tasks in the snapshot"""
+    when = datetime.now(timezone.utc) + timedelta(seconds=5)
+    await docket.add(tasks.trace, when=when, key="future-task")("hiya!")
+
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "docket",
+        "snapshot",
+        "--url",
+        docket.url,
+        "--docket",
+        docket.name,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await process.wait()
+
+    assert process.stderr
+    stderr = await process.stderr.read()
+    assert process.returncode == 0, stderr.decode()
+
+    assert process.stdout
+    output = await process.stdout.read()
+    output_text = output.decode()
+
+    assert "0 workers, 0/1 running" in output_text
+    assert "future-task" in output_text
+
+
+async def test_snapshot_with_running_tasks(docket: Docket):
+    """Should show running tasks in the snapshot"""
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+
+    await docket.add(tasks.sleep)(2)
+
+    async with Worker(docket, name="test-worker") as worker:
+        worker_running = asyncio.create_task(worker.run_until_finished())
+
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "docket",
+            "snapshot",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await process.wait()
+
+        assert process.stderr
+        stderr = await process.stderr.read()
+        assert process.returncode == 0, stderr.decode()
+
+        assert process.stdout
+        output = await process.stdout.read()
+        output_text = output.decode()
+
+        assert "1 workers, 1/1 running" in output_text
+        assert "sleep" in output_text
+        assert "test-worker" in output_text
+
+        worker_running.cancel()
+        await worker_running
+
+
+async def test_snapshot_with_mixed_tasks(docket: Docket):
+    """Should show both running and scheduled tasks in the snapshot"""
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+
+    future = datetime.now(timezone.utc) + timedelta(seconds=5)
+    await docket.add(tasks.trace, when=future)("hi!")
+    for _ in range(5):  # more than the concurrency allows
+        await docket.add(tasks.sleep)(2)
+
+    async with Worker(docket, name="test-worker", concurrency=2) as worker:
+        worker_running = asyncio.create_task(worker.run_until_finished())
+
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "docket",
+            "snapshot",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await process.wait()
+
+        assert process.stderr
+        stderr = await process.stderr.read()
+        assert process.returncode == 0, stderr.decode()
+
+        assert process.stdout
+        output = await process.stdout.read()
+        output_text = output.decode()
+
+        print(output_text)
+
+        assert "1 workers, 2/6 running" in output_text
+        assert "sleep" in output_text
+        assert "test-worker" in output_text
+        assert "trace" in output_text
+
+        worker_running.cancel()
+        await worker_running
+
+
+@pytest.mark.parametrize(
+    "now, when, expected",
+    [
+        # Near future
+        (
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2023, 1, 1, 12, 15, 0, tzinfo=timezone.utc),
+            "in 0:15:00",
+        ),
+        # Distant future
+        (
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+            "at 2023-01-02 12:00:00 +0000",
+        ),
+        # Recent past
+        (
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2023, 1, 1, 11, 45, 0, tzinfo=timezone.utc),
+            "0:15:00 ago",
+        ),
+        # Distant past
+        (
+            datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            "at 2023-01-01 10:00:00 +0000",
+        ),
+    ],
+)
+def test_relative_time(
+    now: datetime, when: datetime, expected: str, monkeypatch: MonkeyPatch
+):
+    """Should format relative times correctly based on the time difference"""
+
+    def consistent_format(dt: datetime) -> str:
+        return dt.strftime("%Y-%m-%d %H:%M:%S %z")
+
+    monkeypatch.setattr("docket.cli.local_time", consistent_format)
+
+    assert relative_time(now, when) == expected

--- a/tests/cli/test_tasks.py
+++ b/tests/cli/test_tasks.py
@@ -19,6 +19,7 @@ def test_trace_command(
     result = runner.invoke(
         app,
         [
+            "tasks",
             "trace",
             "hiya!",
             "--url",
@@ -37,7 +38,7 @@ def test_trace_command(
     assert "ERROR" not in caplog.text
 
 
-def test_trace_command_with_error(
+def test_fail_command(
     runner: CliRunner,
     docket: Docket,
     worker: Worker,
@@ -46,15 +47,7 @@ def test_trace_command_with_error(
     """Should add a trace task to the docket"""
     result = runner.invoke(
         app,
-        [
-            "trace",
-            "hiya!",
-            "--url",
-            docket.url,
-            "--docket",
-            docket.name,
-            "--error",
-        ],
+        ["tasks", "fail", "hiya!", "--url", docket.url, "--docket", docket.name],
     )
     assert result.exit_code == 0
     assert "Added fail task" in result.stdout.strip()
@@ -64,3 +57,32 @@ def test_trace_command_with_error(
 
     assert "hiya!" in caplog.text
     assert "ERROR" in caplog.text
+
+
+def test_sleep_command(
+    runner: CliRunner,
+    docket: Docket,
+    worker: Worker,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Should add a trace task to the docket"""
+    result = runner.invoke(
+        app,
+        [
+            "tasks",
+            "sleep",
+            "0.1",
+            "--url",
+            docket.url,
+            "--docket",
+            docket.name,
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Added sleep task" in result.stdout.strip()
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(worker.run_until_finished())
+
+    assert "Sleeping for 0.1 seconds" in caplog.text
+    assert "ERROR" not in caplog.text

--- a/tests/test_docket.py
+++ b/tests/test_docket.py
@@ -1,0 +1,14 @@
+import pytest
+import redis.exceptions
+
+from docket.docket import Docket
+
+
+async def test_docket_aenter_propagates_connection_errors():
+    """The docket should propagate Redis connection errors"""
+
+    docket = Docket(name="test-docket", url="redis://nonexistent-host:12345/0")
+    with pytest.raises(redis.exceptions.RedisError):
+        await docket.__aenter__()
+
+    await docket.__aexit__(None, None, None)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,14 @@
 version = 1
-revision = 1
 requires-python = ">=3.12"
+
+[[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+]
 
 [[package]]
 name = "certifi"
@@ -134,6 +142,15 @@ wheels = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +192,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
 ]
 
 [[package]]
@@ -264,6 +290,51 @@ wheels = [
 ]
 
 [[package]]
+name = "ipython"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/33/1901c9a842b301d8674f367dee597e654e402548a903faf7280aae8fc2d4/ipython-9.0.1.tar.gz", hash = "sha256:377ea91c8226b48dc9021ac9846a64761abc7ddf74c5efe38e6eb06f6e052f3a", size = 4365847 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/39/fda74f8215ef94a812dd780073c61a826a88a01e51f627a3454f7ae6951d/ipython-9.0.1-py3-none-any.whl", hash = "sha256:3e878273824b52e0a2280ed84f8193aba8c4ba9a6f45a438348a3d5ef1a34bd0", size = 600186 },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074 },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +344,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
 ]
 
 [[package]]
@@ -521,6 +604,27 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -564,6 +668,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.29.3"
 source = { registry = "https://pypi.org/simple" }
@@ -575,6 +691,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/06/7c467744d23c3979ce250397e26d8ad8eeb2bea7b18ca12ad58313c1b8d5/protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84", size = 319573 },
     { url = "https://files.pythonhosted.org/packages/a8/45/2ebbde52ad2be18d3675b6bee50e68cd73c9e0654de77d595540b5129df8/protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f", size = 319672 },
     { url = "https://files.pythonhosted.org/packages/fd/b2/ab07b09e0f6d143dfb839693aa05765257bceaa13d03bf1a696b78323e7a/protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f", size = 172550 },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
 ]
 
 [[package]]
@@ -595,6 +729,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "docker" },
+    { name = "ipython" },
     { name = "mypy" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp" },
@@ -627,6 +762,7 @@ requires-dist = [
 dev = [
     { name = "codespell", specifier = ">=2.4.1" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "ipython", specifier = ">=9.0.1" },
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "opentelemetry-distro", specifier = ">=0.51b0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.30.0" },
@@ -838,6 +974,29 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
+]
+
+[[package]]
 name = "typer"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -882,6 +1041,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/88/dacc875dd54a8acadb4bcbfd4e3e86df8be75527116c91d8f9784f5e9cab/virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728", size = 4320272 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fa/849483d56773ae29740ae70043ad88e068f98a6401aa819b5d6bee604683/virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a", size = 4301478 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]
 
 [[package]]


### PR DESCRIPTION
Here we print out a status report of the state of the docket, including

* How many workers are running
* How many total tasks are in queue/scheduled
* How many tasks are running now
* A table of the nearest 1,000 tasks, with the worker they are running
  on if they are currently in-flight

Closes #10
