### PR TITLE
Fix memory leak in _tasks_by_key cleanup

### DIFF
--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -509,8 +509,8 @@ class Worker:
             completed_tasks = {task for task in active_tasks if task.done()}
             for task in completed_tasks:
                 message_id = active_tasks.pop(task)
-                task_executions.pop(task)
-                self._tasks_by_key.pop(task.get_name(), None)
+                execution = task_executions.pop(task)
+                self._tasks_by_key.pop(execution.key, None)
                 try:
                     await task
                     await ack_message(redis, message_id)


### PR DESCRIPTION
The worker was storing tasks in `_tasks_by_key[execution.key]` but then trying to remove them with `_tasks_by_key.pop(task.get_name())`. Since task names are formatted as `"docket-name - task:key"` while the dict key is just `"key"`, the pop never found a match and entries accumulated forever.

Each leaked entry held a reference to the asyncio.Task and its associated Execution, so memory grew linearly with task count.

🤖 Generated with [Claude Code](https://claude.ai/code)