### PR TITLE
Refactor progress interface to use Progress instead of ExecutionProgress

### DIFF
--- a/examples/task_progress.py
+++ b/examples/task_progress.py
@@ -1,13 +1,13 @@
 """Example demonstrating task progress tracking and real-time monitoring.
 
 This example shows how to:
-- Report progress from within a task using ExecutionProgress
+- Report progress from within a task using Progress
 - Track progress with current value, total, and status messages
 - Monitor task progress in real-time using the 'docket watch' command
 - Schedule tasks for future execution
 
 Key Concepts:
-- ExecutionProgress: Tracks task progress (current/total) and status messages
+- Progress: Tracks task progress (current/total) and status messages
 - Progress dependency: Injected into tasks via Progress() default parameter
 - Real-time monitoring: Use 'docket watch' CLI to monitor running tasks
 - State tracking: Tasks transition through SCHEDULED → QUEUED → RUNNING → COMPLETED
@@ -20,12 +20,10 @@ from docket import Docket, Progress, Worker
 import asyncio
 import rich.console
 
-from docket.execution import ExecutionProgress
-
 from .common import run_redis
 
 
-async def long_task(progress: ExecutionProgress = Progress()) -> None:
+async def long_task(progress: Progress = Progress()) -> None:
     """A long-running task that reports progress as it executes.
 
     This demonstrates the key progress tracking patterns:
@@ -33,12 +31,12 @@ async def long_task(progress: ExecutionProgress = Progress()) -> None:
     - Incremental progress updates with increment()
     - Status messages with set_message()
 
-    The ExecutionProgress object has a default total of 100, so we don't need
+    The Progress object has a default total of 100, so we don't need
     to call set_total() in this example. The progress automatically increments
     from 0 to 100.
 
     Args:
-        progress: Injected ExecutionProgress tracker (automatically provided by Docket)
+        progress: Injected Progress tracker (automatically provided by Docket)
 
     Pattern for your own tasks:
         1. Add progress parameter with Progress() default

--- a/tests/cli/test_watch.py
+++ b/tests/cli/test_watch.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from docket import Docket, Progress, Worker
-from docket.execution import ExecutionProgress, ExecutionState
+from docket.execution import ExecutionState
 from tests._key_leak_checker import KeyCountChecker
 
 from .run import run_cli
@@ -133,7 +133,7 @@ async def test_watch_running_task_until_completion(docket: Docket, worker: Worke
 async def test_watch_with_progress_updates(docket: Docket, worker: Worker):
     """Watch should display progress bar updates."""
 
-    async def task_with_progress(progress: ExecutionProgress = Progress()):
+    async def task_with_progress(progress: Progress = Progress()):
         await progress.set_total(10)
         await progress.set_message("Starting")
         for i in range(10):
@@ -201,7 +201,7 @@ async def test_watch_scheduled_task_transition(docket: Docket, worker: Worker):
 async def test_watch_task_with_initial_progress(docket: Docket, worker: Worker):
     """Watch should handle task that already has progress when monitoring starts."""
 
-    async def task_with_initial_progress(progress: ExecutionProgress = Progress()):
+    async def task_with_initial_progress(progress: Progress = Progress()):
         # Set progress before watch likely connects
         await progress.set_total(20)
         await progress.increment(5)
@@ -271,7 +271,7 @@ async def test_watch_task_with_worker_assignment(docket: Docket, worker: Worker)
 async def test_watch_task_that_starts_while_watching(docket: Docket, worker: Worker):
     """Watch should receive started_at event and update progress bar timing."""
 
-    async def task_that_waits_then_progresses(progress: ExecutionProgress = Progress()):
+    async def task_that_waits_then_progresses(progress: Progress = Progress()):
         # Immediately report progress so watch sees it
         await progress.set_total(10)
         await progress.increment(1)
@@ -312,7 +312,7 @@ async def test_watch_receives_progress_events_during_execution(
 ):
     """Watch should receive and process progress events as they occur."""
 
-    async def task_with_many_updates(progress: ExecutionProgress = Progress()):
+    async def task_with_many_updates(progress: Progress = Progress()):
         await progress.set_total(20)
         for i in range(20):
             await asyncio.sleep(0.08)  # 1.6 seconds total
@@ -348,7 +348,7 @@ async def test_watch_receives_progress_events_during_execution(
 async def test_watch_already_running_task_with_progress(docket: Docket, worker: Worker):
     """Watch a task that's already running with progress when watch starts."""
 
-    async def task_already_running(progress: ExecutionProgress = Progress()):
+    async def task_already_running(progress: Progress = Progress()):
         # Set up some initial state quickly
         await progress.set_total(30)
         await progress.increment(10)
@@ -389,7 +389,7 @@ async def test_watch_already_running_task_with_progress(docket: Docket, worker: 
 async def test_watch_task_with_worker_in_state_event(docket: Docket, worker: Worker):
     """Watch should handle state events containing worker name."""
 
-    async def task_with_delays(progress: ExecutionProgress = Progress()):
+    async def task_with_delays(progress: Progress = Progress()):
         # Publish progress to create progress bar
         await progress.set_total(15)
         await progress.increment(1)

--- a/tests/test_execution_progress.py
+++ b/tests/test_execution_progress.py
@@ -150,7 +150,7 @@ async def test_progress_dependency_injection(docket: Docket, worker: Worker):
     """Progress dependency should be injected into task functions."""
     progress_values: list[int] = []
 
-    async def task_with_progress(progress: ExecutionProgress = Progress()):
+    async def task_with_progress(progress: Progress = Progress()):
         await progress.set_total(10)
         for i in range(10):
             await asyncio.sleep(0.001)
@@ -172,7 +172,7 @@ async def test_progress_dependency_injection(docket: Docket, worker: Worker):
 async def test_progress_deleted_on_completion(docket: Docket, worker: Worker):
     """Progress data should be deleted when task completes."""
 
-    async def task_with_progress(progress: ExecutionProgress = Progress()):
+    async def task_with_progress(progress: Progress = Progress()):
         await progress.set_total(5)
         await progress.increment()
 
@@ -238,7 +238,7 @@ async def test_full_lifecycle_integration(docket: Docket, worker: Worker):
     """Test complete lifecycle: SCHEDULED -> QUEUED -> RUNNING -> COMPLETED."""
     states_observed: list[ExecutionState] = []
 
-    async def tracking_task(progress: ExecutionProgress = Progress()):
+    async def tracking_task(progress: Progress = Progress()):
         await progress.set_total(3)
         for i in range(3):
             await progress.increment()
@@ -270,7 +270,7 @@ async def test_full_lifecycle_integration(docket: Docket, worker: Worker):
 async def test_progress_with_multiple_increments(docket: Docket, worker: Worker):
     """Test progress tracking with realistic usage pattern."""
 
-    async def process_items(items: list[int], progress: ExecutionProgress = Progress()):
+    async def process_items(items: list[int], progress: Progress = Progress()):
         await progress.set_total(len(items))
         await progress.set_message("Starting processing")
 
@@ -294,7 +294,7 @@ async def test_progress_with_multiple_increments(docket: Docket, worker: Worker)
 async def test_progress_without_total(docket: Docket, worker: Worker):
     """Progress should work even without setting total."""
 
-    async def task_without_total(progress: ExecutionProgress = Progress()):
+    async def task_without_total(progress: Progress = Progress()):
         for _ in range(5):
             await progress.increment()
             await asyncio.sleep(0.001)
@@ -527,7 +527,7 @@ async def test_end_to_end_progress_monitoring_with_worker(
     """Test complete end-to-end progress monitoring with real worker execution."""
     collected_events: list[StateEvent | ProgressEvent] = []
 
-    async def task_with_progress(progress: ExecutionProgress = Progress()):
+    async def task_with_progress(progress: Progress = Progress()):
         """Task that reports progress as it executes."""
         await progress.set_total(5)
         await progress.set_message("Starting work")
@@ -610,7 +610,7 @@ async def test_end_to_end_failed_task_monitoring(docket: Docket, worker: Worker)
     """Test progress monitoring for a task that fails."""
     collected_events: list[StateEvent | ProgressEvent] = []
 
-    async def failing_task(progress: ExecutionProgress = Progress()):
+    async def failing_task(progress: Progress = Progress()):
         """Task that reports progress then fails."""
         await progress.set_total(10)
         await progress.set_message("Starting work")

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -36,7 +36,7 @@ from docket import (
     Worker,
     tasks,
 )
-from docket.execution import ExecutionProgress, StateEvent
+from docket.execution import StateEvent
 from tests._key_leak_checker import KeyCountChecker
 
 
@@ -593,7 +593,7 @@ async def test_tasks_can_report_progress(docket: Docket, worker: Worker):
     async def the_task(
         a: str,
         b: str,
-        progress: ExecutionProgress = Progress(),
+        progress: Progress = Progress(),
     ):
         assert a == "a"
         assert b == "c"


### PR DESCRIPTION
Users can now write `progress: Progress = Progress()` instead of the awkward `progress: ExecutionProgress = Progress()` pattern. This makes Progress consistent with other dependencies like `Retry` where the type annotation matches the class being instantiated.

## Changes

**Core refactoring:**
- Created `Progress` class in dependencies.py that wraps `ExecutionProgress`
- Progress extends `Dependency` and forwards calls to underlying ExecutionProgress
- Slimmed down Progress interface to only methods tasks need:
  - Properties: `current`, `total`, `message`  
  - Methods: `set_total()`, `increment()`, `set_message()`
- Removed framework-internal methods from public interface: `sync()`, `delete()`, `subscribe()`, `updated_at`

**ExecutionProgress remains as internal implementation:**
- Unchanged in execution.py with full API
- Used by framework internals and CLI tools
- Not exported from main `docket` package

**Updated all usage:**
- test_fundamentals.py - uses `progress: Progress = Progress()`
- test_execution_progress.py - updated dependency injection uses
- test_watch.py - updated dependency injection uses  
- examples/task_progress.py - updated docs and type hints

## Testing

- All 450 tests pass
- 100% coverage maintained
- All prek hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)