### PR TITLE
Fix duplicate task execution race condition

### DIFF
--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -594,6 +594,11 @@ class Execution:
                                 -- Check if task already exists (check new location first, then legacy)
                                 local known_exists = redis.call('HEXISTS', runs_key, 'known') == 1
                                 if not known_exists then
+                                    -- Check if task is currently running (known field deleted at claim time)
+                                    local state = redis.call('HGET', runs_key, 'state')
+                                    if state == 'running' then
+                                        return 'EXISTS'
+                                    end
                                     -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
                                     known_exists = redis.call('EXISTS', known_key) == 1
                                 end

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -904,7 +904,8 @@ async def test_self_perpetuating_immediate_tasks(
     async def the_task(start: int, iteration: int, key: str = TaskKey()):
         calls[key].append(start + iteration)
         if iteration < 3:
-            await docket.add(the_task, key=key)(start, iteration + 1)
+            # Use replace() for self-perpetuating to allow rescheduling while running
+            await docket.replace(the_task, now(), key=key)(start, iteration + 1)
 
     await docket.add(the_task, key="first")(10, 1)
     await docket.add(the_task, key="second")(20, 1)
@@ -929,7 +930,8 @@ async def test_self_perpetuating_scheduled_tasks(
         calls[key].append(start + iteration)
         if iteration < 3:
             soon = now() + timedelta(milliseconds=100)
-            await docket.add(the_task, key=key, when=soon)(start, iteration + 1)
+            # Use replace() for self-perpetuating to allow rescheduling while running
+            await docket.replace(the_task, key=key, when=soon)(start, iteration + 1)
 
     await docket.add(the_task, key="first")(10, 1)
     await docket.add(the_task, key="second")(20, 1)
@@ -954,12 +956,14 @@ async def test_infinitely_self_perpetuating_tasks(
     async def the_task(start: int, iteration: int, key: str = TaskKey()):
         calls[key].append(start + iteration)
         soon = now() + timedelta(milliseconds=100)
-        await docket.add(the_task, key=key, when=soon)(start, iteration + 1)
+        # Use replace() for self-perpetuating to allow rescheduling while running
+        await docket.replace(the_task, key=key, when=soon)(start, iteration + 1)
 
     async def unaffected_task(start: int, iteration: int, key: str = TaskKey()):
         calls[key].append(start + iteration)
         if iteration < 3:
-            await docket.add(unaffected_task, key=key)(start, iteration + 1)
+            # Use replace() for self-perpetuating to allow rescheduling while running
+            await docket.replace(unaffected_task, now(), key=key)(start, iteration + 1)
 
     await docket.add(the_task, key="first")(10, 1)
     await docket.add(the_task, key="second")(20, 1)


### PR DESCRIPTION
Tasks without a Perpetual dependency could execute multiple times in parallel
because the `known` field is deleted when `claim()` is called, before the task
function runs. This opens a window where duplicate `docket.add()` calls with
the same key succeed.

The fix adds a check for `state='running'` in the schedule Lua script's
deduplication logic. Now a task "exists" if either the `known` field exists
(scheduled/queued) OR the `state` is `running` (currently executing).

Also updated the self-perpetuating test patterns to use `replace()` instead of
`add()` for rescheduling, which is the correct pattern (matching how Perpetual
tasks work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)