### PR TITLE
First-class support for self-perpetuating tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,13 @@ repos:
     hooks:
       - id: pyright
         name: pyright (docket package)
-        entry: uv run pyright --verifytypes docket --ignoreexternal
+        entry: pyright --verifytypes docket --ignoreexternal
         language: system
         types: [python]
         pass_filenames: false
       - id: pyright
         name: pyright (source and tests)
-        entry: uv run pyright tests
+        entry: pyright tests
         language: system
         types: [python]
         pass_filenames: false

--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -14,6 +14,7 @@ from .dependencies import (
     CurrentExecution,
     CurrentWorker,
     ExponentialRetry,
+    Perpetual,
     Retry,
     TaskKey,
     TaskLogger,
@@ -34,5 +35,6 @@ __all__ = [
     "Retry",
     "ExponentialRetry",
     "Logged",
+    "Perpetual",
     "__version__",
 ]

--- a/src/docket/instrumentation.py
+++ b/src/docket/instrumentation.py
@@ -70,6 +70,12 @@ TASKS_RETRIED = meter.create_counter(
     unit="1",
 )
 
+TASKS_PERPETUATED = meter.create_counter(
+    "docket_tasks_perpetuated",
+    description="How many tasks that have been self-perpetuated",
+    unit="1",
+)
+
 TASK_DURATION = meter.create_histogram(
     "docket_task_duration",
     description="How long tasks take to complete",

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -22,6 +22,7 @@ from docket import (
     Execution,
     ExponentialRetry,
     Logged,
+    Perpetual,
     Retry,
     TaskKey,
     TaskLogger,
@@ -854,3 +855,104 @@ async def test_adding_task_with_unbindable_arguments(
         await worker.run_until_finished()
 
     assert "got an unexpected keyword argument 'd'" in caplog.text
+
+
+async def test_perpetual_tasks(docket: Docket, worker: Worker):
+    """Perpetual tasks should reschedule themselves forever"""
+
+    calls = 0
+
+    async def perpetual_task(
+        a: str,
+        b: int,
+        perpetual: Perpetual = Perpetual(every=timedelta(milliseconds=50)),
+    ):
+        assert a == "a"
+        assert b == 2
+
+        assert isinstance(perpetual, Perpetual)
+
+        assert perpetual.every == timedelta(milliseconds=50)
+
+        nonlocal calls
+        calls += 1
+
+    execution = await docket.add(perpetual_task)(a="a", b=2)
+
+    await worker.run_at_most({execution.key: 3})
+
+    assert calls == 3
+
+
+async def test_perpetual_tasks_can_cancel_themselves(docket: Docket, worker: Worker):
+    """A perpetual task can request its own cancellation"""
+    calls = 0
+
+    async def perpetual_task(
+        a: str,
+        b: int,
+        perpetual: Perpetual = Perpetual(every=timedelta(milliseconds=50)),
+    ):
+        assert a == "a"
+        assert b == 2
+
+        assert isinstance(perpetual, Perpetual)
+
+        assert perpetual.every == timedelta(milliseconds=50)
+
+        nonlocal calls
+        calls += 1
+
+        if calls == 3:
+            perpetual.cancel()
+
+    await docket.add(perpetual_task)(a="a", b=2)
+
+    await worker.run_until_finished()
+
+    assert calls == 3
+
+
+async def test_perpetual_tasks_can_change_their_parameters(
+    docket: Docket, worker: Worker
+):
+    """Perpetual tasks may change their parameters each time"""
+    arguments: list[tuple[str, int]] = []
+
+    async def perpetual_task(
+        a: str,
+        b: int,
+        perpetual: Perpetual = Perpetual(every=timedelta(milliseconds=50)),
+    ):
+        arguments.append((a, b))
+        perpetual.perpetuate(a + "a", b=b + 1)
+
+    execution = await docket.add(perpetual_task)(a="a", b=1)
+
+    await worker.run_at_most({execution.key: 3})
+
+    assert len(arguments) == 3
+    assert arguments == [("a", 1), ("aa", 2), ("aaa", 3)]
+
+
+async def test_perpetual_tasks_perpetuate_even_after_errors(
+    docket: Docket, worker: Worker
+):
+    """Perpetual tasks may change their parameters each time"""
+    calls = 0
+
+    async def perpetual_task(
+        a: str,
+        b: int,
+        perpetual: Perpetual = Perpetual(every=timedelta(milliseconds=50)),
+    ):
+        nonlocal calls
+        calls += 1
+
+        raise ValueError("woops!")
+
+    execution = await docket.add(perpetual_task)(a="a", b=1)
+
+    await worker.run_at_most({execution.key: 3})
+
+    assert calls == 3

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -388,4 +388,4 @@ async def test_perpetual_tasks_are_scheduled_close_to_target_time(
     average = total / len(intervals)
 
     # even with a variable duration, Docket attempts to schedule them equally
-    assert timedelta(milliseconds=40) <= average <= timedelta(milliseconds=60)
+    assert timedelta(milliseconds=45) <= average <= timedelta(milliseconds=70)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,6 +11,7 @@ import redis.exceptions
 from redis.asyncio import Redis
 
 from docket import CurrentWorker, Docket, Worker
+from docket.dependencies import Perpetual
 from docket.docket import RedisMessage
 from docket.tasks import standard_tasks
 
@@ -358,3 +359,33 @@ async def test_worker_recovers_from_redis_errors(
         assert worker_info.last_seen > error_time, (
             "Worker should have sent heartbeats after the Redis error"
         )
+
+
+async def test_perpetual_tasks_are_scheduled_close_to_target_time(
+    docket: Docket, worker: Worker
+):
+    """A perpetual task is scheduled as close to the target period as possible"""
+    timestamps: list[datetime] = []
+
+    async def perpetual_task(
+        a: str,
+        b: int,
+        perpetual: Perpetual = Perpetual(every=timedelta(milliseconds=50)),
+    ):
+        timestamps.append(datetime.now(timezone.utc))
+
+        if len(timestamps) % 2 == 0:
+            await asyncio.sleep(0.05)
+
+    await docket.add(perpetual_task, key="my-key")(a="a", b=2)
+
+    await worker.run_at_most({"my-key": 8})
+
+    assert len(timestamps) == 8
+
+    intervals = [next - previous for previous, next in zip(timestamps, timestamps[1:])]
+    total = timedelta(seconds=sum(i.total_seconds() for i in intervals))
+    average = total / len(intervals)
+
+    # even with a variable duration, Docket attempts to schedule them equally
+    assert timedelta(milliseconds=40) <= average <= timedelta(milliseconds=60)


### PR DESCRIPTION
With the new `Perpetual` dependency, a user can request that a task
automatically perpetuate itself indefinitely.  `Perpetual` gives an
API for cancelling the chain of tasks, as well as adjusting parameters
between executions.

The typing for `perpetual.perpetuate(*args, **kwargs)` isn't aware of
the tasks' function signature, and I'm not sure how that would be
possible without requiring the user to make some pretty onerous generics
and a `Protocol` representing the task.
