### PR TITLE
Re-export _Depends and _parameter_cache from dependencies package

### DIFF
--- a/src/docket/dependencies/__init__.py
+++ b/src/docket/dependencies/__init__.py
@@ -52,8 +52,6 @@ __all__ = [
     "DependencyFunction",
     "Shared",
     "SharedContext",
-    "_Depends",
-    "_parameter_cache",
     "get_dependency_parameters",
     # Retry
     "ForcedRetry",
@@ -72,4 +70,7 @@ __all__ = [
     "get_single_dependency_parameter_of_type",
     "resolved_dependencies",
     "validate_dependencies",
+    # fastmcp uses these for its DI integration; do not remove
+    "_Depends",
+    "_parameter_cache",
 ]


### PR DESCRIPTION
When dependencies.py was refactored into a package (#287), these internal
symbols stopped being accessible. fastmcp imports them directly for its
DI integration on both main and release/2.x branches.

🤖 Generated with [Claude Code](https://claude.ai/code)