### PR TITLE
Checks for maximum execution counts at both execution and scheduling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import fcntl
+import logging
 import os
 import socket
 import time
@@ -18,6 +19,12 @@ from redis import ConnectionPool, Redis
 from docket import Docket, Worker
 
 REDIS_VERSION = os.environ.get("REDIS_VERSION", "7.4")
+
+
+@pytest.fixture(autouse=True)
+def log_level(caplog: pytest.LogCaptureFixture) -> Generator[None, None, None]:
+    with caplog.at_level(logging.DEBUG):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
While trying to integrate docket `Perpetual` and `run_at_most` in a
real-world project that has longer time horizons between tasks, I
noticed that the test suite was hanging because we were actually
scheduling the new task and then waiting for it it come due.
