### PR TITLE
Add Valkey support to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
-        redis-version: ["6.2", "7.4"]
+        redis-version: ["6.2", "7.4", "valkey-8.0"]
         redis-py-version: [">=4.6,<5", ">=5"]
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Docket** (`pydocket` on PyPI) is a distributed background task system for Python functions with Redis-backed persistence. It enables scheduling both immediate and future work with comprehensive dependency injection, retry mechanisms, and fault tolerance.
 
-**Key Requirements**: Python 3.12+, Redis 6.2+
+**Key Requirements**: Python 3.12+, Redis 6.2+ or Valkey 8.0+
 
 ## Development Commands
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,8 +90,15 @@ def redis_server(testrun_uid: str, worker_id: str) -> Generator[Container, None,
                 s.bind(("", 0))
                 redis_port = s.getsockname()[1]
 
+            # Determine Docker image based on version
+            if REDIS_VERSION.startswith("valkey-"):
+                version = REDIS_VERSION.replace("valkey-", "")
+                image = f"valkey/valkey:{version}"
+            else:
+                image = f"redis:{REDIS_VERSION}"
+
             container = client.containers.run(
-                f"redis:{REDIS_VERSION}",
+                image,
                 detach=True,
                 ports={"6379/tcp": redis_port},
                 labels={


### PR DESCRIPTION
## Summary
- Adds Valkey 8.0 to the CI test matrix to verify compatibility alongside Redis 6.2 and 7.4
- Updates test infrastructure to handle both Redis and Valkey Docker images
- Maintains full backward compatibility with existing Redis testing

## Changes
- **CI Matrix**: Added `valkey-8.0` to test matrix, creating 12 total test combinations
- **Test Infrastructure**: Enhanced Docker image selection logic in `conftest.py` to support Valkey images
- **Documentation**: Updated requirements to mention Valkey 8.0+ support

This closes #139 to test against Valkey as a Redis-compatible alternative.

🤖 Generated with [Claude Code](https://claude.ai/code)