### PR TITLE
Allow dependabot in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-opus-4-1-20250805"
+          allowed_bots: "dependabot[bot]"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |


### PR DESCRIPTION
The claude-code-action blocks bot-initiated PRs by default, causing all dependabot PRs to fail the claude-review check.

Fixes #237, #238, #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)