### PR TITLE
Avoids errors when a `None` messages comes back from redis

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -291,6 +291,9 @@ class Worker:
                     def start_task(
                         message_id: RedisMessageID, message: RedisMessage
                     ) -> None:
+                        if not message:  # pragma: no cover
+                            return
+
                         task = asyncio.create_task(self._execute(message))
                         active_tasks[task] = message_id
 


### PR DESCRIPTION
I'm not entirely sure exactly under which conditions this can happen,
but it's easy enough to handle here.

Closes #83
