### PR TITLE
Update fakeredis dependency to main repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ classifiers = [
 dependencies = [
     "cloudpickle>=3.1.1",
     "exceptiongroup>=1.2.0; python_version < '3.11'",
+    # Using specific commit until version > 2.32.0 is released
+    # This includes the fix for xpending_range to return all 4 required fields
+    # See: https://github.com/cunla/fakeredis-py/pull/427
+    "fakeredis[lua] @ git+https://github.com/cunla/fakeredis-py.git@ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12",
     "opentelemetry-api>=1.30.0",
     "opentelemetry-exporter-prometheus>=0.51b0",
     "prometheus-client>=0.21.1",
@@ -40,10 +44,6 @@ dependencies = [
 dev = [
     "codespell>=2.4.1",
     "docker>=7.1.0",
-    # Using fork until https://github.com/cunla/fakeredis-py/pull/427 is merged
-    # This fixes xpending_range to return all 4 required fields (message_id, consumer,
-    # time_since_delivered, times_delivered) instead of just 2, matching Redis behavior
-    "fakeredis[lua] @ git+https://github.com/zzstoatzz/fakeredis-py.git@fix-xpending-range-fields",
     "ipython>=8.0.0",
     "mypy>=1.14.1",
     "opentelemetry-distro>=0.51b0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -405,7 +405,7 @@ wheels = [
 [[package]]
 name = "fakeredis"
 version = "2.32.1"
-source = { git = "https://github.com/zzstoatzz/fakeredis-py.git?rev=fix-xpending-range-fields#a333f0b70397a64f6fdb3e624e130bb586eac910" }
+source = { git = "https://github.com/cunla/fakeredis-py.git?rev=ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12#ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12" }
 dependencies = [
     { name = "redis" },
     { name = "sortedcontainers" },
@@ -1516,6 +1516,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "prometheus-client" },
@@ -1531,7 +1532,6 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "docker" },
-    { name = "fakeredis", extra = ["lua"] },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy" },
@@ -1565,6 +1565,7 @@ examples = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
+    { name = "fakeredis", extras = ["lua"], git = "https://github.com/cunla/fakeredis-py.git?rev=ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.51b0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
@@ -1580,7 +1581,6 @@ requires-dist = [
 dev = [
     { name = "codespell", specifier = ">=2.4.1" },
     { name = "docker", specifier = ">=7.1.0" },
-    { name = "fakeredis", extras = ["lua"], git = "https://github.com/zzstoatzz/fakeredis-py.git?rev=fix-xpending-range-fields" },
     { name = "ipython", specifier = ">=8.0.0" },
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "opentelemetry-distro", specifier = ">=0.51b0" },


### PR DESCRIPTION
Nate's PR fixing xpending_range has been merged into the main fakeredis repo, so we can now switch from his fork to the official repository.

## Changes

- Moved fakeredis from dev dependencies to main dependencies (it's used for the memory backend feature, not just testing)
- Updated from Nate's fork to main repo at commit ad50a0d
- This commit includes the xpending_range fix that returns all 4 required fields (message_id, consumer, time_since_delivered, times_delivered)
- Added comment noting we're using a specific commit until version > 2.32.0 is released (presumably 2.33.0)

## Testing

Verified with full test suite using memory backend - all 272 tests pass, including the 4 memory backend specific tests.

Related: https://github.com/cunla/fakeredis-py/pull/427

🤖 Generated with [Claude Code](https://claude.com/claude-code)