### PR TITLE
Fix flaky test_task_duration_is_measured on Windows

### DIFF
--- a/tests/instrumentation/test_export.py
+++ b/tests/instrumentation/test_export.py
@@ -45,9 +45,9 @@ async def test_task_duration_is_measured(
 
     async def the_task():
         nonlocal inner_elapsed
-        start = time.monotonic()
+        start = time.time()
         await asyncio.sleep(0.1)
-        inner_elapsed = time.monotonic() - start
+        inner_elapsed = time.time() - start
 
     await docket.add(the_task)()
     await worker.run_until_finished()


### PR DESCRIPTION
The test calibrated `asyncio.sleep(0.1)` outside the task and used that to
bound the duration measured inside the task. Each sleep varies
independently, so the calibration didn't predict the task's actual sleep
— Windows CI on #344 hit this (calibration got 125ms, task only slept
93ms).

Instead, the task now captures its own elapsed time and the assertion
uses that directly: the worker's duration must be at least the inner
sleep and no more than 2x (headroom for dep injection, serialization,
etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>