### PR TITLE
Handles `XAUTOCLAIM` responses with only 2 elements.

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -262,7 +262,7 @@ class Worker:
                         )
 
                     redeliveries: RedisMessages
-                    _, redeliveries, _ = await redis.xautoclaim(
+                    _, redeliveries, *_ = await redis.xautoclaim(
                         name=self.docket.stream_key,
                         groupname=self.docket.worker_group_name,
                         consumername=self.name,


### PR DESCRIPTION
Under some circumstance, `xautoclaim` will only return 2 elements
instead of 3.  This appears to be the case with either `redis==4.6.0` or
Redis 6, based on some empirical testing.  In either case, we're only
interested in the second element (the messages), so we can safely handle
either response.
