### PR TITLE
Add Docket.get_execution() method for claim check pattern

### DIFF
--- a/chaos/driver.py
+++ b/chaos/driver.py
@@ -119,7 +119,7 @@ async def main(
 
         async def spawn_producer() -> Process:
             docket_version = base_version if random.random() < 0.5 else "main"
-            base_command = ["uv", "run"]
+            base_command = ["uv", "run", "--isolated"]
             if docket_version != "main":
                 logger.info("Using pydocket %s for producer", docket_version)
                 base_command.extend(["--with", f"pydocket=={docket_version}"])
@@ -142,7 +142,7 @@ async def main(
 
         async def spawn_worker() -> Process:
             docket_version = base_version if random.random() < 0.5 else "main"
-            base_command = ["uv", "run"]
+            base_command = ["uv", "run", "--isolated"]
             if docket_version != "main":
                 logger.info("Using pydocket %s for worker", docket_version)
                 base_command.extend(["--with", f"pydocket=={docket_version}"])

--- a/src/docket/agenda.py
+++ b/src/docket/agenda.py
@@ -185,8 +185,8 @@ class Agenda:
                 function=resolved_func,
                 args=args,
                 kwargs=kwargs,
-                when=schedule_time,
                 key=key,
+                when=schedule_time,
                 attempt=1,
             )
             executions.append(execution)

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -9,7 +9,6 @@ import time
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Annotated, Any, AsyncIterator, Collection
-from unittest.mock import AsyncMock
 
 import typer
 from rich.console import Console
@@ -27,7 +26,7 @@ from rich.table import Table
 
 from . import __version__, tasks
 from .docket import Docket, DocketSnapshot, WorkerInfo
-from .execution import Execution, ExecutionState, Operator
+from .execution import ExecutionState, Operator
 from .worker import Worker
 
 
@@ -868,9 +867,15 @@ def watch(
 
     async def monitor() -> None:
         async with Docket(docket_name, url) as docket:
-            execution = Execution(
-                docket, AsyncMock(), (), {}, datetime.now(timezone.utc), key, 1
-            )  # TODO: Replace AsyncMock with actual task function
+            execution = await docket.get_execution(key)
+            if not execution:
+                console = Console()
+                console.print(
+                    f"[red]Error:[/red] Task with key '{key}' not found or function not registered",
+                    style="bold",
+                )
+                return
+
             console = Console()
 
             # State colors for display

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -321,7 +321,9 @@ class Worker:
             is_redelivery: bool = False,
         ) -> bool:
             try:
-                execution = await Execution.from_message(self.docket, message)
+                execution = await Execution.from_message(
+                    self.docket, message, redelivered=is_redelivery
+                )
             except ValueError as e:
                 logger.error(
                     "Unable to start task: %s",
@@ -329,7 +331,6 @@ class Worker:
                     extra=log_context,
                 )
                 return False
-            execution.redelivered = is_redelivery
 
             task = asyncio.create_task(self._execute(execution), name=execution.key)
             active_tasks[task] = message_id

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -589,22 +589,22 @@ async def test_contextvar_reset_on_reentrant_call(docket: Docket, worker: Worker
 
     execution1 = Execution(
         docket=docket,
-        key="task1-key",
         function=task1,
         args=(),
         kwargs={},
-        attempt=1,
+        key="task1-key",
         when=datetime.now(timezone.utc),
+        attempt=1,
     )
 
     execution2 = Execution(
         docket=docket,
-        key="task2-key",
         function=task2,
         args=(),
         kwargs={},
-        attempt=1,
+        key="task2-key",
         when=datetime.now(timezone.utc),
+        attempt=1,
     )
 
     # Capture contextvars from first call
@@ -640,12 +640,12 @@ async def test_contextvar_not_leaked_to_caller(docket: Docket):
 
     execution = Execution(
         docket=docket,
-        key="test-key",
         function=dummy_task,
         args=(),
         kwargs={},
-        attempt=1,
+        key="test-key",
         when=datetime.now(timezone.utc),
+        attempt=1,
     )
 
     async with Docket("test-contextvar-leak", url="memory://leak-test") as test_docket:

--- a/tests/test_execution_progress.py
+++ b/tests/test_execution_progress.py
@@ -110,7 +110,7 @@ async def test_progress_increment_invalid(docket: Docket):
 async def test_progress_increment(docket: Docket):
     """Progress should atomically increment current value."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Initialize with set_running (which sets current=0)
@@ -325,7 +325,7 @@ async def test_error_message_stored_on_failure(docket: Docket, worker: Worker):
 async def test_concurrent_progress_updates(docket: Docket):
     """Progress updates should be atomic and safe for concurrent access."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
     progress = execution.progress
 
@@ -351,7 +351,7 @@ async def test_concurrent_progress_updates(docket: Docket):
 async def test_progress_publish_events(docket: Docket):
     """Progress updates should publish events to pub/sub channel."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
     progress = execution.progress
 
@@ -417,7 +417,7 @@ async def test_state_publish_events(docket: Docket, the_task: AsyncMock):
 async def test_run_subscribe_both_state_and_progress(docket: Docket):
     """Run.subscribe() should yield both state and progress events."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Set up subscriber in background
@@ -477,7 +477,7 @@ async def test_run_subscribe_both_state_and_progress(docket: Docket):
 async def test_completed_state_publishes_event(docket: Docket):
     """Completed state should publish event with completed_at timestamp."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Set up subscriber
@@ -507,7 +507,7 @@ async def test_completed_state_publishes_event(docket: Docket):
 async def test_failed_state_publishes_event_with_error(docket: Docket):
     """Failed state should publish event with error message."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Set up subscriber
@@ -687,7 +687,7 @@ async def test_end_to_end_failed_task_monitoring(docket: Docket, worker: Worker)
 async def test_mark_as_failed_without_error_message(docket: Docket):
     """Test mark_as_failed with error=None."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     await execution.claim("worker-1")
@@ -702,7 +702,7 @@ async def test_mark_as_failed_without_error_message(docket: Docket):
 async def test_execution_sync_with_no_redis_data(docket: Docket):
     """Test sync() when no execution data exists in Redis."""
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "nonexistent-key", 1
+        docket, AsyncMock(), (), {}, "nonexistent-key", datetime.now(timezone.utc), 1
     )
 
     # Sync without ever scheduling
@@ -721,7 +721,7 @@ async def test_execution_sync_with_missing_state_field(docket: Docket):
     from unittest.mock import AsyncMock, patch
 
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Set initial state
@@ -756,7 +756,7 @@ async def test_execution_sync_with_string_state_value(docket: Docket):
     from unittest.mock import AsyncMock, patch
 
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
 
     # Mock Redis to return string state (defensive code handles both bytes and str)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -340,7 +340,7 @@ async def test_get_result_with_expired_timeout(docket: Docket):
 
     # Create execution in non-terminal state
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
     execution.state = ExecutionState.RUNNING
 
@@ -362,7 +362,7 @@ async def test_get_result_failed_task_without_result_key(docket: Docket):
 
     # Create execution in FAILED state without result_key
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
     execution.state = ExecutionState.FAILED
     execution.error = "Something went wrong"
@@ -467,7 +467,7 @@ async def test_get_result_with_both_timeout_and_deadline_raises(
     from unittest.mock import AsyncMock
 
     execution = Execution(
-        docket, AsyncMock(), (), {}, datetime.now(timezone.utc), "test-key", 1
+        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
     )
     execution.state = ExecutionState.COMPLETED
 


### PR DESCRIPTION
This adds a `get_execution(key)` method to retrieve task executions by their key, enabling the "claim check" pattern where you schedule a task, save its key, and retrieve the execution later to check status or get results.

## Changes

**Docket API:**
- Added `get_execution(key)` method that reconstructs Execution from Redis
- Returns None if key doesn't exist
- Creates placeholder function when not registered (for CLI observability)
- Includes fallback to parked hash for 0.13.0 compatibility

**Execution immutability:**
- Made task definition fields read-only properties: `docket`, `function`, `args`, `kwargs`, `key`, `trace_context`, `redelivered`
- Scheduling metadata (`when`, `attempt`) remain mutable for rescheduling/retries
- Lifecycle state fields remain mutable for execution tracking
- Reorganized `__init__` parameter order hierarchically: `docket, function, args, kwargs, key, when, attempt, ...`

**Enhanced Redis data model:**
- Lua scheduling script now persists `function`, `args`, `kwargs` to `{docket}:runs:{key}` hash
- All three scheduling paths updated (immediate, scheduled, rescheduled)
- Enables claim check pattern without needing parked hash

**CLI improvements:**
- Fixed `docket watch` to use `get_execution()` instead of AsyncMock workaround
- Shows helpful error when task not found
- Fixed `RunningExecution` to properly call parent constructor

**Chaos driver fix:**
- Added `--isolated` flag to prevent venv corruption from concurrent `uv run --with` commands

## Testing

- Added 13 new tests for get_execution() and immutability
- Added test for 0.13.0 compatibility fallback
- All 435 tests passing
- 100% coverage of both src/ and tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)