### PR TITLE
Suppress strike stream xread spans

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -214,7 +214,11 @@ class Worker:
             healthcheck_server(port=healthcheck_port),
             metrics_server(port=metrics_port),
         ):
-            async with Docket(name=docket_name, url=url) as docket:
+            async with Docket(
+                name=docket_name,
+                url=url,
+                suppress_internal_instrumentation=suppress_internal_instrumentation,
+            ) as docket:
                 for task_path in tasks:
                     docket.register_collection(task_path)
 


### PR DESCRIPTION
The `_monitor_strikes` method in Docket polls the strike stream via `xread`
every 60 seconds, generating noisy OTel spans. This adds the same
`suppress_internal_instrumentation` parameter to `Docket` that `Worker`
already has, so the strike monitoring xread calls get suppressed too.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)