### PR TITLE
Add logging to Docker image retry

### DIFF
--- a/tests/_container.py
+++ b/tests/_container.py
@@ -152,7 +152,15 @@ def with_image_retry(fn: Callable[P, T], max_retries: int = 3) -> Callable[P, T]
             except docker.errors.ImageNotFound as e:
                 last_error = e
                 if attempt < max_retries - 1:
-                    time.sleep(2**attempt)  # Exponential backoff: 1s, 2s, 4s
+                    wait = 2**attempt
+                    print(
+                        f"[with_image_retry] ImageNotFound on attempt {attempt + 1}/{max_retries}, retrying in {wait}s: {e}"
+                    )
+                    time.sleep(wait)
+                else:
+                    print(
+                        f"[with_image_retry] ImageNotFound on final attempt {attempt + 1}/{max_retries}, giving up: {e}"
+                    )
         raise last_error or docker.errors.ImageNotFound("Image pull failed")
 
     return wrapper


### PR DESCRIPTION
## Summary

Adds print statements to the `with_image_retry` function so we can see in CI logs whether retries are happening and how many attempts before giving up.

This should help diagnose the intermittent `ImageNotFound` failures we're seeing in CI - we'll be able to tell if the retry logic is actually running or if there's something else going on.

🤖 Generated with [Claude Code](https://claude.ai/code)