### PR TITLE
Fix race condition in task replacement where duplicate executions occur

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -406,7 +406,7 @@ class Worker:
                             task[task_data[j]] = task_data[j+1]
                         end
 
-                        redis.call('XADD', KEYS[2], '*',
+                        local message_id = redis.call('XADD', KEYS[2], '*',
                             'key', task['key'],
                             'when', task['when'],
                             'function', task['function'],
@@ -414,6 +414,9 @@ class Worker:
                             'kwargs', task['kwargs'],
                             'attempt', task['attempt']
                         )
+                        -- Store the message ID in the known task key
+                        local known_key = ARGV[2] .. ":known:" .. key
+                        redis.call('HSET', known_key, 'stream_message_id', message_id)
                         redis.call('DEL', hash_key)
                         due_work = due_work + 1
                     end

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -250,10 +250,10 @@ async def test_cancelling_future_task(
     the_task.assert_not_called()
 
 
-async def test_cancelling_current_task_not_supported(
+async def test_cancelling_immediate_task(
     docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
 ):
-    """docket does not allow cancelling a task that is schedule now"""
+    """docket can cancel a task that is scheduled immediately"""
 
     execution = await docket.add(the_task, now())("a", "b", c="c")
 
@@ -261,7 +261,28 @@ async def test_cancelling_current_task_not_supported(
 
     await worker.run_until_finished()
 
-    the_task.assert_awaited_once_with("a", "b", c="c")
+    the_task.assert_not_called()
+
+
+async def test_cancellation_is_idempotent(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test that canceling the same task twice doesn't error."""
+    key = f"test-task:{uuid4()}"
+
+    # Schedule a task
+    later = now() + timedelta(seconds=1)
+    await docket.add(the_task, later, key=key)("test")
+
+    # Cancel it twice - both should succeed without error
+    await docket.cancel(key)
+    await docket.cancel(key)  # Should be idempotent
+
+    # Run worker to ensure the task was actually cancelled
+    await worker.run_until_finished()
+
+    # Task should not have been executed since it was cancelled
+    the_task.assert_not_called()
 
 
 async def test_errors_are_logged(


### PR DESCRIPTION
Fix race condition in task replacement where duplicate executions occur

Previously, `docket.replace()` could not cancel tasks that had already been moved from the queue to the stream by the scheduler, causing duplicate execution when the old task ran alongside the replacement. This happened because:

1. Scheduler moves due tasks from queue → stream, assigning Redis message IDs
2. `replace()` only checked the queue, missing tasks already in the stream
3. Both old and new tasks would execute

This implements atomic task scheduling and cancellation using Lua scripts that track stream message IDs. The solution:

- **Atomic scheduling**: New Lua script handles task existence checks, replacement cancellation, and scheduling in a single operation
- **Stream message ID tracking**: When tasks move to stream, their message IDs are stored in the known task metadata
- **Atomic cancellation**: Can delete tasks from stream using stored message IDs or from queue for scheduled tasks
- **Race-free replacement**: Uses Redis locks per task key and atomic operations

Comprehensive test coverage includes race condition scenarios and idempotent operations.

Closes #149

🤖 Generated with [Claude Code](https://claude.ai/code)