### PR TITLE
Add prefix property and key() method for consistent key construction

### DIFF
--- a/src/docket/strikelist.py
+++ b/src/docket/strikelist.py
@@ -198,9 +198,17 @@ class StrikeList:
         self._strikes_loaded = None
 
     @property
+    def prefix(self) -> str:
+        """Return the key prefix for this strike list.
+
+        All Redis keys for this strike list are prefixed with this value.
+        """
+        return self.name
+
+    @property
     def strike_key(self) -> str:
         """Redis stream key for strike instructions."""
-        return f"{self.name}:strikes"
+        return f"{self.prefix}:strikes"
 
     @contextmanager
     def _maybe_suppress_instrumentation(self) -> Generator[None, None, None]:

--- a/tests/test_docket.py
+++ b/tests/test_docket.py
@@ -12,6 +12,77 @@ from docket.worker import Worker
 from tests._key_leak_checker import KeyCountChecker
 
 
+class TestPrefixAndKeyMethods:
+    """Tests for the prefix property and key() method."""
+
+    def test_prefix_returns_name(self):
+        """prefix property should return the docket name."""
+        docket = Docket(name="my-docket", url="memory://")
+        assert docket.prefix == "my-docket"
+
+    def test_key_builds_correct_key(self):
+        """key() should build keys with the prefix."""
+        docket = Docket(name="my-docket", url="memory://")
+        assert docket.key("queue") == "my-docket:queue"
+        assert docket.key("stream") == "my-docket:stream"
+        assert docket.key("runs:task-123") == "my-docket:runs:task-123"
+
+    def test_queue_key_uses_key_method(self):
+        """queue_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.queue_key == "test:queue"
+
+    def test_stream_key_uses_key_method(self):
+        """stream_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.stream_key == "test:stream"
+
+    def test_workers_set_uses_key_method(self):
+        """workers_set should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.workers_set == "test:workers"
+
+    def test_known_task_key_uses_key_method(self):
+        """known_task_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.known_task_key("task-123") == "test:known:task-123"
+
+    def test_parked_task_key_uses_key_method(self):
+        """parked_task_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.parked_task_key("task-123") == "test:task-123"
+
+    def test_stream_id_key_uses_key_method(self):
+        """stream_id_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.stream_id_key("task-123") == "test:stream-id:task-123"
+
+    def test_runs_key_uses_key_method(self):
+        """runs_key should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.runs_key("task-123") == "test:runs:task-123"
+
+    def test_cancel_channel_uses_key_method(self):
+        """cancel_channel should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.cancel_channel("task-123") == "test:cancel:task-123"
+
+    def test_results_collection_uses_key_method(self):
+        """results_collection should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.results_collection == "test:results"
+
+    def test_worker_tasks_set_uses_key_method(self):
+        """worker_tasks_set should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.worker_tasks_set("worker-1") == "test:worker-tasks:worker-1"
+
+    def test_task_workers_set_uses_key_method(self):
+        """task_workers_set should use the key() method."""
+        docket = Docket(name="test", url="memory://")
+        assert docket.task_workers_set("my_task") == "test:task-workers:my_task"
+
+
 async def test_docket_propagates_connection_errors_on_operation():
     """Connection errors should propagate when operations are attempted."""
     docket = Docket(name="test-docket", url="redis://nonexistent-host:12345/0")

--- a/tests/test_synced_strikelist.py
+++ b/tests/test_synced_strikelist.py
@@ -101,10 +101,15 @@ class TestStrikeListBasic:
         # Second close should be a no-op
         await strikes.close()
 
-    async def test_strike_key_property(self, redis_url: str, strike_name: str) -> None:
-        """Test the strike_key property."""
+    async def test_prefix_property(self, redis_url: str, strike_name: str) -> None:
+        """Test the prefix property returns the name."""
         strikes = StrikeList(url=redis_url, name=strike_name)
-        assert strikes.strike_key == f"{strike_name}:strikes"
+        assert strikes.prefix == strike_name
+
+    async def test_strike_key_property(self, redis_url: str, strike_name: str) -> None:
+        """Test the strike_key property uses prefix."""
+        strikes = StrikeList(url=redis_url, name=strike_name)
+        assert strikes.strike_key == f"{strikes.prefix}:strikes"
 
     async def test_local_only_mode(self, strike_name: str) -> None:
         """Test StrikeList works without Redis (local-only mode)."""


### PR DESCRIPTION
Introduces a centralized pattern for building Redis keys in Docket and StrikeList. All key properties and methods now go through a `prefix` property and `key(suffix)` method, which makes it straightforward to support hash-tagged keys for Redis Cluster in the future.

Changes:
- Add `prefix` property and `key()` method to Docket
- Add `runs_key()`, `cancel_channel()`, and `results_collection` helpers
- Update all existing key methods to use the new pattern
- Add `prefix` property to StrikeList

This is groundwork for #120 (Redis Cluster support) - see the [progress report](https://github.com/chrisguidry/docket/issues/120#issuecomment-3716100156) for the breakdown of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: nate nowack <thrast36@gmail.com>