### PR TITLE
Point PyPI homepage to docket.lol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,9 @@ examples = [
 docket = "docket.__main__:app"
 
 [project.urls]
-"Homepage" = "https://github.com/chrisguidry/docket"
+"Homepage" = "https://docket.lol/"
+"Documentation" = "https://docket.lol/en/latest/"
+"Repository" = "https://github.com/chrisguidry/docket"
 "Bug Tracker" = "https://github.com/chrisguidry/docket/issues"
 
 [tool.hatch.version]


### PR DESCRIPTION
Follow-up to #347 — now that docs are on ReadTheDocs, update the
project URLs so PyPI links to docket.lol instead of the GitHub repo.
Also adds separate Documentation and Repository entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)