### PR TITLE
Fix replace() to register unregistered functions

### DIFF
--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -441,6 +441,8 @@ class Docket:
         """
         if isinstance(function, str):
             function = self.tasks[function]
+        else:
+            self.register(function)
 
         async def scheduler(*args: P.args, **kwargs: P.kwargs) -> Execution:
             execution = Execution(self, function, args, kwargs, key, when, attempt=1)

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -178,6 +178,24 @@ async def test_rescheduling_by_name(
     assert later <= now()
 
 
+async def test_replace_without_existing_task_acts_like_add(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """docket.replace() on a non-existent key should schedule the task like add()"""
+
+    key = f"my-cool-task:{uuid4()}"
+
+    # Replace without prior add - should just schedule the task
+    later = now() + timedelta(milliseconds=100)
+    await docket.replace(the_task, later, key=key)("b", "c", c="d")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("b", "c", c="d")
+
+    assert later <= now()
+
+
 async def test_task_keys_are_idempotent_in_the_future(
     docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
 ):


### PR DESCRIPTION
When calling `docket.replace()` with an unregistered function, the method wasn't registering it with the docket. This caused tasks to be scheduled successfully but fail during execution when the worker couldn't find the function in the task registry.

## The Issue

The `replace()` method was missing the `else: self.register(function)` clause that `add()` has. This meant that while the Lua scheduling script correctly scheduled the task (acting like an add when the key doesn't exist), the Python function object wasn't available for the worker to execute.

This became apparent when testing whether `replace()` on a non-existent key acts as a no-op, an error, or like an `add()`. The Lua script showed it should act like `add()`, but the missing registration caused execution failures.

## The Fix

Added the missing registration logic to `replace()` (lines 444-445 in `src/docket/docket.py`) to match `add()`'s behavior:

```python
if isinstance(function, str):
    function = self.tasks[function]
else:
    self.register(function)  # ← Added this
```

This makes `replace()` truly idempotent and safe to call regardless of whether a task with that key already exists.

## Testing

- Added `test_replace_without_existing_task_acts_like_add()` to verify that `replace()` on a non-existent key schedules and executes correctly
- All existing tests pass
- The key leak checker confirmed proper TTL handling after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)