### PR TITLE
Wait for strikes to load before scheduling automatic perpetuals

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -704,6 +704,10 @@ class Worker:
                 logger.warning("Failed to renew leases", exc_info=True)
 
     async def _schedule_all_automatic_perpetual_tasks(self) -> None:
+        # Wait for strikes to be fully loaded before scheduling to avoid
+        # scheduling struck tasks or missing restored tasks
+        await self.docket.wait_for_strikes_loaded()
+
         async with self.docket.redis() as redis:
             try:
                 async with redis.lock(


### PR DESCRIPTION
Fixes a race condition where automatic perpetual tasks could be scheduled before all strikes were loaded from the stream. This could cause struck tasks to be scheduled (strike not yet loaded) or restored tasks to be skipped (old strike still in local list).

The solution uses an `asyncio.Event` that the strike monitor sets after completing its initial non-blocking read of all existing strike messages. The worker now waits for this event before scheduling automatic perpetual tasks.

Note: Redis XREAD with `block=0` means "block forever", not "non-blocking". Use `block=None` for non-blocking behavior.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)