### PR TITLE
Revert fakeredis to dev dependencies for PyPI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,6 @@ classifiers = [
 dependencies = [
     "cloudpickle>=3.1.1",
     "exceptiongroup>=1.2.0; python_version < '3.11'",
-    # Using specific commit until version > 2.32.0 is released
-    # This includes the fix for xpending_range to return all 4 required fields
-    # See: https://github.com/cunla/fakeredis-py/pull/427
-    "fakeredis[lua] @ git+https://github.com/cunla/fakeredis-py.git@ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12",
     "opentelemetry-api>=1.30.0",
     "opentelemetry-exporter-prometheus>=0.51b0",
     "prometheus-client>=0.21.1",
@@ -44,6 +40,11 @@ dependencies = [
 dev = [
     "codespell>=2.4.1",
     "docker>=7.1.0",
+    # Using specific commit until version > 2.32.0 is released to PyPI
+    # This includes the fix for xpending_range to return all 4 required fields
+    # Once released, we can use "fakeredis[lua]>=2.33.0" and move to main dependencies
+    # See: https://github.com/cunla/fakeredis-py/pull/427
+    "fakeredis[lua] @ git+https://github.com/cunla/fakeredis-py.git@ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12",
     "ipython>=8.0.0",
     "mypy>=1.14.1",
     "opentelemetry-distro>=0.51b0",

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,6 @@ source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "fakeredis", extra = ["lua"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "prometheus-client" },
@@ -1532,6 +1531,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "docker" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy" },
@@ -1565,7 +1565,6 @@ examples = [
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
-    { name = "fakeredis", extras = ["lua"], git = "https://github.com/cunla/fakeredis-py.git?rev=ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.51b0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
@@ -1581,6 +1580,7 @@ requires-dist = [
 dev = [
     { name = "codespell", specifier = ">=2.4.1" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "fakeredis", extras = ["lua"], git = "https://github.com/cunla/fakeredis-py.git?rev=ad50a0de8d6dce554fb629ec284bc4ccbc6a7f12" },
     { name = "ipython", specifier = ">=8.0.0" },
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "opentelemetry-distro", specifier = ">=0.51b0" },


### PR DESCRIPTION
The previous change moved fakeredis to main dependencies, but PyPI doesn't allow git dependencies in published packages. We need to wait for an official release (version > 2.32.0, presumably 2.33.0) before we can use it as a main dependency.

## Changes

- Moved fakeredis back to dev dependencies
- Still using the main repo (not Nate's fork) at the commit with the fix
- Updated comment to explain we're waiting for a PyPI release
- Once released, we can use `fakeredis[lua]>=2.33.0` as a main dependency

## Why This Matters

PyPI requires all dependencies to be proper versioned packages, not git references. While the fix we need is merged into the main repo, it hasn't been released to PyPI yet. Until then, we'll keep fakeredis as a dev dependency for testing purposes only.

Related: https://github.com/cunla/fakeredis-py/pull/427

🤖 Generated with [Claude Code](https://claude.com/claude-code)