### PR TITLE
Add CANCELLED state for task cancellation tracking

### DIFF
--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -82,6 +82,9 @@ class ExecutionState(enum.Enum):
     FAILED = "failed"
     """Task execution failed."""
 
+    CANCELLED = "cancelled"
+    """Task was explicitly cancelled before completion."""
+
 
 class ProgressEvent(TypedDict):
     type: Literal["progress"]


### PR DESCRIPTION
This adds a CANCELLED execution state that creates tombstone records when tasks are explicitly cancelled, enabling the claim check pattern where external callers can use `get_execution(key)` to see the complete task history.

## Changes

**Core implementation:**
- Added CANCELLED state to ExecutionState enum
- Modified cancel() Lua script to create tombstone with CANCELLED state and completed_at timestamp
- Tombstone respects execution_ttl (expires after TTL or deletes immediately if TTL=0)
- Preserves task metadata (function, args, kwargs) in tombstone for observability
- Still cleans up queue entries, stream messages, and parked data
- replace() continues to atomically replace tasks without CANCELLED state (replacement is not cancellation)

**Memory leak prevention:**
- Added `verify_remaining_keys_have_ttl()` method to KeyCountChecker test helper
- Validates all data keys have TTL set to prevent permanent memory accumulation
- Updated all Redis cleanup tests to verify TTL on tombstones
- Distinguishes between permanent infrastructure keys (stream, workers) and temporary data keys

**Testing:**
- 7 new tests covering CANCELLED state behavior, TTL handling, get_execution() retrieval, replace() semantics, and idempotency
- Enhanced existing cleanup tests to validate TTL on all remaining keys
- 442 tests passing with 100% coverage maintained

The tombstone approach balances observability (users can query cancelled task status) with resource management (all data eventually expires via TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)