### PR TITLE
Fixes a potential race condition that would abandon claimed tasks

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -280,8 +280,6 @@ class Worker:
 
                     for message_id, message in redeliveries:
                         start_task(message_id, message)
-                        if available_slots <= 0:
-                            break
 
                     if available_slots <= 0:
                         continue
@@ -300,8 +298,7 @@ class Worker:
                     for _, messages in new_deliveries:
                         for message_id, message in messages:
                             start_task(message_id, message)
-                            if available_slots <= 0:
-                                break
+
             except asyncio.CancelledError:
                 if active_tasks:  # pragma: no cover
                     logger.info(


### PR DESCRIPTION
There is a subtle race condition here, where if we break early from
these two loops of starting tasks, we could end up _not_ running a task
that we'd claimed.  I'm not sure what conditions would get us here, but
it seems better to violate the concurrency than to claim tasks and then
never work them.
