### PR TITLE
Support registering tasks with custom names

### DIFF
--- a/tests/test_docket.py
+++ b/tests/test_docket.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock
@@ -7,6 +8,7 @@ import redis.exceptions
 
 from docket.docket import Docket
 from docket.execution import ExecutionState
+from docket.worker import Worker
 from tests._key_leak_checker import KeyCountChecker
 
 
@@ -652,6 +654,91 @@ async def test_docket_reentry_preserves_tasks():
     async with docket:
         assert "my_task" in docket.tasks
         assert "trace" in docket.tasks
+
+
+def test_register_task_with_custom_name():
+    """Tasks can be registered under a custom name instead of __name__."""
+    docket = Docket(name="test-custom-name", url="memory://")
+
+    async def my_task() -> None: ...
+
+    docket.register(my_task, names=["custom_name"])
+
+    assert "custom_name" in docket.tasks
+    assert docket.tasks["custom_name"] is my_task
+    # Original name should NOT be registered
+    assert "my_task" not in docket.tasks
+
+
+def test_register_task_with_multiple_names():
+    """Tasks can be registered under multiple names."""
+    docket = Docket(name="test-multiple-names", url="memory://")
+
+    async def my_task() -> None: ...
+
+    docket.register(my_task, names=["alias_a", "alias_b", "alias_c"])
+
+    assert "alias_a" in docket.tasks
+    assert "alias_b" in docket.tasks
+    assert "alias_c" in docket.tasks
+    assert docket.tasks["alias_a"] is my_task
+    assert docket.tasks["alias_b"] is my_task
+    assert docket.tasks["alias_c"] is my_task
+    # Original name should NOT be registered
+    assert "my_task" not in docket.tasks
+
+
+def test_register_task_with_empty_names_defaults_to_function_name():
+    """Empty names list should default to function.__name__."""
+    docket = Docket(name="test-empty-names", url="memory://")
+
+    async def my_task() -> None: ...
+
+    docket.register(my_task, names=[])
+
+    assert "my_task" in docket.tasks
+    assert docket.tasks["my_task"] is my_task
+
+
+def test_register_task_with_none_names_defaults_to_function_name():
+    """None names should default to function.__name__."""
+    docket = Docket(name="test-none-names", url="memory://")
+
+    async def my_task() -> None: ...
+
+    docket.register(my_task, names=None)
+
+    assert "my_task" in docket.tasks
+    assert docket.tasks["my_task"] is my_task
+
+
+async def test_schedule_task_by_alias(docket: Docket, worker: Worker):
+    """Tasks can be scheduled by their alias name."""
+    results: list[str] = []
+
+    async def my_task(value: str) -> None:
+        results.append(value)
+
+    docket.register(my_task, names=["task_alias"])
+
+    await docket.add("task_alias")("hello")
+    await worker.run_until_finished()
+
+    assert results == ["hello"]
+
+
+async def test_alias_appears_in_worker_announcements(docket: Docket):
+    """Alias names should appear in worker task announcements."""
+
+    async def my_task() -> None: ...
+
+    docket.register(my_task, names=["custom_alias"])
+
+    async with Worker(docket) as w:
+        await asyncio.sleep(0.1)  # Let heartbeat fire
+        workers = await docket.task_workers("custom_alias")
+        assert len(workers) == 1
+        assert w.name in {worker.name for worker in workers}
 
 
 async def test_stream_not_created_on_docket_init(redis_url: str):


### PR DESCRIPTION
Adds a `names` parameter to `docket.register()` so tasks can be registered
under custom names instead of (or in addition to) their `__name__`.

```python
docket.register(my_func)  # registers as "my_func" (unchanged)
docket.register(my_func, names=["custom"])  # registers only as "custom"
docket.register(my_func, names=["a", "b"])  # registers as both "a" and "b"
```

Also fixes `add()` and `replace()` to preserve the name used for lookup
when scheduling by string name, so the worker can find the task.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)