### PR TITLE
Handle AlreadyExists race in cluster image build

### DIFF
--- a/tests/_container.py
+++ b/tests/_container.py
@@ -177,11 +177,17 @@ def build_cluster_image(client: DockerClient, base_image: str) -> str:
         pass
 
     cluster_dir = Path(__file__).parent / "cluster"
-    client.images.build(
-        path=str(cluster_dir),
-        tag=tag,
-        buildargs={"BASE_IMAGE": base_image},
-    )
+    try:
+        client.images.build(
+            path=str(cluster_dir),
+            tag=tag,
+            buildargs={"BASE_IMAGE": base_image},
+        )
+    except docker.errors.BuildError as e:
+        if "AlreadyExists" in str(e):
+            pass
+        else:
+            raise
     return tag
 
 


### PR DESCRIPTION
`build_cluster_image` does a check-then-build that can race when parallel
test sessions try to build the same image. The `images.get()` check passes
for both, then one build succeeds and the other gets a `BuildError` with
`AlreadyExists`. This showed up as every test failing in a CI cluster job:

https://github.com/chrisguidry/docket/actions/runs/22020705636/job/63639829973

🤖 Generated with [Claude Code](https://claude.com/claude-code)