### PR TITLE
Remove unnecessary build deps install from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,9 +37,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
-      - name: Install build dependencies
-        run: uv pip install --system hatchling hatch-vcs
-
       - name: Build package
         run: uv build
 


### PR DESCRIPTION
uv build automatically handles build dependencies from pyproject.toml's
build-system.requires in an isolated environment. The separate install
step was hitting PEP 668 externally managed environment errors which
broke the 0.15.4 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)