### PR TITLE
Clear `known` from runs hash on cancel so add() can reschedule

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -18,8 +18,8 @@ max_lines = 945
 
 [[rules]]
 path = "src/docket/execution.py"
-max_lines = 1021
+max_lines = 1020
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 866
+max_lines = 869

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -698,6 +698,9 @@ class Docket(DocketSnapshotMixin):
                     redis.call('DEL', known_key, parked_key, stream_id_key)
                     redis.call('ZREM', queue_key, task_key)
 
+                    -- Clear scheduling markers so add() can reschedule this key
+                    redis.call('HDEL', runs_key, 'known', 'stream_id')
+
                     -- Only set CANCELLED if not already in a terminal state
                     local current_state = redis.call('HGET', runs_key, 'state')
                     if current_state ~= 'completed' and current_state ~= 'failed' and current_state ~= 'cancelled' then


### PR DESCRIPTION
When a scheduled task gets cancelled via `docket.cancel()`, the cancel Lua
script removes it from the stream/queue but leaves the `known` field in the
runs hash. Later, when `_schedule_all_automatic_perpetual_tasks` (or any
`docket.add()`) tries to reschedule the same key, the schedule script sees
`known` and returns EXISTS. The task stays silently unscheduled until
`execution_ttl` expires (default 15 min).

The fix adds an `HDEL runs_key 'known' 'stream_id'` to the cancel script,
clearing the dedup markers while keeping `state=cancelled` and `completed_at`
for observability. The schedule script's existing fallback (`state == 'running'`
→ EXISTS) already handles cancelled tasks correctly once `known` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)