### PR TITLE
Making startup logs look less bad

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -43,8 +43,6 @@ async def run_example_workers(workers: int, concurrency: int, tasks: str):
             await asyncio.create_subprocess_exec(
                 "docket",
                 "worker",
-                "--name",
-                f"worker-{i}",
                 "--url",
                 redis_url,
                 "--tasks",

--- a/examples/find_and_flood.py
+++ b/examples/find_and_flood.py
@@ -17,7 +17,7 @@ async def find(
     perpetual: Perpetual = Perpetual(every=timedelta(seconds=3), automatic=True),
 ) -> None:
     for i in range(1, 10 + 1):
-        await docket.add(flood, key=f"item-{i}")(i)
+        await docket.add(flood)(i)
 
 
 async def flood(

--- a/examples/find_and_flood.py
+++ b/examples/find_and_flood.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 from datetime import timedelta
 from logging import Logger, LoggerAdapter
 from typing import Annotated
@@ -24,6 +25,7 @@ async def flood(
     logger: LoggerAdapter[Logger] = TaskLogger(),
 ) -> None:
     logger.info("Working on %s", item)
+    await asyncio.sleep(random.uniform(0.5, 2))
 
 
 tasks = [find, flood]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "redis>=4.6",
     "rich>=13.9.4",
     "typer>=0.15.1",
+    "uuid7>=0.1.0",
 ]
 
 [dependency-groups]

--- a/src/docket/__main__.py
+++ b/src/docket/__main__.py
@@ -1,3 +1,3 @@
-from docket.cli import app
+from .cli import app
 
 app()

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -23,12 +23,12 @@ from typing import (
     cast,
     overload,
 )
-from uuid import uuid4
 
 import redis.exceptions
 from opentelemetry import propagate, trace
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import Pipeline
+from uuid_extensions import uuid7
 
 from .execution import (
     Execution,
@@ -254,7 +254,7 @@ class Docket:
             when = datetime.now(timezone.utc)
 
         if key is None:
-            key = f"{function.__name__}:{uuid4()}"
+            key = str(uuid7())
 
         async def scheduler(*args: P.args, **kwargs: P.kwargs) -> Execution:
             execution = Execution(function, args, kwargs, when, key, attempt=1)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,0 +1,63 @@
+from typing import Annotated
+
+import pytest
+
+from docket import Docket, Worker
+from docket.annotations import Logged
+from docket.dependencies import CurrentDocket, CurrentWorker, Depends
+from docket.execution import TaskFunction, compact_signature, get_signature
+
+
+async def no_args() -> None: ...  # pragma: no cover
+
+
+async def one_arg(a: str) -> None: ...  # pragma: no cover
+
+
+async def two_args(a: str, b: str) -> None: ...  # pragma: no cover
+
+
+async def optional_args(a: str, b: str, c: str = "c") -> None: ...  # pragma: no cover
+
+
+async def logged_args(
+    a: Annotated[str, Logged()],
+    b: Annotated[str, Logged()] = "foo",
+) -> None: ...  # pragma: no cover
+
+
+async def a_dependency() -> str: ...  # pragma: no cover
+
+
+async def dependencies(
+    a: str,
+    b: int = 42,
+    c: str = Depends(a_dependency),
+    docket: Docket = CurrentDocket(),
+    worker: Worker = CurrentWorker(),
+) -> None: ...  # pragma: no cover
+
+
+async def only_dependencies(
+    a: str = Depends(a_dependency),
+    docket: Docket = CurrentDocket(),
+    worker: Worker = CurrentWorker(),
+) -> None: ...  # pragma: no cover
+
+
+@pytest.mark.parametrize(
+    "function, expected",
+    [
+        (no_args, ""),
+        (one_arg, "a: str"),
+        (two_args, "a: str, b: str"),
+        (optional_args, "a: str, b: str, c: str = 'c'"),
+        (logged_args, "a: str, b: str = 'foo'"),
+        (dependencies, "a: str, b: int = 42, ..."),
+        (only_dependencies, "..."),
+    ],
+)
+async def test_compact_signature(
+    docket: Docket, worker: Worker, function: TaskFunction, expected: str
+):
+    assert compact_signature(get_signature(function)) == expected

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -273,14 +273,14 @@ async def test_worker_announcements(
     docket.register(the_task)
     docket.register(another_task)
 
-    async with Worker(docket) as worker_a:
+    async with Worker(docket, name="worker-a") as worker_a:
         await asyncio.sleep(heartbeat.total_seconds() * 5)
 
         workers = await docket.workers()
         assert len(workers) == 1
         assert worker_a.name in {w.name for w in workers}
 
-        async with Worker(docket) as worker_b:
+        async with Worker(docket, name="worker-b") as worker_b:
             await asyncio.sleep(heartbeat.total_seconds() * 5)
 
             workers = await docket.workers()
@@ -315,14 +315,14 @@ async def test_task_announcements(
 
     docket.register(the_task)
     docket.register(another_task)
-    async with Worker(docket) as worker_a:
+    async with Worker(docket, name="worker-a") as worker_a:
         await asyncio.sleep(heartbeat.total_seconds() * 5)
 
         workers = await docket.task_workers("the_task")
         assert len(workers) == 1
         assert worker_a.name in {w.name for w in workers}
 
-        async with Worker(docket) as worker_b:
+        async with Worker(docket, name="worker-b") as worker_b:
             await asyncio.sleep(heartbeat.total_seconds() * 5)
 
             workers = await docket.task_workers("the_task")

--- a/uv.lock
+++ b/uv.lock
@@ -723,6 +723,7 @@ dependencies = [
     { name = "redis" },
     { name = "rich" },
     { name = "typer" },
+    { name = "uuid7" },
 ]
 
 [package.dev-dependencies]
@@ -756,6 +757,7 @@ requires-dist = [
     { name = "redis", specifier = ">=4.6" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "typer", specifier = ">=0.15.1" },
+    { name = "uuid7", specifier = ">=0.1.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1027,6 +1029,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "uuid7"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #115
Closes #114

I also noticed that the default task keys were prefaced with the function name, which is where most of the redundancy in `docket snapshot` was coming from.  Using `uuid7` makes these more compact and also look cooler.

Closes #116
