### PR TITLE
Fixing a myriad of race conditions

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -1,0 +1,69 @@
+import asyncio
+import os
+import socket
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from docker import DockerClient
+
+
+@asynccontextmanager
+async def run_redis(version: str) -> AsyncGenerator[str, None]:
+    def get_free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            return s.getsockname()[1]
+
+    port = get_free_port()
+
+    client = DockerClient.from_env()
+    container = client.containers.run(
+        f"redis:{version}",
+        detach=True,
+        ports={"6379/tcp": port},
+        auto_remove=True,
+    )
+
+    # Wait for Redis to be ready
+    for line in container.logs(stream=True):
+        if b"Ready to accept connections" in line:
+            break
+
+    url = f"redis://localhost:{port}/0"
+    print("***** Redis is running on %s *****", url)
+    try:
+        yield url
+    finally:
+        container.stop()
+
+
+async def run_example_workers(workers: int, concurrency: int, tasks: str):
+    async with run_redis("7.4.2") as redis_url:
+        processes = [
+            await asyncio.create_subprocess_exec(
+                "docket",
+                "worker",
+                "--name",
+                f"worker-{i}",
+                "--url",
+                redis_url,
+                "--tasks",
+                tasks,
+                "--concurrency",
+                str(concurrency),
+                env={
+                    **os.environ,
+                    "PYTHONPATH": os.path.abspath(
+                        os.path.join(os.path.dirname(__file__), "..")
+                    ),
+                },
+            )
+            for i in range(workers)
+        ]
+        try:
+            await asyncio.gather(*[p.wait() for p in processes])
+        except asyncio.CancelledError:
+            for p in processes:
+                p.kill()
+        finally:
+            await asyncio.gather(*[p.wait() for p in processes])

--- a/examples/find_and_flood.py
+++ b/examples/find_and_flood.py
@@ -1,22 +1,19 @@
 import asyncio
-import os
-import socket
-from contextlib import asynccontextmanager
 from datetime import timedelta
 from logging import Logger, LoggerAdapter
-from typing import Annotated, AsyncGenerator
-
-from docker import DockerClient
+from typing import Annotated
 
 from docket import Docket
 from docket.annotations import Logged
 from docket.dependencies import CurrentDocket, Perpetual, TaskLogger
 
+from .common import run_example_workers
+
 
 async def find(
     docket: Docket = CurrentDocket(),
     logger: LoggerAdapter[Logger] = TaskLogger(),
-    perpetual: Perpetual = Perpetual(every=timedelta(seconds=10), automatic=True),
+    perpetual: Perpetual = Perpetual(every=timedelta(seconds=3), automatic=True),
 ) -> None:
     for i in range(1, 10 + 1):
         await docket.add(flood, key=str(i))(i)
@@ -32,66 +29,11 @@ async def flood(
 tasks = [find, flood]
 
 
-@asynccontextmanager
-async def run_redis(version: str) -> AsyncGenerator[str, None]:
-    def get_free_port() -> int:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            return s.getsockname()[1]
-
-    port = get_free_port()
-
-    client = DockerClient.from_env()
-    container = client.containers.run(
-        f"redis:{version}",
-        detach=True,
-        ports={"6379/tcp": port},
-        auto_remove=True,
-    )
-
-    # Wait for Redis to be ready
-    for line in container.logs(stream=True):
-        if b"Ready to accept connections" in line:
-            break
-
-    try:
-        yield f"redis://localhost:{port}/0"
-    finally:
-        container.stop()
-
-
-async def main():
-    async with run_redis("7.4.2") as redis_url:
-        print("***** Redis is running on %s", redis_url)
-        processes = [
-            await asyncio.create_subprocess_exec(
-                "docket",
-                "worker",
-                "--name",
-                f"worker-{i}",
-                "--url",
-                redis_url,
-                "--tasks",
-                "examples.find_and_flood:tasks",
-                "--concurrency",
-                "5",
-                env={
-                    **os.environ,
-                    "PYTHONPATH": os.path.abspath(
-                        os.path.join(os.path.dirname(__file__), "..")
-                    ),
-                },
-            )
-            for i in range(3)
-        ]
-        try:
-            await asyncio.gather(*[p.wait() for p in processes])
-        except asyncio.CancelledError:
-            for p in processes:
-                p.kill()
-        finally:
-            await asyncio.gather(*[p.wait() for p in processes])
-
-
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(
+        run_example_workers(
+            workers=3,
+            concurrency=8,
+            tasks="examples.find_and_flood:tasks",
+        )
+    )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -387,8 +387,10 @@ async def test_perpetual_tasks_are_scheduled_close_to_target_time(
     total = timedelta(seconds=sum(i.total_seconds() for i in intervals))
     average = total / len(intervals)
 
+    debug = ", ".join([f"{i.total_seconds() * 1000:.2f}ms" for i in intervals])
+
     # even with a variable duration, Docket attempts to schedule them equally
-    assert timedelta(milliseconds=45) <= average <= timedelta(milliseconds=75)
+    assert timedelta(milliseconds=45) <= average <= timedelta(milliseconds=75), debug
 
 
 async def test_worker_can_exit_from_perpetual_tasks_that_queue_further_tasks(


### PR DESCRIPTION
Working through the stripped down find & flood example, I noticed all
sorts of problems when running multiple workers with these quick tasks.

First, right off the bat, we had massive race condition in
`Docket.schedule` where two processes could both check if the task was
already scheduled, both see "nope", and then both proceed to schedule
the tasks.  I was seeing massive overscheduling of quick tasks.

Next, the loop for constantly adding perpetual tasks was deeply flawed
because it had no context or memory of the timing of the task's natural
rescheduling, so it would often just jump in an reschedule a task right
as it was starting.  I realized that the far more reliable thing was to
preemptively reschedule the task in the future just before executing
it, so if there was any problem after that, it was already queued for
the future.  Much safer and less polling.

Third, it occurred to me overnight that `Docket.replace` wasn't atomic,
which is a major reliability issue as well.  This prompted me to
refactor `.add`, `.replace`, `.cancel`, and `.schedule` to use pipelines
that are passed to the underlying implementations.

Closes #98
