### PR TITLE
Add Docker test runner for reproducing CI timing issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.venv
+.pytest_cache
+.mypy_cache
+.ruff_cache
+__pycache__
+*.pyc
+*.egg-info
+dist
+coverage.xml
+.coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,40 @@ pytest
 
 # Run specific test
 pytest tests/test_docket.py::test_specific_function
-
 ```
 
 The project REQUIRES 100% test coverage
+
+### Docker Test Runner (for reproducing CI timing issues)
+
+When debugging flaky CI tests that are hard to reproduce locally, use the Docker test
+runner with CPU limits. CI failures often stem from timing issues that only manifest
+under CPU contention - throttling to 0.1-0.25 CPU can reproduce these locally.
+
+Use docker compose to run tests with CPU throttling, simulating slow CI environments:
+
+```bash
+# Run specific tests with CPU limit (default 0.5 = half a core)
+docker compose run --rm pytest tests/path/to/test.py -v
+
+# Extreme throttling to reproduce timing bugs
+CPU_LIMIT=0.1 docker compose run --rm pytest tests/concurrency_limits/ -v --timeout=120
+
+# Different Python version
+PYTHON_VERSION=3.12 docker compose build
+PYTHON_VERSION=3.12 docker compose run --rm pytest tests/path -v
+```
+
+Environment variables:
+- `PYTHON_VERSION`: Python version (default: 3.10)
+- `CPU_LIMIT`: CPU cores fraction (default: 0.5)
+- `MEM_LIMIT`: Memory limit (default: 512M)
+- `REDIS_VERSION`: `memory` or version like `6.2`, `8.0`, `valkey-8.0` (default: memory)
+
+```bash
+# With real Redis
+REDIS_VERSION=6.2 docker compose run --rm pytest tests/path -v
+```
 
 ### Code Quality
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-slim
+
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN pip install uv
+
+WORKDIR /app
+
+COPY . .
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv pip install --system . && \
+    uv pip install --system --group dev
+
+ENV PYTHONPATH=/app/src
+
+ENTRYPOINT ["pytest", "--no-cov", "-p", "no:cacheprovider"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  pytest:
+    build:
+      context: .
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.10}
+    volumes:
+      - .:/app:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - REDIS_VERSION=${REDIS_VERSION:-memory}
+    network_mode: host
+    deploy:
+      resources:
+        limits:
+          cpus: "${CPU_LIMIT:-0.5}"
+          memory: "${MEM_LIMIT:-512M}"


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` and `docker-compose.yml` for running tests with CPU throttling
- Helps reproduce flaky CI tests that fail due to timing issues under load
- Supports configurable Python version, CPU/memory limits, and Redis version

## Usage

```bash
# Basic run
docker compose run --rm pytest tests/path -v

# Extreme throttling to reproduce timing bugs
CPU_LIMIT=0.1 docker compose run --rm pytest tests/path -v --timeout=120

# Different Python version
PYTHON_VERSION=3.12 docker compose build
docker compose run --rm pytest tests/path -v

# With real Redis
REDIS_VERSION=6.2 docker compose run --rm pytest tests/path -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)