### PR TITLE
A first take at idempotency, which addresses tasks in the stream

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -377,6 +377,9 @@ class Worker:
 
         execution = Execution.from_message(function, message)
 
+        async with self.docket.redis() as redis:
+            await redis.delete(self.docket.known_task_key(execution.key))
+
         log_context = {**log_context, **execution.specific_labels()}
         counter_labels = {**self.labels(), **execution.general_labels()}
 

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -79,7 +79,7 @@ async def test_scheduled_execution(
     assert when <= now()
 
 
-async def test_adding_is_itempotent(
+async def test_adding_is_idempotent(
     docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
 ):
     """docket should allow for rescheduling a task for later"""
@@ -157,6 +157,77 @@ async def test_rescheduling_by_name(
     the_task.assert_awaited_once_with("b", "c", c="d")
 
     assert later <= now()
+
+
+async def test_task_keys_are_idempotent_in_the_future(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """docket should only allow one task with the same key to be scheduled or due"""
+
+    key = f"my-cool-task:{uuid4()}"
+
+    soon = now() + timedelta(milliseconds=10)
+    await docket.add(the_task, when=soon, key=key)("a", "b", c="c")
+    await docket.add(the_task, when=now(), key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("a", "b", c="c")
+    the_task.reset_mock()
+
+    # It should be fine to run it afterward
+    await docket.add(the_task, key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("d", "e", c="f")
+
+
+async def test_task_keys_are_idempotent_between_the_future_and_present(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """docket should only allow one task with the same key to be scheduled or due"""
+
+    key = f"my-cool-task:{uuid4()}"
+
+    soon = now() + timedelta(milliseconds=10)
+    await docket.add(the_task, when=now(), key=key)("a", "b", c="c")
+    await docket.add(the_task, when=soon, key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("a", "b", c="c")
+    the_task.reset_mock()
+
+    # It should be fine to run it afterward
+    await docket.add(the_task, key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("d", "e", c="f")
+
+
+async def test_task_keys_are_idempotent_in_the_present(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """docket should only allow one task with the same key to be scheduled or due"""
+
+    key = f"my-cool-task:{uuid4()}"
+
+    await docket.add(the_task, when=now(), key=key)("a", "b", c="c")
+    await docket.add(the_task, when=now(), key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("a", "b", c="c")
+    the_task.reset_mock()
+
+    # It should be fine to run it afterward
+    await docket.add(the_task, key=key)("d", "e", c="f")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("d", "e", c="f")
 
 
 async def test_cancelling_future_task(
@@ -696,7 +767,8 @@ async def test_striking_entire_parameters(
             call(customer_id="123", order_id="456"),
             call(customer_id="456", order_id="789"),
             # customer_id == 789 is stricken
-        ]
+        ],
+        any_order=True,
     )
     the_task.reset_mock()
 
@@ -705,7 +777,8 @@ async def test_striking_entire_parameters(
         [
             call(customer_id="456", order_id="012"),
             # customer_id == 789 is stricken
-        ]
+        ],
+        any_order=True,
     )
     another_task.reset_mock()
 
@@ -725,7 +798,8 @@ async def test_striking_entire_parameters(
             # customer_id == 123 is stricken
             call(customer_id="456", order_id="789"),
             # customer_id == 789 is stricken
-        ]
+        ],
+        any_order=True,
     )
     the_task.reset_mock()
 
@@ -734,7 +808,8 @@ async def test_striking_entire_parameters(
         [
             call(customer_id="456", order_id="012"),
             # customer_id == 789 is stricken
-        ]
+        ],
+        any_order=True,
     )
     another_task.reset_mock()
 
@@ -754,7 +829,8 @@ async def test_striking_entire_parameters(
             call(customer_id="123", order_id="456"),
             call(customer_id="456", order_id="789"),
             # customer_id == 789 is still stricken
-        ]
+        ],
+        any_order=True,
     )
 
     assert another_task.call_count == 1
@@ -762,7 +838,8 @@ async def test_striking_entire_parameters(
         [
             call(customer_id="456", order_id="012"),
             # customer_id == 789 is still stricken
-        ]
+        ],
+        any_order=True,
     )
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -388,7 +388,7 @@ async def test_perpetual_tasks_are_scheduled_close_to_target_time(
     average = total / len(intervals)
 
     # even with a variable duration, Docket attempts to schedule them equally
-    assert timedelta(milliseconds=45) <= average <= timedelta(milliseconds=70)
+    assert timedelta(milliseconds=45) <= average <= timedelta(milliseconds=75)
 
 
 async def test_worker_can_exit_from_perpetual_tasks_that_queue_further_tasks(


### PR DESCRIPTION
Without addressing per-task locking on the task key, this makes sure
that task keys are treated idempotently between the queue and the
stream.  A key is set for each task as it is queued, and that key exists
until the task starts execution.  This helps to tie the lifetime of that
key to the redelivery mechanism, so that if a worker crashes during the
window between retrieving the message and deleting that key, it will
still be available to execute from the stream after the redelivery
timeout.
