### PR TITLE
Optimize chaos test setup and add type checking

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     name: Chaos tests
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,9 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: pyright
+        name: pyright (chaos tests)
+        entry: pyright chaos
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ branch = true
 parallel = true
 
 [tool.pyright]
-include = ["src", "tests"]
+include = ["src", "tests", "chaos"]
 typeCheckingMode = "strict"
 venvPath = "."
 venv = ".venv"


### PR DESCRIPTION
The chaos tests spawn 15 processes (5 producers + 10 workers) that randomly use either the latest PyPI release or the current main branch. This helps catch data contract issues when introducing changes.

Previously, each process used \`uv run --isolated --with pydocket==X.Y.Z\`, creating a new isolated environment for every spawn (~0.45s each). With 15 processes, that's about 6.75 seconds of overhead just for environment setup.

## Changes

**Performance optimization:**
- Added \`setup_environments()\` function that creates two persistent venvs once at startup (one for base version, one for main)
- Modified process spawning to use Python executables directly from pre-created environments
- Removed \`uv run --isolated\` overhead, reducing setup time from ~6.75s to ~1s
- Reduced CI timeout from 3 minutes to 2 minutes

**Type checking improvements:**
- Added \`chaos/\` to pyright include paths in pyproject.toml
- Added new pre-commit hook for chaos tests using the same strict mode as the test suite
- Fixed type errors from incomplete third-party library stubs (docker, redis) with appropriate type: ignore comments

The optimization saves about 5-6 seconds per chaos test run while maintaining the same random version selection behavior for migration testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude <noreply@anthropic.com>