### PR TITLE
Allow task registration before entering context manager

### DIFF
--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -197,14 +197,15 @@ class Docket:
                 url=url, default_collection=f"{name}:results"
             )
 
+        from .tasks import standard_tasks
+
+        self.tasks: dict[str, TaskFunction] = {fn.__name__: fn for fn in standard_tasks}
+
     @property
     def worker_group_name(self) -> str:
         return "docket-workers"
 
     async def __aenter__(self) -> Self:
-        from .tasks import standard_tasks
-
-        self.tasks = {fn.__name__: fn for fn in standard_tasks}
         self.strike_list = StrikeList()
 
         # Check if we should use in-memory backend (fakeredis)
@@ -261,7 +262,6 @@ class Docket:
         if isinstance(self.result_storage, BaseContextManagerStore):
             await self.result_storage.__aexit__(exc_type, exc_value, traceback)
 
-        del self.tasks
         del self.strike_list
 
         self._monitor_strikes_task.cancel()


### PR DESCRIPTION
Moves the task registry initialization from `__aenter__` to `__init__`,
so you can now register tasks on a Docket before calling `async with`.
This helps with integration scenarios where tasks need to be configured
before establishing the Redis connection.

The change also means tasks persist after `__aexit__`, enabling re-entry
with the same task registry. Standard tasks (trace, fail, sleep) are
available immediately after constructing a Docket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)