### PR TITLE
Group Dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
We've been manually batching Dependabot PRs (#306, #319, #327) because
they each only touch `uv.lock` and conflict with each other. This
configures Dependabot's built-in grouping so it opens one PR per
ecosystem per week instead of one per package.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>