### PR TITLE
Allow memory:// URLs for docket worker command

### DIFF
--- a/examples/self_contained_service.py
+++ b/examples/self_contained_service.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Example: Self-Contained Service with In-Memory Backend
+
+Demonstrates running a complete docket service in a single process using
+the memory:// backend. This is useful for simple services that need
+background task scheduling but don't require distributed workers.
+
+The service has:
+- An automatic perpetual task that runs every few seconds
+- That perpetual task spawns additional work tasks
+
+To run this example:
+    uv run examples/self_contained_service.py
+
+In your own project, you can use the CLI:
+    docket worker --url memory:// --docket my-service --tasks myapp.tasks:tasks
+"""
+
+import asyncio
+import random
+from datetime import timedelta
+
+from docket import Docket, Worker
+from docket.dependencies import CurrentDocket, Perpetual
+
+
+async def do_work(item: str) -> None:
+    """A simple work task spawned by the monitor."""
+    print(f"  Processing: {item}")
+    await asyncio.sleep(0.1)
+
+
+async def monitor(
+    docket: Docket = CurrentDocket(),
+    perpetual: Perpetual = Perpetual(every=timedelta(seconds=2), automatic=True),
+) -> None:
+    """Periodic task that spawns work items."""
+    count = random.randint(1, 3)
+    print(f"Monitor tick - spawning {count} work items")
+    for i in range(count):
+        await docket.add(do_work)(f"item-{random.randint(1000, 9999)}")
+
+
+tasks = [monitor, do_work]
+
+
+async def main() -> None:
+    print("Starting self-contained service (memory:// backend)\n")
+
+    async with Docket(name="self-contained", url="memory://") as docket:
+        for task in tasks:
+            docket.register(task)
+
+        async with Worker(docket) as worker:
+            try:
+                await asyncio.wait_for(worker.run_forever(), timeout=10.0)
+            except asyncio.TimeoutError:
+                print("\nDemo complete!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/docket/cli.py
+++ b/src/docket/cli.py
@@ -234,7 +234,6 @@ def worker(
         typer.Option(
             help="The URL of the Redis server",
             envvar="DOCKET_URL",
-            callback=validate_url,
         ),
     ] = "redis://localhost:6379/0",
     name: Annotated[

--- a/tests/cli/test_url_validation.py
+++ b/tests/cli/test_url_validation.py
@@ -6,7 +6,6 @@ from tests.cli.run import run_cli
 @pytest.mark.parametrize(
     "cli_args",
     [
-        ["worker", "--until-finished", "--url", "memory://", "--docket", "test-docket"],
         ["strike", "--url", "memory://", "--docket", "test-docket", "example_task"],
         ["clear", "--url", "memory://", "--docket", "test-docket"],
         ["restore", "--url", "memory://", "--docket", "test-docket", "example_task"],
@@ -57,3 +56,20 @@ def test_valid_urls_accepted(valid_url: str):
     # Should not raise any exceptions - just testing validation logic
     result = validate_url(valid_url)
     assert result == valid_url
+
+
+async def test_worker_accepts_memory_url():
+    """Worker command should accept memory:// URLs for single-process services"""
+    result = await run_cli(
+        "worker",
+        "--until-finished",
+        "--url",
+        "memory://",
+        "--docket",
+        "test-memory-worker",
+    )
+
+    # Should NOT fail with URL validation error
+    assert "not supported" not in result.output.lower()
+    # Exit code 0 means worker ran successfully (no tasks = immediate exit with --until-finished)
+    assert result.exit_code == 0

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -15,12 +15,6 @@ from docket.worker import Worker
 from tests._key_leak_checker import KeyCountChecker
 from tests.cli.run import run_cli
 
-# Skip CLI tests when using memory backend since CLI rejects memory:// URLs
-pytestmark = pytest.mark.skipif(
-    os.environ.get("REDIS_VERSION") == "memory",
-    reason="CLI commands require a persistent Redis backend",
-)
-
 
 @pytest.fixture(autouse=True)
 def reset_logging() -> None:
@@ -81,6 +75,10 @@ async def test_worker_command(
     assert "trace" in result.output
 
 
+@pytest.mark.skipif(
+    os.environ.get("REDIS_VERSION") == "memory",
+    reason="Memory backend doesn't share state across processes",
+)
 async def test_worker_command_with_fallback_task(
     docket: Docket,
 ):
@@ -248,6 +246,10 @@ async def _test_signal_graceful_shutdown(
     assert "↩" in output or "↫" in output, f"Task did not complete\n{output}"
 
 
+@pytest.mark.skipif(
+    os.environ.get("REDIS_VERSION") == "memory",
+    reason="Memory backend doesn't share state across processes",
+)
 async def test_sigterm_gracefully_drains_inflight_tasks(
     docket: Docket, key_leak_checker: KeyCountChecker
 ) -> None:
@@ -260,6 +262,10 @@ async def test_sigterm_gracefully_drains_inflight_tasks(
     await _test_signal_graceful_shutdown(docket, key_leak_checker, signal.SIGTERM)
 
 
+@pytest.mark.skipif(
+    os.environ.get("REDIS_VERSION") == "memory",
+    reason="Memory backend doesn't share state across processes",
+)
 async def test_sigint_gracefully_drains_inflight_tasks(
     docket: Docket, key_leak_checker: KeyCountChecker
 ) -> None:


### PR DESCRIPTION
## Summary

The `memory://` URL was rejected by all CLI commands because it doesn't persist across processes. But the `worker` command is different - it can run a complete self-contained service in a single process, which is useful for:

- Local development with automatic perpetual tasks
- Simple single-process services that don't need external Redis
- Testing CLI-based deployments without Redis infrastructure

This removes the URL validation from the worker command while keeping it on other commands (strike, restore, clear, snapshot, etc.) that genuinely need cross-process state.

Also adds an example (`examples/self_contained_service.py`) showing a single-process service with an automatic perpetual task that spawns work items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)