### PR TITLE
fix: robust fakeredis imports for compatibility with newer versions

### DIFF
--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -268,7 +268,10 @@ class RedisConnection:
                 try:
                     from fakeredis import FakeAsyncConnection as FakeConnection
                 except ImportError:
-                    from fakeredis import FakeConnection
+                    raise ImportError(
+                        "fakeredis async connection class not found — "
+                        "need fakeredis>=2.31.0 with `lupa` extra for memory:// backend"
+                    ) from None
 
         # Apply Lua runtime patch on first use
         _patch_fakeredis_lua_runtime()

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -263,9 +263,12 @@ class RedisConnection:
             from fakeredis import FakeServer
 
             try:
-                from fakeredis import FakeRedisConnection as FakeConnection
+                from fakeredis import FakeAsyncRedisConnection as FakeConnection
             except ImportError:
-                from fakeredis import FakeConnection
+                try:
+                    from fakeredis import FakeAsyncConnection as FakeConnection
+                except ImportError:
+                    from fakeredis import FakeConnection
 
         # Apply Lua runtime patch on first use
         _patch_fakeredis_lua_runtime()
@@ -395,7 +398,6 @@ def _patch_fakeredis_lua_runtime() -> None:  # pragma: no cover
         )
 
         # Attempt to import cjson helpers from wherever they might be in older/newer versions
-        # or fall back to dummy values if they are truly missing (which might break the patch)
         try:
             from fakeredis.commands_mixins.scripting_mixin import (
                 _lua_cjson_decode,
@@ -403,15 +405,10 @@ def _patch_fakeredis_lua_runtime() -> None:  # pragma: no cover
                 _lua_cjson_null,
             )
         except ImportError:
-            # For versions where these are prefixed with something else or moved
-            # This is a best-effort fallback
-            _lua_cjson_decode = getattr(
-                typing.Any, "_lua_cjson_decode", lambda *args: None
-            )
-            _lua_cjson_encode = getattr(
-                typing.Any, "_lua_cjson_encode", lambda *args: None
-            )
-            _lua_cjson_null = getattr(typing.Any, "_lua_cjson_null", None)
+            # cjson helpers are required for the patch to work correctly.
+            # If we can't import them, skip the patch entirely rather than
+            # silently installing no-op hooks that break Lua scripts.
+            return
 
     # Import lupa module (fakeredis uses this dynamically)
     try:

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -22,7 +22,10 @@ from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
 
 if typing.TYPE_CHECKING:
-    from fakeredis.aioredis import FakeServer
+    try:
+        from fakeredis.aioredis import FakeServer
+    except ImportError:
+        from fakeredis import FakeServer
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -254,7 +257,15 @@ class RedisConnection:
         """Create a connection pool for a memory:// URL using fakeredis."""
         global _memory_servers
 
-        from fakeredis.aioredis import FakeConnection, FakeServer
+        try:
+            from fakeredis.aioredis import FakeConnection, FakeServer
+        except ImportError:
+            from fakeredis import FakeServer
+
+            try:
+                from fakeredis import FakeRedisConnection as FakeConnection
+            except ImportError:
+                from fakeredis import FakeConnection
 
         # Apply Lua runtime patch on first use
         _patch_fakeredis_lua_runtime()
@@ -366,14 +377,41 @@ def _patch_fakeredis_lua_runtime() -> None:  # pragma: no cover
     from fakeredis import _msgs as msgs
     from fakeredis._commands import Int, command
     from fakeredis._helpers import SimpleError
-    from fakeredis.commands_mixins.scripting_mixin import (
-        ScriptingCommandsMixin,
-        _check_for_lua_globals,
-        _lua_cjson_decode,
-        _lua_cjson_encode,
-        _lua_cjson_null,
-        _lua_redis_log,
-    )
+
+    try:
+        from fakeredis.commands_mixins.scripting_mixin import (
+            ScriptingCommandsMixin,
+            _check_for_lua_globals,
+            _lua_cjson_decode,
+            _lua_cjson_encode,
+            _lua_cjson_null,
+            _lua_redis_log,
+        )
+    except ImportError:
+        from fakeredis.commands_mixins.scripting_mixin import (
+            ScriptingCommandsMixin,
+            _check_for_lua_globals,
+            _lua_redis_log,
+        )
+
+        # Attempt to import cjson helpers from wherever they might be in older/newer versions
+        # or fall back to dummy values if they are truly missing (which might break the patch)
+        try:
+            from fakeredis.commands_mixins.scripting_mixin import (
+                _lua_cjson_decode,
+                _lua_cjson_encode,
+                _lua_cjson_null,
+            )
+        except ImportError:
+            # For versions where these are prefixed with something else or moved
+            # This is a best-effort fallback
+            _lua_cjson_decode = getattr(
+                typing.Any, "_lua_cjson_decode", lambda *args: None
+            )
+            _lua_cjson_encode = getattr(
+                typing.Any, "_lua_cjson_encode", lambda *args: None
+            )
+            _lua_cjson_null = getattr(typing.Any, "_lua_cjson_null", None)
 
     # Import lupa module (fakeredis uses this dynamically)
     try:


### PR DESCRIPTION
## Description

This PR fixes `ImportError` crashes in `docket._redis` when used with newer versions of `fakeredis` (>= 2.31.0).

### The Problem
Newer `fakeredis` releases have reorganized their internal APIs:
- `FakeConnection` and `FakeServer` were moved from `fakeredis.aioredis` to the root `fakeredis` namespace.
- Internal scripting helpers like `_lua_cjson_decode` were moved or renamed.
- `FakeServer` was renamed to `TcpFakeServer` in some versions.

### The Fix
- Updated `_redis.py` to try the new import paths and fall back to the old ones.
- Added robust error handling for scripting mixin imports.
- Ensured the `memory://` backend works across `fakeredis` versions.

This resolves the issue reported in `colab-mcp` where the entire server crashed on startup due to these import failures.