### PR TITLE
Fix memory leak in Prometheus metrics by removing unbounded labels

### DIFF
--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -455,7 +455,7 @@ class Docket:
                 1,
                 {
                     **self.labels(),
-                    **execution.specific_labels(),
+                    **execution.general_labels(),
                     "docket.where": "docket",
                 },
             )

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -732,7 +732,7 @@ class Worker:
         execution.attempt += 1
         await self.docket.schedule(execution)
 
-        TASKS_RETRIED.add(1, {**self.labels(), **execution.specific_labels()})
+        TASKS_RETRIED.add(1, {**self.labels(), **execution.general_labels()})
         return True
 
     async def _perpetuate_if_requested(
@@ -758,7 +758,7 @@ class Worker:
         )
 
         if duration is not None:
-            TASKS_PERPETUATED.add(1, {**self.labels(), **execution.specific_labels()})
+            TASKS_PERPETUATED.add(1, {**self.labels(), **execution.general_labels()})
 
         return True
 


### PR DESCRIPTION
The `TASKS_PERPETUATED`, `TASKS_RETRIED`, and `TASKS_STRICKEN` metrics were using `execution.specific_labels()` which includes task keys, timestamps, and attempt numbers. These create unbounded cardinality in Prometheus, causing memory growth over time as each unique combination creates a new time series.

Changed these metrics to use `execution.general_labels()` instead, which only includes bounded labels like task name, docket name, and worker name. This keeps the metrics useful for observability while preventing the cardinality explosion.

OpenTelemetry spans and log contexts can still safely use `specific_labels()` since they're sampled/streamed rather than aggregated like Prometheus metrics.

Added tests to verify metrics only use safe labels going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)