### PR TITLE
Runs tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,14 @@ source = "vcs"
 packages = ["src/docket"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/docket --cov=tests --cov-report=term-missing --cov-branch"
+addopts = [
+    "--numprocesses=logical",
+    "--maxprocesses=4",
+    "--cov=src/docket",
+    "--cov=tests",
+    "--cov-report=term-missing",
+    "--cov-branch",
+]
 filterwarnings = ["error"]
 
 [tool.pyright]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import fcntl
 import os
 import socket
 import time
@@ -24,13 +25,6 @@ def now() -> Callable[[], datetime]:
     return partial(datetime.now, timezone.utc)
 
 
-@pytest.fixture(scope="session")
-def redis_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
 @contextmanager
 def _sync_redis(url: str) -> Generator[Redis, None, None]:
     pool: ConnectionPool | None = None
@@ -44,48 +38,102 @@ def _sync_redis(url: str) -> Generator[Redis, None, None]:
             pool.disconnect()
 
 
-@pytest.fixture(scope="session")
-def redis_server(redis_port: int) -> Generator[Container, None, None]:
-    client = DockerClient.from_env()
+@contextmanager
+def _adminitrative_redis(port: int) -> Generator[Redis, None, None]:
+    with _sync_redis(f"redis://localhost:{port}/15") as r:
+        yield r
 
-    container: Container
 
-    # Find and remove any containers from previous test runs
-    containers: Iterable[Container] = cast(
-        Iterable[Container],
-        client.containers.list(all=True, filters={"label": "source=docket-unit-tests"}),  # type: ignore
-    )
-    for container in containers:  # pragma: no cover
-        container.remove(force=True)
-
-    container = client.containers.run(
-        f"redis:{REDIS_VERSION}",
-        detach=True,
-        ports={"6379/tcp": redis_port},
-        labels={"source": "docket-unit-tests"},
-        auto_remove=True,
-    )
-
-    url = f"redis://localhost:{redis_port}/0"
-
+def _wait_for_redis(port: int) -> None:
     while True:
         try:
-            with _sync_redis(url) as r:
+            with _adminitrative_redis(port) as r:
                 success = r.ping()  # type: ignore
                 if success:  # pragma: no branch
-                    break
+                    return
         except redis.exceptions.ConnectionError:  # pragma: no cover
             time.sleep(0.1)
+
+
+@pytest.fixture(scope="session")
+def redis_server(testrun_uid: str, worker_id: str) -> Generator[Container, None, None]:
+    client = DockerClient.from_env()
+
+    container: Container | None = None
+    lock_file_name = f"/tmp/docket-unit-tests-{testrun_uid}-startup"
+
+    with open(lock_file_name, "w+") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+        containers: Iterable[Container] = cast(
+            Iterable[Container],
+            client.containers.list(  # type: ignore
+                all=True,
+                filters={"label": "source=docket-unit-tests"},
+            ),
+        )
+        for c in containers:
+            if c.labels.get("testrun_uid") == testrun_uid:  # type: ignore
+                container = c
+            else:
+                c.remove(force=True)  # pragma: no cover
+
+        if not container:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                redis_port = s.getsockname()[1]
+
+            container = client.containers.run(
+                f"redis:{REDIS_VERSION}",
+                detach=True,
+                ports={"6379/tcp": redis_port},
+                labels={
+                    "source": "docket-unit-tests",
+                    "testrun_uid": testrun_uid,
+                },
+                auto_remove=True,
+            )
+
+            _wait_for_redis(redis_port)
+        else:
+            port_bindings = container.attrs["HostConfig"]["PortBindings"]["6379/tcp"]
+            redis_port = int(port_bindings[0]["HostPort"])
+
+        with _adminitrative_redis(redis_port) as r:
+            r.sadd(f"docket-unit-tests:{testrun_uid}", worker_id)
 
     try:
         yield container
     finally:
-        container.stop()
+        with _adminitrative_redis(redis_port) as r:
+            with r.pipeline() as pipe:  # type: ignore
+                pipe.srem(f"docket-unit-tests:{testrun_uid}", worker_id)
+                pipe.scard(f"docket-unit-tests:{testrun_uid}")
+                count: int
+                _, count = pipe.execute()  # type: ignore
+
+        if count == 0:
+            container.stop()
+            os.remove(lock_file_name)
 
 
 @pytest.fixture
-def redis_url(redis_server: Container, redis_port: int) -> str:
-    url = f"redis://localhost:{redis_port}/0"
+def redis_port(redis_server: Container) -> int:
+    port_bindings = redis_server.attrs["HostConfig"]["PortBindings"]["6379/tcp"]
+    return int(port_bindings[0]["HostPort"])
+
+
+@pytest.fixture(scope="session")
+def redis_db(worker_id: str) -> int:
+    if not worker_id or "gw" not in worker_id:
+        return 0  # pragma: no cover
+    else:
+        return 0 + int(worker_id.replace("gw", ""))  # pragma: no cover
+
+
+@pytest.fixture
+def redis_url(redis_port: int, redis_db: int) -> str:
+    url = f"redis://localhost:{redis_port}/{redis_db}"
     with _sync_redis(url) as r:
         r.flushdb()  # type: ignore
     return url


### PR DESCRIPTION
This uses `pytest-xdist` for splitting tests over multiple processes,
and coordinates the workers to create a single redis container, with
each worker using a different DB.  This allows for up to 15 workers (as
we hold off db=15 itself to be for bookkeeping of the test suite).

With some emperical testing, I found that 4 workers results in the
lowest runtime right now.

Closes #71
