### PR TITLE
Uses `CliRunner` instead of subprocesses for faster testing

### DIFF
--- a/src/docket/__main__.py
+++ b/src/docket/__main__.py
@@ -1,3 +1,3 @@
-from docket.cli import app  # pragma: no cover
+from docket.cli import app
 
-app()  # pragma: no cover
+app()

--- a/src/docket/__main__.py
+++ b/src/docket/__main__.py
@@ -1,3 +1,3 @@
-from docket.cli import app
+from docket.cli import app  # pragma: no cover
 
-app()
+app()  # pragma: no cover

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -365,7 +365,7 @@ def restore(
     value_ = interpret_python_value(value)
     if parameter:
         function_name = f"{function or '(all tasks)'}"
-        print(f"Striking {function_name} {parameter} {operator} {value_!r}")
+        print(f"Restoring {function_name} {parameter} {operator} {value_!r}")
     else:
         print(f"Restoring {function}")
 

--- a/tests/cli/test_module.py
+++ b/tests/cli/test_module.py
@@ -1,18 +1,22 @@
 import asyncio
+import subprocess
+import sys
 
-from typer.testing import CliRunner
-
-from docket.cli import app
+import docket
 
 
-async def test_module_invocation_as_cli_entrypoint(runner: CliRunner):
+async def test_module_invocation_as_cli_entrypoint():
     """Should allow invoking docket as a module with python -m docket."""
-    result = await asyncio.get_running_loop().run_in_executor(
-        None,
-        runner.invoke,
-        app,
-        ["version"],
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "docket",
+        "version",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
 
-    assert result.exit_code == 0
-    assert result.output.strip() != ""
+    stdout, stderr = await process.communicate()
+
+    assert process.returncode == 0, stderr.decode()
+    assert stdout.decode().strip() == docket.__version__

--- a/tests/cli/test_module.py
+++ b/tests/cli/test_module.py
@@ -1,14 +1,18 @@
-import subprocess
-import sys
+import asyncio
+
+from typer.testing import CliRunner
+
+from docket.cli import app
 
 
-def test_module_invocation_as_cli_entrypoint():
+async def test_module_invocation_as_cli_entrypoint(runner: CliRunner):
     """Should allow invoking docket as a module with python -m docket."""
-    result = subprocess.run(
-        [sys.executable, "-m", "docket", "version"],
-        capture_output=True,
-        text=True,
-        check=True,
+    result = await asyncio.get_running_loop().run_in_executor(
+        None,
+        runner.invoke,
+        app,
+        ["version"],
     )
-    assert result.returncode == 0
-    assert result.stdout.strip() != ""
+
+    assert result.exit_code == 0
+    assert result.output.strip() != ""

--- a/tests/cli/test_workers.py
+++ b/tests/cli/test_workers.py
@@ -1,12 +1,14 @@
 import asyncio
-import sys
 from datetime import timedelta
 
+from typer.testing import CliRunner
+
+from docket.cli import app
 from docket.docket import Docket
 from docket.worker import Worker
 
 
-async def test_list_workers_command(docket: Docket):
+async def test_list_workers_command(docket: Docket, runner: CliRunner):
     """Should list all active workers"""
     heartbeat = timedelta(milliseconds=20)
     docket.heartbeat_interval = heartbeat
@@ -15,34 +17,26 @@ async def test_list_workers_command(docket: Docket):
     async with Worker(docket, name="worker-1"), Worker(docket, name="worker-2"):
         await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "docket",
-            "workers",
-            "ls",
-            "--url",
-            docket.url,
-            "--docket",
-            docket.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        result = await asyncio.get_running_loop().run_in_executor(
+            None,
+            runner.invoke,
+            app,
+            [
+                "workers",
+                "ls",
+                "--url",
+                docket.url,
+                "--docket",
+                docket.name,
+            ],
         )
-        await process.wait()
+        assert result.exit_code == 0, result.output
 
-        assert process.stderr
-        stderr = await process.stderr.read()
-        assert process.returncode == 0, stderr.decode()
-
-        assert process.stdout
-        output = await process.stdout.read()
-        output_text = output.decode()
-
-        assert "worker-1" in output_text
-        assert "worker-2" in output_text
+        assert "worker-1" in result.output
+        assert "worker-2" in result.output
 
 
-async def test_list_workers_for_task(docket: Docket):
+async def test_list_workers_for_task(docket: Docket, runner: CliRunner):
     """Should list workers that can handle a specific task"""
     heartbeat = timedelta(milliseconds=20)
     docket.heartbeat_interval = heartbeat
@@ -51,29 +45,21 @@ async def test_list_workers_for_task(docket: Docket):
     async with Worker(docket, name="worker-1"), Worker(docket, name="worker-2"):
         await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "docket",
-            "workers",
-            "for-task",
-            "trace",
-            "--url",
-            docket.url,
-            "--docket",
-            docket.name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        result = await asyncio.get_running_loop().run_in_executor(
+            None,
+            runner.invoke,
+            app,
+            [
+                "workers",
+                "for-task",
+                "trace",
+                "--url",
+                docket.url,
+                "--docket",
+                docket.name,
+            ],
         )
-        await process.wait()
+        assert result.exit_code == 0, result.output
 
-        assert process.stderr
-        stderr = await process.stderr.read()
-        assert process.returncode == 0, stderr.decode()
-
-        assert process.stdout
-        output = await process.stdout.read()
-        output_text = output.decode()
-
-        assert "worker-1" in output_text
-        assert "worker-2" in output_text
+        assert "worker-1" in result.output
+        assert "worker-2" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,8 +62,11 @@ def redis_server(redis_port: int) -> Generator[Container, None, None]:
         container.stop()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def redis_url(redis_server: Container, redis_port: int) -> str:
+    with Redis.from_url(f"redis://localhost:{redis_port}/0") as r:  # type: ignore
+        r.flushdb()  # type: ignore
+
     return f"redis://localhost:{redis_port}/0"
 
 


### PR DESCRIPTION
I'd underestimated how much slower the test suite was with the subprocesses, until I noticed that each subprocess created its own intermediate `coverage` output file.  Then I realized that coverage needed to instrument all the code for each subprocess invocation.