### PR TITLE
Makes the chaos tests a little more interesting with future tasks

### DIFF
--- a/chaos/driver.py
+++ b/chaos/driver.py
@@ -76,7 +76,7 @@ async def run_redis(version: str) -> AsyncGenerator[tuple[str, Container], None]
 
 async def main(
     mode: Literal["performance", "chaos"] = "chaos",
-    tasks: int = 10000,
+    tasks: int = 20000,
     producers: int = 5,
     workers: int = 10,
 ):


### PR DESCRIPTION
About half of the tasks here will now be shortly in the future, meaning
we'll have more work to do in the scheduling of due tasks Lua script.

On my laptop (admittedly kind of a beast), I've gotten speeds of > 5k
tasks per second through on shorter runs with small numbers of workers.
When cranking up to 500 workers against a single redis, I can routinely
get > 800/s (which crushes my machine peaking out around 5k redis
clients connected at once).  With 100 workers, I can get > 2.8k/s.
