### PR TITLE
Restore race condition fixes for task replacement

### DIFF
--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -16,6 +16,7 @@ from typing import (
     Mapping,
     NoReturn,
     ParamSpec,
+    Protocol,
     Self,
     Sequence,
     TypedDict,
@@ -27,7 +28,6 @@ from typing import (
 import redis.exceptions
 from opentelemetry import propagate, trace
 from redis.asyncio import ConnectionPool, Redis
-from redis.asyncio.client import Pipeline
 from uuid_extensions import uuid7
 
 from .execution import (
@@ -53,6 +53,18 @@ from .instrumentation import (
 
 logger: logging.Logger = logging.getLogger(__name__)
 tracer: trace.Tracer = trace.get_tracer(__name__)
+
+
+class _schedule_task(Protocol):
+    async def __call__(
+        self, keys: list[str], args: list[str | float | bytes]
+    ) -> str: ...  # pragma: no cover
+
+
+class _cancel_task(Protocol):
+    async def __call__(
+        self, keys: list[str], args: list[str]
+    ) -> str: ...  # pragma: no cover
 
 
 P = ParamSpec("P")
@@ -131,6 +143,8 @@ class Docket:
 
     _monitor_strikes_task: asyncio.Task[None]
     _connection_pool: ConnectionPool
+    _schedule_task_script: _schedule_task | None
+    _cancel_task_script: _cancel_task | None
 
     def __init__(
         self,
@@ -156,6 +170,8 @@ class Docket:
         self.url = url
         self.heartbeat_interval = heartbeat_interval
         self.missed_heartbeats = missed_heartbeats
+        self._schedule_task_script = None
+        self._cancel_task_script = None
 
     @property
     def worker_group_name(self) -> str:
@@ -300,9 +316,7 @@ class Docket:
             execution = Execution(function, args, kwargs, when, key, attempt=1)
 
             async with self.redis() as redis:
-                async with redis.pipeline() as pipeline:
-                    await self._schedule(redis, pipeline, execution, replace=False)
-                    await pipeline.execute()
+                await self._schedule(redis, execution, replace=False)
 
             TASKS_ADDED.add(1, {**self.labels(), **execution.general_labels()})
             TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
@@ -361,9 +375,7 @@ class Docket:
             execution = Execution(function, args, kwargs, when, key, attempt=1)
 
             async with self.redis() as redis:
-                async with redis.pipeline() as pipeline:
-                    await self._schedule(redis, pipeline, execution, replace=True)
-                    await pipeline.execute()
+                await self._schedule(redis, execution, replace=True)
 
             TASKS_REPLACED.add(1, {**self.labels(), **execution.general_labels()})
             TASKS_CANCELLED.add(1, {**self.labels(), **execution.general_labels()})
@@ -383,9 +395,7 @@ class Docket:
             },
         ):
             async with self.redis() as redis:
-                async with redis.pipeline() as pipeline:
-                    await self._schedule(redis, pipeline, execution, replace=False)
-                    await pipeline.execute()
+                await self._schedule(redis, execution, replace=False)
 
         TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
 
@@ -400,9 +410,7 @@ class Docket:
             attributes={**self.labels(), "docket.key": key},
         ):
             async with self.redis() as redis:
-                async with redis.pipeline() as pipeline:
-                    await self._cancel(pipeline, key)
-                    await pipeline.execute()
+                await self._cancel(redis, key)
 
         TASKS_CANCELLED.add(1, self.labels())
 
@@ -420,13 +428,23 @@ class Docket:
     def parked_task_key(self, key: str) -> str:
         return f"{self.name}:{key}"
 
+    def stream_id_key(self, key: str) -> str:
+        return f"{self.name}:stream-id:{key}"
+
     async def _schedule(
         self,
         redis: Redis,
-        pipeline: Pipeline,
         execution: Execution,
         replace: bool = False,
     ) -> None:
+        """Schedule a task atomically.
+
+        Handles:
+        - Checking for task existence
+        - Cancelling existing tasks when replacing
+        - Adding tasks to stream (immediate) or queue (future)
+        - Tracking stream message IDs for later cancellation
+        """
         if self.strike_list.is_stricken(execution):
             logger.warning(
                 "%r is stricken, skipping schedule of %r",
@@ -449,32 +467,138 @@ class Docket:
         key = execution.key
         when = execution.when
         known_task_key = self.known_task_key(key)
+        is_immediate = when <= datetime.now(timezone.utc)
 
+        # Lock per task key to prevent race conditions between concurrent operations
         async with redis.lock(f"{known_task_key}:lock", timeout=10):
-            if replace:
-                await self._cancel(pipeline, key)
-            else:
-                # if the task is already in the queue or stream, retain it
-                if await redis.exists(known_task_key):
-                    logger.debug(
-                        "Task %r is already in the queue or stream, not scheduling",
-                        key,
-                        extra=self.labels(),
-                    )
-                    return
+            if self._schedule_task_script is None:
+                self._schedule_task_script = cast(
+                    _schedule_task,
+                    redis.register_script(
+                        # KEYS: stream_key, known_key, parked_key, queue_key, stream_id_key
+                        # ARGV: task_key, when_timestamp, is_immediate, replace, ...message_fields
+                        """
+                        local stream_key = KEYS[1]
+                        local known_key = KEYS[2]
+                        local parked_key = KEYS[3]
+                        local queue_key = KEYS[4]
+                        local stream_id_key = KEYS[5]
 
-            pipeline.set(known_task_key, when.timestamp())
+                        local task_key = ARGV[1]
+                        local when_timestamp = ARGV[2]
+                        local is_immediate = ARGV[3] == '1'
+                        local replace = ARGV[4] == '1'
 
-            if when <= datetime.now(timezone.utc):
-                pipeline.xadd(self.stream_key, message)  # type: ignore[arg-type]
-            else:
-                pipeline.hset(self.parked_task_key(key), mapping=message)  # type: ignore[arg-type]
-                pipeline.zadd(self.queue_key, {key: when.timestamp()})
+                        -- Extract message fields from ARGV[5] onwards
+                        local message = {}
+                        for i = 5, #ARGV, 2 do
+                            message[#message + 1] = ARGV[i]     -- field name
+                            message[#message + 1] = ARGV[i + 1] -- field value
+                        end
 
-    async def _cancel(self, pipeline: Pipeline, key: str) -> None:
-        pipeline.delete(self.known_task_key(key))
-        pipeline.delete(self.parked_task_key(key))
-        pipeline.zrem(self.queue_key, key)
+                        -- Handle replacement: cancel existing task if needed
+                        if replace then
+                            local existing_message_id = redis.call('GET', stream_id_key)
+                            if existing_message_id then
+                                redis.call('XDEL', stream_key, existing_message_id)
+                            end
+                            redis.call('DEL', known_key, parked_key, stream_id_key)
+                            redis.call('ZREM', queue_key, task_key)
+                        else
+                            -- Check if task already exists
+                            if redis.call('EXISTS', known_key) == 1 then
+                                return 'EXISTS'
+                            end
+                        end
+
+                        if is_immediate then
+                            -- Add to stream and store message ID for later cancellation
+                            local message_id = redis.call('XADD', stream_key, '*', unpack(message))
+                            redis.call('SET', known_key, when_timestamp)
+                            redis.call('SET', stream_id_key, message_id)
+                            return message_id
+                        else
+                            -- Add to queue with task data in parked hash
+                            redis.call('SET', known_key, when_timestamp)
+                            redis.call('HSET', parked_key, unpack(message))
+                            redis.call('ZADD', queue_key, when_timestamp, task_key)
+                            return 'QUEUED'
+                        end
+                        """
+                    ),
+                )
+            schedule_task = self._schedule_task_script
+
+            await schedule_task(
+                keys=[
+                    self.stream_key,
+                    known_task_key,
+                    self.parked_task_key(key),
+                    self.queue_key,
+                    self.stream_id_key(key),
+                ],
+                args=[
+                    key,
+                    str(when.timestamp()),
+                    "1" if is_immediate else "0",
+                    "1" if replace else "0",
+                    *[
+                        item
+                        for field, value in message.items()
+                        for item in (field, value)
+                    ],
+                ],
+            )
+
+    async def _cancel(self, redis: Redis, key: str) -> None:
+        """Cancel a task atomically.
+
+        Handles cancellation regardless of task location:
+        - From the stream (using stored message ID)
+        - From the queue (scheduled tasks)
+        - Cleans up all associated metadata keys
+        """
+        if self._cancel_task_script is None:
+            self._cancel_task_script = cast(
+                _cancel_task,
+                redis.register_script(
+                    # KEYS: stream_key, known_key, parked_key, queue_key, stream_id_key
+                    # ARGV: task_key
+                    """
+                    local stream_key = KEYS[1]
+                    local known_key = KEYS[2]
+                    local parked_key = KEYS[3]
+                    local queue_key = KEYS[4]
+                    local stream_id_key = KEYS[5]
+                    local task_key = ARGV[1]
+
+                    -- Delete from stream if message ID exists
+                    local message_id = redis.call('GET', stream_id_key)
+                    if message_id then
+                        redis.call('XDEL', stream_key, message_id)
+                    end
+
+                    -- Clean up all task-related keys
+                    redis.call('DEL', known_key, parked_key, stream_id_key)
+                    redis.call('ZREM', queue_key, task_key)
+
+                    return 'OK'
+                    """
+                ),
+            )
+        cancel_task = self._cancel_task_script
+
+        # Execute the cancellation script
+        await cancel_task(
+            keys=[
+                self.stream_key,
+                self.known_task_key(key),
+                self.parked_task_key(key),
+                self.queue_key,
+                self.stream_id_key(key),
+            ],
+            args=[key],
+        )
 
     @property
     def strike_key(self) -> str:
@@ -781,6 +905,7 @@ class Docket:
                         key = key_bytes.decode()
                         pipeline.delete(self.parked_task_key(key))
                         pipeline.delete(self.known_task_key(key))
+                        pipeline.delete(self.stream_id_key(key))
 
                     await pipeline.execute()
 

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -495,7 +495,8 @@ class Worker:
 
         logger.debug("Deleting known task", extra=self._log_context())
         known_task_key = self.docket.known_task_key(key)
-        await redis.delete(known_task_key)
+        stream_id_key = self.docket.stream_id_key(key)
+        await redis.delete(known_task_key, stream_id_key)
 
     async def _execute(self, execution: Execution) -> None:
         log_context = {**self._log_context(), **execution.specific_labels()}

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -104,13 +104,9 @@ async def test_adding_is_idempotent(
     assert soon <= now() < later
 
 
-@pytest.mark.skip(
-    "Temporarily skipping due to test flake for task rescheduling. "
-    "See https://github.com/chrisguidry/docket/issues/149"
-)
 async def test_rescheduling_later(
     docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
-):  # pragma: no cover
+):
     """docket should allow for rescheduling a task for later"""
 
     key = f"my-cool-task:{uuid4()}"
@@ -254,10 +250,10 @@ async def test_cancelling_future_task(
     the_task.assert_not_called()
 
 
-async def test_cancelling_current_task_not_supported(
+async def test_cancelling_immediate_task(
     docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
 ):
-    """docket does not allow cancelling a task that is schedule now"""
+    """docket can cancel a task that is scheduled immediately"""
 
     execution = await docket.add(the_task, now())("a", "b", c="c")
 
@@ -265,7 +261,28 @@ async def test_cancelling_current_task_not_supported(
 
     await worker.run_until_finished()
 
-    the_task.assert_awaited_once_with("a", "b", c="c")
+    the_task.assert_not_called()
+
+
+async def test_cancellation_is_idempotent(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test that canceling the same task twice doesn't error."""
+    key = f"test-task:{uuid4()}"
+
+    # Schedule a task
+    later = now() + timedelta(seconds=1)
+    await docket.add(the_task, later, key=key)("test")
+
+    # Cancel it twice - both should succeed without error
+    await docket.cancel(key)
+    await docket.cancel(key)  # Should be idempotent
+
+    # Run worker to ensure the task was actually cancelled
+    await worker.run_until_finished()
+
+    # Task should not have been executed since it was cancelled
+    the_task.assert_not_called()
 
 
 async def test_errors_are_logged(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,10 +1,14 @@
 import asyncio
 import logging
+import time
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Callable, Iterable
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
+import cloudpickle  # type: ignore[import]
 import pytest
 from redis.asyncio import Redis
 from redis.exceptions import ConnectionError
@@ -17,6 +21,8 @@ from docket import (
     Perpetual,
     Worker,
 )
+from docket.dependencies import Timeout
+from docket.execution import Execution
 from docket.tasks import standard_tasks
 from docket.worker import ms
 
@@ -174,7 +180,6 @@ async def test_redeliveries_respect_concurrency_limits(docket: Docket):
         nonlocal failure_count
 
         # Record when this task runs
-        import time
 
         task_executions.append((customer_id, time.time()))
 
@@ -555,7 +560,6 @@ async def test_worker_can_be_told_to_skip_automatic_tasks(docket: Docket):
 
 async def test_worker_concurrency_limits_task_queuing_behavior(docket: Docket):
     """Test that concurrency limits control task execution properly"""
-    from contextvars import ContextVar
 
     # Use contextvar for reliable tracking across async execution
     execution_log: ContextVar[list[tuple[str, int]]] = ContextVar("execution_log")
@@ -1171,7 +1175,6 @@ async def test_worker_concurrency_edge_cases(docket: Docket):
 
 async def test_worker_timeout_exceeds_redelivery_timeout(docket: Docket):
     """Test worker handles user timeout longer than redelivery timeout."""
-    from docket.dependencies import Timeout
 
     task_executed = False
 
@@ -1250,8 +1253,6 @@ async def test_worker_concurrency_missing_argument_early_return(docket: Docket):
 
 async def test_worker_no_concurrency_dependency_in_function(docket: Docket):
     """Test _can_start_task with function that has no concurrency dependency."""
-    from docket.execution import Execution
-    from datetime import datetime, timezone
 
     async def task_without_concurrency_dependency():
         await asyncio.sleep(0.001)
@@ -1277,8 +1278,6 @@ async def test_worker_no_concurrency_dependency_in_function(docket: Docket):
 
 async def test_worker_no_concurrency_dependency_in_release(docket: Docket):
     """Test _release_concurrency_slot with function that has no concurrency dependency."""
-    from docket.execution import Execution
-    from datetime import datetime, timezone
 
     async def task_without_concurrency_dependency():
         await asyncio.sleep(0.001)
@@ -1303,8 +1302,6 @@ async def test_worker_no_concurrency_dependency_in_release(docket: Docket):
 
 async def test_worker_missing_concurrency_argument_in_release(docket: Docket):
     """Test _release_concurrency_slot when concurrency argument is missing."""
-    from docket.execution import Execution
-    from datetime import datetime, timezone
 
     async def task_with_missing_arg(
         concurrency: ConcurrencyLimit = ConcurrencyLimit(
@@ -1333,8 +1330,6 @@ async def test_worker_missing_concurrency_argument_in_release(docket: Docket):
 
 async def test_worker_concurrency_missing_argument_in_can_start(docket: Docket):
     """Test _can_start_task with missing concurrency argument during execution."""
-    from docket.execution import Execution
-    from datetime import datetime, timezone
 
     async def task_with_missing_concurrency_arg(
         concurrency: ConcurrencyLimit = ConcurrencyLimit(
@@ -1383,7 +1378,6 @@ async def test_worker_exception_before_dependencies(docket: Docket):
     task_failed = False
 
     # Mock resolved_dependencies to fail before setting dependencies
-    from unittest.mock import patch, AsyncMock
 
     await docket.add(task_that_will_fail)()
 
@@ -1427,3 +1421,338 @@ async def test_finally_block_releases_concurrency_on_success(docket: Docket):
 
     # If both tasks completed, the finally block successfully released slots
     assert task_completed
+
+
+async def test_replacement_race_condition_stream_tasks(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test that replace() properly cancels tasks already in the stream.
+
+    This reproduces the race condition where:
+    1. Task is scheduled for immediate execution
+    2. Scheduler moves it to stream
+    3. replace() tries to cancel but only checks queue/hash, not stream
+    4. Both original and replacement tasks execute
+    """
+    key = f"my-cool-task:{uuid4()}"
+
+    # Schedule a task immediately (will be moved to stream quickly)
+    await docket.add(the_task, now(), key=key)("a", "b", c="c")
+
+    # Let the scheduler move the task to the stream
+    # The scheduler runs every 250ms by default
+    await asyncio.sleep(0.3)
+
+    # Now replace the task - this should cancel the one in the stream
+    later = now() + timedelta(milliseconds=100)
+    await docket.replace(the_task, later, key=key)("b", "c", c="d")
+
+    # Run the worker to completion
+    await worker.run_until_finished()
+
+    # Should only execute the replacement task, not both
+    the_task.assert_awaited_once_with("b", "c", c="d")
+    assert the_task.await_count == 1, (
+        f"Task was called {the_task.await_count} times, expected 1"
+    )
+
+
+async def test_replace_task_in_queue_before_stream(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test that replace() works correctly when task is still in queue."""
+    key = f"my-cool-task:{uuid4()}"
+
+    # Schedule a task slightly in the future (stays in queue)
+    soon = now() + timedelta(seconds=1)
+    await docket.add(the_task, soon, key=key)("a", "b", c="c")
+
+    # Replace immediately (before scheduler can move it)
+    later = now() + timedelta(milliseconds=100)
+    await docket.replace(the_task, later, key=key)("b", "c", c="d")
+
+    await worker.run_until_finished()
+
+    # Should only execute the replacement
+    the_task.assert_awaited_once_with("b", "c", c="d")
+    assert the_task.await_count == 1
+
+
+async def test_rapid_replace_operations(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test multiple rapid replace operations."""
+    key = f"my-cool-task:{uuid4()}"
+
+    # Schedule initial task
+    await docket.add(the_task, now(), key=key)("a", "b", c="c")
+
+    # Rapid replacements
+    for i in range(5):
+        when = now() + timedelta(milliseconds=50 + i * 10)
+        await docket.replace(the_task, when, key=key)(f"arg{i}", b=f"b{i}")
+
+    await worker.run_until_finished()
+
+    # Should only execute the last replacement
+    the_task.assert_awaited_once_with("arg4", b="b4")
+    assert the_task.await_count == 1
+
+
+async def test_wrongtype_error_with_legacy_known_task_key(
+    docket: Docket,
+    worker: Worker,
+    the_task: AsyncMock,
+    now: Callable[[], datetime],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test graceful handling when known task keys exist as strings from legacy implementations.
+
+    Regression test for issue where worker scheduler would get WRONGTYPE errors when trying to
+    HSET on known task keys that existed as string values from older docket versions.
+
+    The original error occurred when:
+    1. A legacy docket created known task keys as simple string values (timestamps)
+    2. The new scheduler tried to HSET stream_message_id on these keys
+    3. Redis threw WRONGTYPE error because you can't HSET on a string key
+    4. This caused scheduler loop failures in production
+
+    This test reproduces that scenario by manually setting up the legacy state,
+    then verifies the new code handles it gracefully without errors.
+    """
+    key = f"legacy-task:{uuid4()}"
+
+    # Simulate legacy behavior: create the known task key as a string
+    # This is what older versions of docket would have done
+    async with docket.redis() as redis:
+        known_task_key = docket.known_task_key(key)
+        when = now() + timedelta(seconds=1)
+
+        # Set up legacy state: known key as string, task in queue with parked data
+        await redis.set(known_task_key, str(when.timestamp()))
+        await redis.zadd(docket.queue_key, {key: when.timestamp()})
+
+        await redis.hset(  # type: ignore
+            docket.parked_task_key(key),
+            mapping={
+                "key": key,
+                "when": when.isoformat(),
+                "function": "trace",
+                "args": cloudpickle.dumps(["legacy task test"]),  # type: ignore[arg-type]
+                "kwargs": cloudpickle.dumps({}),  # type: ignore[arg-type]
+                "attempt": "1",
+            },
+        )
+
+    # Capture logs to ensure no errors occur and see task execution
+    with caplog.at_level(logging.INFO):
+        await worker.run_until_finished()
+
+    # Should not have any ERROR logs now that the issue is fixed
+    error_logs = [record for record in caplog.records if record.levelname == "ERROR"]
+    assert len(error_logs) == 0, (
+        f"Expected no error logs, but got: {[r.message for r in error_logs]}"
+    )
+
+    # The task should execute successfully
+    # Since we used trace, we should see an INFO log with the message
+    info_logs = [record for record in caplog.records if record.levelname == "INFO"]
+    trace_logs = [
+        record for record in info_logs if "legacy task test" in record.message
+    ]
+    assert len(trace_logs) > 0, (
+        f"Expected to see trace log with 'legacy task test', got: {[r.message for r in info_logs]}"
+    )
+
+
+async def count_redis_keys_by_type(redis: Redis, prefix: str) -> dict[str, int]:
+    """Count Redis keys by type for a given prefix."""
+    pattern = f"{prefix}*"
+    keys: Iterable[str] = await redis.keys(pattern)  # type: ignore
+    counts: dict[str, int] = {}
+
+    for key in keys:
+        key_type = await redis.type(key)
+        key_type_str = (
+            key_type.decode() if isinstance(key_type, bytes) else str(key_type)
+        )
+        counts[key_type_str] = counts.get(key_type_str, 0) + 1
+
+    return counts
+
+
+class KeyCountChecker:
+    """Helper to verify Redis key counts remain consistent across operations."""
+
+    def __init__(self, docket: Docket, redis: Redis) -> None:
+        self.docket = docket
+        self.redis = redis
+        self.baseline_counts: dict[str, int] = {}
+
+    async def capture_baseline(self) -> None:
+        """Capture baseline key counts after worker priming."""
+        self.baseline_counts = await count_redis_keys_by_type(
+            self.redis, self.docket.name
+        )
+        print(f"Baseline key counts: {self.baseline_counts}")
+
+    async def verify_keys_increased(self, operation: str) -> None:
+        """Verify that key counts increased after scheduling operation."""
+        current_counts = await count_redis_keys_by_type(self.redis, self.docket.name)
+        print(f"After {operation} key counts: {current_counts}")
+
+        total_current = sum(current_counts.values())
+        total_baseline = sum(self.baseline_counts.values())
+        assert total_current > total_baseline, (
+            f"Expected more keys after {operation}, but got {total_current} vs {total_baseline}"
+        )
+
+    async def verify_keys_returned_to_baseline(self, operation: str) -> None:
+        """Verify that key counts returned to baseline after operation completion."""
+        final_counts = await count_redis_keys_by_type(self.redis, self.docket.name)
+        print(f"Final key counts: {final_counts}")
+
+        # Check each key type matches baseline
+        all_key_types = set(self.baseline_counts.keys()) | set(final_counts.keys())
+        for key_type in all_key_types:
+            baseline_count = self.baseline_counts.get(key_type, 0)
+            final_count = final_counts.get(key_type, 0)
+            assert final_count == baseline_count, (
+                f"Memory leak detected after {operation}: {key_type} keys not cleaned up properly. "
+                f"Baseline: {baseline_count}, Final: {final_count}"
+            )
+
+
+async def test_redis_key_cleanup_successful_task(
+    docket: Docket, worker: Worker
+) -> None:
+    """Test that Redis keys are properly cleaned up after successful task execution.
+
+    This test systematically counts Redis keys before and after task operations to detect
+    memory leaks where keys are not properly cleaned up.
+    """
+    # Prime the worker (run once with no tasks to establish baseline)
+    await worker.run_until_finished()
+
+    # Create and register a simple task
+    task_executed = False
+
+    async def successful_task():
+        nonlocal task_executed
+        task_executed = True
+        await asyncio.sleep(0.01)  # Small delay to ensure proper execution flow
+
+    docket.register(successful_task)
+
+    async with docket.redis() as redis:
+        checker = KeyCountChecker(docket, redis)
+        await checker.capture_baseline()
+
+        # Schedule the task
+        await docket.add(successful_task)()
+        await checker.verify_keys_increased("scheduling")
+
+        # Execute the task
+        await worker.run_until_finished()
+
+        # Verify task executed successfully
+        assert task_executed, "Task should have executed successfully"
+
+        # Verify cleanup
+        await checker.verify_keys_returned_to_baseline("successful task execution")
+
+
+async def test_redis_key_cleanup_failed_task(docket: Docket, worker: Worker) -> None:
+    """Test that Redis keys are properly cleaned up after failed task execution."""
+    # Prime the worker
+    await worker.run_until_finished()
+
+    # Create a task that will fail
+    task_attempted = False
+
+    async def failing_task():
+        nonlocal task_attempted
+        task_attempted = True
+        raise ValueError("Intentional test failure")
+
+    docket.register(failing_task)
+
+    async with docket.redis() as redis:
+        checker = KeyCountChecker(docket, redis)
+        await checker.capture_baseline()
+
+        # Schedule the task
+        await docket.add(failing_task)()
+        await checker.verify_keys_increased("scheduling")
+
+        # Execute the task (should fail)
+        await worker.run_until_finished()
+
+        # Verify task was attempted
+        assert task_attempted, "Task should have been attempted"
+
+        # Verify cleanup despite failure
+        await checker.verify_keys_returned_to_baseline("failed task execution")
+
+
+async def test_redis_key_cleanup_cancelled_task(docket: Docket, worker: Worker) -> None:
+    """Test that Redis keys are properly cleaned up after task cancellation."""
+    # Prime the worker
+    await worker.run_until_finished()
+
+    # Create a task that won't be executed
+    task_executed = False
+
+    async def task_to_cancel():
+        nonlocal task_executed
+        task_executed = True  # pragma: no cover
+
+    docket.register(task_to_cancel)
+
+    async with docket.redis() as redis:
+        checker = KeyCountChecker(docket, redis)
+        await checker.capture_baseline()
+
+        # Schedule the task for future execution
+        future_time = datetime.now(timezone.utc) + timedelta(seconds=10)
+        execution = await docket.add(task_to_cancel, future_time)()
+        await checker.verify_keys_increased("scheduling")
+
+        # Cancel the task
+        await docket.cancel(execution.key)
+
+        # Run worker to process any cleanup
+        await worker.run_until_finished()
+
+        # Verify task was not executed
+        assert not task_executed, (
+            "Task should not have been executed after cancellation"
+        )
+
+        # Verify cleanup after cancellation
+        await checker.verify_keys_returned_to_baseline("task cancellation")
+
+
+async def test_replace_task_with_legacy_known_key(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """Test that replace() works with legacy string known_keys.
+
+    This reproduces the exact production scenario where replace() would get
+    WRONGTYPE errors when trying to HGET on legacy string known_keys.
+    The main goal is to verify no WRONGTYPE error occurs.
+    """
+    key = f"legacy-replace-task:{uuid4()}"
+
+    # Simulate legacy state: create known_key as string (old format)
+    async with docket.redis() as redis:
+        known_task_key = docket.known_task_key(key)
+        when = now()
+
+        # Create legacy known_key as STRING (what old code did)
+        await redis.set(known_task_key, str(when.timestamp()))
+
+    # Now try to replace - this should work without WRONGTYPE error
+    # The key point is that this call succeeds without throwing WRONGTYPE
+    replacement_time = now() + timedelta(seconds=1)
+    await docket.replace("trace", replacement_time, key=key)("replacement message")


### PR DESCRIPTION
This restores the race condition fixes that were temporarily reverted in PR #155. After investigation, these fixes are working correctly in production and resolve the duplicate execution issues with task replacement, especially for perpetual tasks.

The fixes implement atomic task scheduling and cancellation using Lua scripts that track stream message IDs, preventing the race condition where `docket.replace()` couldn't cancel tasks already moved from queue to stream.

Closes #149

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>