### PR TITLE
Fix flaky heartbeat timing assertions in worker tests

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -209,7 +209,9 @@ builtin_tasks = {function.__name__ for function in standard_tasks}
 async def test_worker_announcements(
     docket: Docket, the_task: AsyncMock, another_task: AsyncMock
 ):
-    heartbeat = timedelta(milliseconds=20)
+    # Use 100ms heartbeat - short enough for fast tests, long enough to be reliable
+    # under CPU contention in CI environments
+    heartbeat = timedelta(milliseconds=100)
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
 
@@ -231,7 +233,8 @@ async def test_worker_announcements(
             assert {w.name for w in workers} == {worker_a.name, worker_b.name}
 
             for worker in workers:
-                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 3)
+                # Allow generous timing tolerance - CI can have significant delays
+                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 20)
                 assert worker.tasks == builtin_tasks | {"the_task", "another_task"}
 
         await asyncio.sleep(heartbeat.total_seconds() * 10)
@@ -252,7 +255,9 @@ async def test_task_announcements(
 ):
     """Test that we can ask about which workers are available for a task"""
 
-    heartbeat = timedelta(milliseconds=20)
+    # Use 100ms heartbeat - short enough for fast tests, long enough to be reliable
+    # under CPU contention in CI environments
+    heartbeat = timedelta(milliseconds=100)
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
 
@@ -273,7 +278,8 @@ async def test_task_announcements(
             assert {w.name for w in workers} == {worker_a.name, worker_b.name}
 
             for worker in workers:
-                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 3)
+                # Allow generous timing tolerance - CI can have significant delays
+                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 20)
                 assert worker.tasks == builtin_tasks | {"the_task", "another_task"}
 
         await asyncio.sleep(heartbeat.total_seconds() * 10)


### PR DESCRIPTION
Two tests (`test_worker_announcements` and `test_task_announcements`) were
failing intermittently in CI due to timing issues under CPU contention.

The 20ms heartbeat interval was too aggressive and the timing tolerance
(3 heartbeats = 60ms) too tight. Under CPU contention, by the time the
assertion ran, `last_seen` could be stale relative to `datetime.now()`.

Changes:
- Increase heartbeat interval from 20ms to 100ms
- Change timing tolerance from `heartbeat * 3` to `heartbeat * 20`

Verified passing 20/20 runs at CPU_LIMIT=0.2 in docker compose.

CI failures:
- https://github.com/chrisguidry/docket/actions/runs/20318966388/job/58369974731
- https://github.com/chrisguidry/docket/actions/runs/20318966388/job/58369974739

🤖 Generated with [Claude Code](https://claude.com/claude-code)