### PR TITLE
Clean up stale concurrency slots to prevent memory accumulation

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -1010,6 +1010,9 @@ class Worker:
         local current_time = tonumber(ARGV[3])
         local slot_timeout = tonumber(ARGV[4])
 
+        -- Clean up stale slots from crashed workers or orphaned tasks
+        redis.call('ZREMRANGEBYSCORE', key, 0, current_time - slot_timeout)
+
         -- Check if this task already has a slot (from a previous delivery attempt)
         local slot_time = redis.call('ZSCORE', key, task_key)
         if slot_time then


### PR DESCRIPTION
PR #223 fixed a concurrency slot release bug but removed the ZREMRANGEBYSCORE
that cleaned up stale entries. This could cause memory growth over time if
slots become orphaned (e.g., worker crashes between acquiring and releasing).

The fix adds ZREMRANGEBYSCORE back to the Lua script but with the correct
cutoff: `slot_timeout` (redelivery_timeout + 5) instead of `redelivery_timeout`.
This is safe because any slot older than slot_timeout is either:
1. Orphaned (should have been released) - safe to clean
2. From a task exceeding redelivery_timeout - will be redelivered anyway

Related: #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)