### PR TITLE
Migrate docs hosting from GitHub Pages to ReadTheDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,7 @@ on:
       - main
 
 permissions:
-  actions: write
   contents: read
-  pages: write
-  id-token: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -40,56 +36,3 @@ jobs:
 
       - name: Build documentation
         run: uv run zensical build
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v6
-        id: docs-artifact
-        with:
-          name: documentation
-          path: site/
-
-      - name: Add or Update Comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: preview
-          message: |
-            📚 Documentation has been built for this PR!
-
-            You can download the documentation directly here:
-            ${{ steps.docs-artifact.outputs.artifact-url }}
-
-  publish:
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: documentation
-          path: site
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      # Clean up any stale github-pages artifacts from previous attempts
-      # See: https://github.com/actions/upload-pages-artifact/issues/97
-      - name: Delete stale Pages artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: github-pages
-          failOnError: false
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  commands:
+    - pip install uv
+    - uv sync --group docs
+    - uv run zensical build
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - cp -r site/* $READTHEDOCS_OUTPUT/html/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ on the scheduling of future work as seamlessly and efficiently as immediate work
 [![GitHub main checks](https://img.shields.io/github/check-runs/chrisguidry/docket/main)](https://github.com/chrisguidry/docket/actions/workflows/ci.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/chrisguidry/docket)](https://app.codecov.io/gh/chrisguidry/docket)
 [![PyPI - License](https://img.shields.io/pypi/l/pydocket)](https://github.com/chrisguidry/docket/blob/main/LICENSE)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://chrisguidry.github.io/docket/)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue.svg)](https://docket.lol/)
 
 ## At a glance
 
@@ -42,9 +42,9 @@ Hello, Jane at 2025-03-05 13:58:21.552644!
 Howdy, John at 2025-03-05 13:58:24.550773!
 ```
 
-Check out our docs for more [details](http://chrisguidry.github.io/docket/),
-[examples](https://chrisguidry.github.io/docket/getting-started/), and the [API
-reference](https://chrisguidry.github.io/docket/api-reference/).
+Check out our docs for more [details](https://docket.lol/),
+[examples](https://docket.lol/getting-started/), and the [API
+reference](https://docket.lol/api-reference/).
 
 ## Why `docket`?
 
@@ -98,7 +98,7 @@ async with Docket(name="my-docket", url="memory://my-docket") as docket:
     ...
 ```
 
-See [Testing with Docket](https://chrisguidry.github.io/docket/testing/#using-in-memory-backend-no-redis-required) for more details.
+See [Testing with Docket](https://docket.lol/testing/#using-in-memory-backend-no-redis-required) for more details.
 
 # Hacking on `docket`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: docket
 site_description: A distributed background task system for Python
+site_url: https://docket.lol/
 repo_url: https://github.com/chrisguidry/docket
 repo_name: chrisguidry/docket
 


### PR DESCRIPTION
The docs CI workflow fails on fork PRs because GitHub restricts the
`GITHUB_TOKEN` to read-only, and the `marocchino/sticky-pull-request-comment`
step can't post. Rather than patching around that, this switches docs
hosting to ReadTheDocs Community, which has built-in PR preview builds
that work for fork PRs automatically.

Custom domain: `docket.lol` (apex, via Porkbun ALIAS record to `readthedocs.io`)

Changes:
- Add `.readthedocs.yaml` with custom build commands for Zensical
- Add `site_url: https://docket.lol/` to `mkdocs.yml`
- Simplify `docs.yml` to a build-check-only workflow (no publish job,
  no sticky comment, minimal permissions)
- Update all doc URLs in README to `docket.lol`

After merge: import project on readthedocs.org, set up Porkbun ALIAS
record for `docket.lol`, configure custom domain in RTD settings, and
delete the `github-pages` environment from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)