### PR TITLE
Decouples the scheduling of due tasks from the working of them

### DIFF
--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -236,6 +236,14 @@ def worker(
             envvar="DOCKET_WORKER_MINIMUM_CHECK_INTERVAL",
         ),
     ] = timedelta(milliseconds=100),
+    scheduling_resolution: Annotated[
+        timedelta,
+        typer.Option(
+            parser=duration,
+            help="How frequently to check for and promote scheduled tasks to the queue",
+            envvar="DOCKET_WORKER_SCHEDULING_RESOLUTION",
+        ),
+    ] = timedelta(milliseconds=250),
     until_finished: Annotated[
         bool,
         typer.Option(
@@ -260,6 +268,7 @@ def worker(
             redelivery_timeout=redelivery_timeout,
             reconnection_delay=reconnection_delay,
             minimum_check_interval=minimum_check_interval,
+            scheduling_resolution=scheduling_resolution,
             until_finished=until_finished,
             metrics_port=metrics_port,
             tasks=tasks,

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -240,7 +240,7 @@ def worker(
         timedelta,
         typer.Option(
             parser=duration,
-            help="How frequently to check for and promote scheduled tasks to the queue",
+            help="How frequently to check for future tasks to be scheduled",
             envvar="DOCKET_WORKER_SCHEDULING_RESOLUTION",
         ),
     ] = timedelta(milliseconds=250),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,9 @@ async def docket(redis_url: str, aiolib: str) -> AsyncGenerator[Docket, None]:
 @pytest.fixture
 async def worker(docket: Docket) -> AsyncGenerator[Worker, None]:
     async with Worker(
-        docket, minimum_check_interval=timedelta(milliseconds=10)
+        docket,
+        minimum_check_interval=timedelta(milliseconds=10),
+        scheduling_resolution=timedelta(milliseconds=10),
     ) as worker:
         yield worker
 


### PR DESCRIPTION
This is an optimization I've had my eye on for a bit: we don't need to
go out to the future schedule queue as frequently as we need to work
tasks on the stream.  Here, I've split that loop out separately from the
worker loop, and given it a separately configurable scheduling
resolution setting.
