### PR TITLE
Tighten the RedisClient protocol's types

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+# `exat`/`pxat` are redis SET command flags exposed as parameters by redis-py.
+ignore-words-list = exat,pxat

--- a/chaos/driver.py
+++ b/chaos/driver.py
@@ -243,7 +243,7 @@ async def main(
         while True:
             try:
                 async with docket.redis() as r:
-                    info: dict[str, Any] = await r.info()  # type: ignore[reportUnknownMemberType]
+                    info: dict[str, Any] = await r.info()
                     connected_clients = int(info.get("connected_clients", 0))
 
                     sent_tasks = await r.zcard("hello:sent")
@@ -283,7 +283,7 @@ async def main(
                 chaos_chance = random.random()
                 if chaos_chance < 0.02:
                     logger.warning("CHAOS: Restarting redis server...")
-                    redis_container.restart(timeout=2)  # type: ignore[reportUnknownMemberType]
+                    redis_container.restart(timeout=2)
 
                 elif chaos_chance < 0.10:
                     worker_index = random.randrange(len(worker_processes))
@@ -315,10 +315,10 @@ async def main(
             await asyncio.sleep(0.25)
 
         async with docket.redis() as r:
-            first_entries: Sequence[tuple[bytes, float]] = await r.zrange(  # type: ignore[reportUnknownMemberType]
+            first_entries: Sequence[tuple[bytes, float]] = await r.zrange(
                 "hello:received", 0, 0, withscores=True
             )
-            last_entries: Sequence[tuple[bytes, float]] = await r.zrange(  # type: ignore[reportUnknownMemberType]
+            last_entries: Sequence[tuple[bytes, float]] = await r.zrange(
                 "hello:received", -1, -1, withscores=True
             )
 

--- a/chaos/redis.py
+++ b/chaos/redis.py
@@ -28,7 +28,7 @@ async def run_redis(version: str) -> AsyncGenerator[tuple[str, Container], None]
     port = get_free_port()
 
     client = DockerClient.from_env()
-    container: Container = client.containers.run(  # type: ignore[reportUnknownMemberType]
+    container: Container = client.containers.run(
         f"redis:{version}",
         detach=True,
         ports={"6379/tcp": port},
@@ -36,11 +36,11 @@ async def run_redis(version: str) -> AsyncGenerator[tuple[str, Container], None]
     )
 
     # Wait for Redis to be ready
-    for line in container.logs(stream=True):  # type: ignore[reportUnknownMemberType]
+    for line in container.logs(stream=True):
         if b"Ready to accept connections" in line:
             break
 
     try:
         yield f"redis://localhost:{port}/0", container
     finally:
-        container.stop()  # type: ignore[reportUnknownMemberType]
+        container.stop()

--- a/chaos/signals.py
+++ b/chaos/signals.py
@@ -40,13 +40,13 @@ async def signal_test_task(
     channel = os.environ.get(CHANNEL_ENV_VAR, "signal-test:events")
 
     async with docket.redis() as redis:
-        await redis.publish(channel, f"started:{task_id}")  # type: ignore[reportUnknownMemberType]
+        await redis.publish(channel, f"started:{task_id}")
         logger.info("Task %s started", task_id)
 
     await asyncio.sleep(duration)
 
     async with docket.redis() as redis:
-        await redis.publish(channel, f"completed:{task_id}")  # type: ignore[reportUnknownMemberType]
+        await redis.publish(channel, f"completed:{task_id}")
         logger.info("Task %s completed", task_id)
 
 
@@ -102,8 +102,8 @@ async def wait_for_tasks_via_pubsub(
     remaining = task_ids.copy()
 
     async with docket.redis() as redis:
-        pubsub = redis.pubsub()  # type: ignore[reportUnknownMemberType]
-        await pubsub.subscribe(channel)  # type: ignore[reportUnknownMemberType]
+        pubsub = redis.pubsub()
+        await pubsub.subscribe(channel)
 
         try:
             deadline = asyncio.get_event_loop().time() + timeout
@@ -120,12 +120,10 @@ async def wait_for_tasks_via_pubsub(
 
                 # Wait for next message with remaining timeout
                 try:
-                    message: (  # type: ignore[reportUnknownVariableType]
+                    message: (
                         dict[str, bytes | str | None] | None
                     ) = await asyncio.wait_for(
-                        pubsub.get_message(  # type: ignore[reportUnknownMemberType]
-                            ignore_subscribe_messages=True, timeout=1.0
-                        ),
+                        pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
                         timeout=min(time_left, 2.0),
                     )
                 except asyncio.TimeoutError:
@@ -155,7 +153,7 @@ async def wait_for_tasks_via_pubsub(
 
         finally:
             await pubsub.unsubscribe(channel)  # type: ignore[reportUnknownMemberType]
-            await pubsub.aclose()  # type: ignore[reportUnknownMemberType]
+            await pubsub.aclose()
 
 
 async def verify_tasks_completed(
@@ -172,7 +170,7 @@ async def verify_tasks_completed(
     async with docket.redis() as redis:
         for key in task_keys:
             runs_key = f"{docket.name}:runs:{key}"
-            state: bytes | None = await redis.hget(runs_key, "state")  # type: ignore[reportUnknownMemberType]
+            state: bytes | None = await redis.hget(runs_key, "state")
 
             if state is None:
                 logger.error("Task %s has no state in Redis", key)

--- a/loq.toml
+++ b/loq.toml
@@ -23,3 +23,7 @@ max_lines = 1014
 [[rules]]
 path = "src/docket/docket.py"
 max_lines = 870
+
+[[rules]]
+path = "src/docket/_redis.py"
+max_lines = 900

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,3 @@ typeCheckingMode = "strict"
 venvPath = "."
 venv = ".venv"
 reportUnnecessaryTypeIgnoreComment = "error"
-
-[tool.codespell]
-# `exat`/`pxat` are redis SET command flags exposed as parameters by redis-py.
-ignore-words-list = "exat,pxat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ include = ["src", "tests", "chaos"]
 typeCheckingMode = "strict"
 venvPath = "."
 venv = ".venv"
+reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.codespell]
 # `exat`/`pxat` are redis SET command flags exposed as parameters by redis-py.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,3 +157,7 @@ include = ["src", "tests", "chaos"]
 typeCheckingMode = "strict"
 venvPath = "."
 venv = ".venv"
+
+[tool.codespell]
+# `exat`/`pxat` are redis SET command flags exposed as parameters by redis-py.
+ignore-words-list = "exat,pxat"

--- a/src/docket/_docket_snapshot.py
+++ b/src/docket/_docket_snapshot.py
@@ -221,8 +221,8 @@ class DocketSnapshotMixin:
 
                 task_names: set[str] = {
                     task_name_bytes.decode()
-                    for task_name_bytes in cast(
-                        set[bytes], await r.smembers(self.worker_tasks_set(worker_name))
+                    for task_name_bytes in await r.smembers(
+                        self.worker_tasks_set(worker_name)
                     )
                 }
 
@@ -258,8 +258,8 @@ class DocketSnapshotMixin:
 
                 task_names: set[str] = {
                     task_name_bytes.decode()
-                    for task_name_bytes in cast(
-                        set[bytes], await r.smembers(self.worker_tasks_set(worker_name))
+                    for task_name_bytes in await r.smembers(
+                        self.worker_tasks_set(worker_name)
                     )
                 }
 

--- a/src/docket/_execution_progress.py
+++ b/src/docket/_execution_progress.py
@@ -3,7 +3,18 @@
 import json
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator, Literal, TypedDict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Generator,
+    Literal,
+    Mapping,
+    TypedDict,
+    cast,
+)
+
+from ._redis import EncodableT, KeyT
 
 from ._telemetry import suppress_instrumentation
 from typing_extensions import Self
@@ -143,10 +154,10 @@ class ExecutionProgress:
         async with self.docket.redis() as redis:
             await redis.hset(
                 self._redis_key,
-                mapping={
-                    "message": message,
-                    "updated_at": updated_at,
-                },
+                mapping=cast(
+                    Mapping[KeyT, EncodableT],
+                    {"message": message, "updated_at": updated_at},
+                ),
             )
         # Update instance attributes
         self.message = message

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -8,13 +8,31 @@ other modules can remain simple. When Redis Cluster support is added, only
 this module will need to change.
 """
 
+from __future__ import annotations
+
 import asyncio
 import importlib
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
-from threading import Lock
+from datetime import datetime, timedelta
+from threading import Lock as _ThreadLock
 from types import TracebackType
-from typing import Any, AsyncGenerator, Callable, Protocol, cast, runtime_checkable
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Iterable,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeAlias,
+    TypedDict,
+    cast,
+    overload,
+    runtime_checkable,
+)
 from urllib.parse import ParseResult, urlparse, urlunparse
 
 from redis.asyncio import ConnectionPool, Redis
@@ -25,81 +43,159 @@ from redis.asyncio.connection import Connection, SSLConnection
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Input type aliases (mirror redis-py's type domain)
+# ---------------------------------------------------------------------------
+
+KeyT: TypeAlias = str | bytes | memoryview
+EncodableT: TypeAlias = str | bytes | bytearray | memoryview | int | float
+StreamIDT: TypeAlias = str | bytes | int
+ExpiryT: TypeAlias = int | timedelta
+AbsExpiryT: TypeAlias = int | datetime
+
+
+# ---------------------------------------------------------------------------
+# Stream return-shape aliases
+#
+# docket always uses decode_responses=False, so stream-related responses are
+# fully bytes-typed.  These aliases consolidate the shapes that stream-reading
+# methods (xrange, xread, xreadgroup, xclaim, xautoclaim) return so callers
+# can annotate their receivers without restating the nesting each time.
+# ---------------------------------------------------------------------------
+
+RedisStreamID: TypeAlias = bytes
+RedisMessageID: TypeAlias = bytes
+RedisMessage: TypeAlias = dict[bytes, bytes]
+RedisMessages: TypeAlias = Sequence[tuple[RedisMessageID, RedisMessage]]
+RedisStream: TypeAlias = tuple[RedisStreamID, RedisMessages]
+RedisReadGroupResponse: TypeAlias = Sequence[RedisStream]
+
+
+class RedisStreamPendingMessage(TypedDict):
+    """One entry returned by XPENDING ... IDLE/RANGE."""
+
+    message_id: bytes
+    consumer: bytes
+    time_since_delivered: int
+    times_delivered: int
+
+
+# ---------------------------------------------------------------------------
+# Companion protocols
+# ---------------------------------------------------------------------------
+
+
 class AsyncCloseable(Protocol):
     """Protocol for objects with an async aclose() method."""
 
     async def aclose(self) -> None: ...
 
 
-@runtime_checkable
-class RedisClient(Protocol):
-    """Protocol capturing the Redis client interface that docket uses.
+class Pipeline(Protocol):
+    """The subset of pipeline operations docket actually invokes inside
+    ``async with redis.pipeline() as pipeline:`` blocks.
 
-    This is the structural type shared by redis.asyncio.Redis,
-    redis.asyncio.cluster.RedisCluster, and burner_redis.BurnerRedis.
-    Method signatures use Any to accommodate differences between implementations.
+    Pipeline command methods are synchronous: they queue the command and
+    return the pipeline itself for chaining.  Only ``execute()`` is awaited,
+    and it returns the heterogeneous results of the queued commands in
+    order.
     """
 
-    async def get(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def set(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def exists(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def keys(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def type(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def ttl(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def delete(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def expire(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def blmove(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def blpop(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def brpop(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lindex(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def linsert(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def llen(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lmove(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lpop(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lpush(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lrange(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lrem(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def lset(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def ltrim(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def rpop(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def rpoplpush(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def rpush(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def hget(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def hgetall(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def hdel(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def hincrby(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def hset(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def sadd(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def srem(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def smembers(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def scard(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zadd(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zrem(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zcard(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zrange(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zrangebyscore(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def zscore(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xadd(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xack(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xautoclaim(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xclaim(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xread(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xrange(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xlen(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xtrim(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xpending(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xinfo_groups(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xinfo_consumers(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xinfo_stream(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def xgroup_create(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def info(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def publish(self, *args: Any, **kwargs: Any) -> Any: ...
-    def pubsub(self, **kwargs: Any) -> Any: ...
-    def scan_iter(self, *args: Any, **kwargs: Any) -> Any: ...
-    def register_script(self, script: str | bytes) -> Any: ...
-    def pipeline(self, **kwargs: Any) -> Any: ...
-    def lock(self, *args: Any, **kwargs: Any) -> Any: ...
+    def delete(self, *names: KeyT) -> "Pipeline": ...
+    def expire(self, name: KeyT, time: ExpiryT) -> "Pipeline": ...
+    def hgetall(self, name: KeyT) -> "Pipeline": ...
+    def sadd(self, name: KeyT, *values: EncodableT) -> "Pipeline": ...
+    def xack(self, name: KeyT, groupname: KeyT, *ids: StreamIDT) -> "Pipeline": ...
+    def xdel(self, name: KeyT, *ids: StreamIDT) -> "Pipeline": ...
+    def xlen(self, name: KeyT) -> "Pipeline": ...
+    def xpending_range(
+        self,
+        name: KeyT,
+        groupname: KeyT,
+        min: StreamIDT,
+        max: StreamIDT,
+        count: int,
+        consumername: KeyT | None = None,
+        idle: int | None = None,
+    ) -> "Pipeline": ...
+    def xrange(
+        self,
+        name: KeyT,
+        min: StreamIDT = "-",
+        max: StreamIDT = "+",
+        count: int | None = None,
+    ) -> "Pipeline": ...
+    def xtrim(
+        self,
+        name: KeyT,
+        maxlen: int | None = None,
+        approximate: bool = True,
+        minid: StreamIDT | None = None,
+        limit: int | None = None,
+    ) -> "Pipeline": ...
+    def zadd(
+        self,
+        name: KeyT,
+        mapping: Mapping[EncodableT, float | int],
+        nx: bool = False,
+        xx: bool = False,
+        ch: bool = False,
+        incr: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+    ) -> "Pipeline": ...
+    def zcard(self, name: KeyT) -> "Pipeline": ...
+    def zcount(
+        self,
+        name: KeyT,
+        min: float | str | bytes,
+        max: float | str | bytes,
+    ) -> "Pipeline": ...
+    def zrange(
+        self, name: KeyT, start: int, end: int, desc: bool = False
+    ) -> "Pipeline": ...
+    def zremrangebyscore(
+        self,
+        name: KeyT,
+        min: float | str | bytes,
+        max: float | str | bytes,
+    ) -> "Pipeline": ...
+
+    async def execute(self, raise_on_error: bool = True) -> list[Any]: ...
+
+    async def __aenter__(self) -> "Pipeline": ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None: ...
+
+
+class Script(Protocol):
+    """A registered Lua script.  Return type varies by script body, so it is
+    typed as ``Any`` here and annotated locally at each call site (e.g.
+    ``result: list[int] = await my_script(keys=..., args=...)``).
+    """
+
+    async def __call__(
+        self,
+        keys: Sequence[KeyT] = ...,
+        args: Sequence[EncodableT] = ...,
+        client: "RedisClient | None" = None,
+    ) -> Any: ...
+
+
+class Lock(Protocol):
+    """A distributed lock acquired via ``async with redis.lock(name):``."""
+
+    async def __aenter__(self) -> "Lock": ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None: ...
 
 
 @runtime_checkable
@@ -110,11 +206,319 @@ class PubSubClient(Protocol):
     burner_redis.pubsub.PubSub.
     """
 
-    async def subscribe(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def psubscribe(self, *args: Any, **kwargs: Any) -> Any: ...
-    async def get_message(self, *args: Any, **kwargs: Any) -> Any: ...
-    def listen(self) -> Any: ...
+    async def subscribe(self, *channels: KeyT) -> None: ...
+    async def psubscribe(self, *patterns: KeyT) -> None: ...
+    async def get_message(
+        self,
+        ignore_subscribe_messages: bool = False,
+        timeout: float | None = 0.0,
+    ) -> dict[str, Any] | None: ...
+    def listen(self) -> AsyncIterator[dict[str, Any]]: ...
     async def aclose(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# RedisClient: the public surface advertised by docket.redis()
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RedisClient(Protocol):
+    """The Redis client surface docket uses and exposes via ``docket.redis()``.
+
+    This is the structural type shared by ``redis.asyncio.Redis``,
+    ``redis.asyncio.cluster.RedisCluster``, and ``burner_redis.BurnerRedis``.
+    Signatures are async-only and committed to ``decode_responses=False``,
+    so reads return ``bytes`` rather than the decoded ``str``.
+
+    The protocol covers what docket itself calls plus the queue-pattern
+    methods (the LPUSH/BRPOP family) that downstream consumers rely on.
+    """
+
+    # ----- Strings & generic key ops -----
+
+    async def get(self, name: KeyT) -> bytes | None: ...
+    async def set(
+        self,
+        name: KeyT,
+        value: EncodableT,
+        ex: ExpiryT | None = None,
+        px: ExpiryT | None = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        get: bool = False,
+        exat: AbsExpiryT | None = None,
+        pxat: AbsExpiryT | None = None,
+    ) -> bool | bytes | None: ...
+    async def setex(self, name: KeyT, time: ExpiryT, value: EncodableT) -> bool: ...
+    async def mget(self, keys: Sequence[KeyT]) -> list[bytes | None]: ...
+    async def exists(self, *names: KeyT) -> int: ...
+    async def keys(self, pattern: KeyT = "*") -> list[bytes]: ...
+    async def type(self, name: KeyT) -> bytes: ...
+    async def ttl(self, name: KeyT) -> int: ...
+    async def delete(self, *names: KeyT) -> int: ...
+    async def expire(self, name: KeyT, time: ExpiryT) -> bool: ...
+
+    # ----- Lists -----
+
+    async def blmove(
+        self,
+        first_list: KeyT,
+        second_list: KeyT,
+        timeout: float,
+        src: Literal["LEFT", "RIGHT"] = "LEFT",
+        dest: Literal["LEFT", "RIGHT"] = "RIGHT",
+    ) -> bytes | None: ...
+    async def blpop(
+        self,
+        keys: KeyT | Iterable[KeyT],
+        timeout: float | None = 0,
+    ) -> tuple[bytes, bytes] | None: ...
+    async def brpop(
+        self,
+        keys: KeyT | Iterable[KeyT],
+        timeout: float | None = 0,
+    ) -> tuple[bytes, bytes] | None: ...
+    async def lindex(self, name: KeyT, index: int) -> bytes | None: ...
+    async def linsert(
+        self,
+        name: KeyT,
+        where: Literal["BEFORE", "AFTER"],
+        refvalue: EncodableT,
+        value: EncodableT,
+    ) -> int: ...
+    async def llen(self, name: KeyT) -> int: ...
+    async def lmove(
+        self,
+        first_list: KeyT,
+        second_list: KeyT,
+        src: Literal["LEFT", "RIGHT"] = "LEFT",
+        dest: Literal["LEFT", "RIGHT"] = "RIGHT",
+    ) -> bytes | None: ...
+    @overload
+    async def lpop(self, name: KeyT) -> bytes | None: ...
+    @overload
+    async def lpop(self, name: KeyT, count: int) -> list[bytes] | None: ...
+    async def lpush(self, name: KeyT, *values: EncodableT) -> int: ...
+    async def lrange(self, name: KeyT, start: int, end: int) -> list[bytes]: ...
+    async def lrem(self, name: KeyT, count: int, value: EncodableT) -> int: ...
+    async def lset(self, name: KeyT, index: int, value: EncodableT) -> bool: ...
+    async def ltrim(self, name: KeyT, start: int, end: int) -> bool: ...
+    @overload
+    async def rpop(self, name: KeyT) -> bytes | None: ...
+    @overload
+    async def rpop(self, name: KeyT, count: int) -> list[bytes] | None: ...
+    async def rpoplpush(self, src: KeyT, dst: KeyT) -> bytes | None: ...
+    async def rpush(self, name: KeyT, *values: EncodableT) -> int: ...
+
+    # ----- Hashes -----
+
+    async def hget(self, name: KeyT, key: KeyT) -> bytes | None: ...
+    async def hgetall(self, name: KeyT) -> dict[bytes, bytes]: ...
+    async def hdel(self, name: KeyT, *keys: KeyT) -> int: ...
+    async def hincrby(self, name: KeyT, key: KeyT, amount: int = 1) -> int: ...
+    async def hset(
+        self,
+        name: KeyT,
+        key: KeyT | None = None,
+        value: EncodableT | None = None,
+        mapping: Mapping[KeyT, EncodableT] | None = None,
+    ) -> int: ...
+
+    # ----- Sets -----
+
+    async def sadd(self, name: KeyT, *values: EncodableT) -> int: ...
+    async def srem(self, name: KeyT, *values: EncodableT) -> int: ...
+    async def smembers(self, name: KeyT) -> set[bytes]: ...
+    async def scard(self, name: KeyT) -> int: ...
+
+    # ----- Sorted sets -----
+
+    async def zadd(
+        self,
+        name: KeyT,
+        mapping: Mapping[EncodableT, float | int],
+        nx: bool = False,
+        xx: bool = False,
+        ch: bool = False,
+        incr: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+    ) -> int | float | None: ...
+    async def zrem(self, name: KeyT, *values: EncodableT) -> int: ...
+    async def zcard(self, name: KeyT) -> int: ...
+    @overload
+    async def zrange(
+        self,
+        name: KeyT,
+        start: int,
+        end: int,
+        desc: bool = False,
+        *,
+        withscores: Literal[True],
+        score_cast_func: type[float] = float,
+    ) -> list[tuple[bytes, float]]: ...
+    @overload
+    async def zrange(
+        self,
+        name: KeyT,
+        start: int,
+        end: int,
+        desc: bool = False,
+        withscores: Literal[False] = False,
+        score_cast_func: type[float] = float,
+    ) -> list[bytes]: ...
+    @overload
+    async def zrangebyscore(
+        self,
+        name: KeyT,
+        min: float | str | bytes,
+        max: float | str | bytes,
+        start: int | None = None,
+        num: int | None = None,
+        *,
+        withscores: Literal[True],
+        score_cast_func: type[float] = float,
+    ) -> list[tuple[bytes, float]]: ...
+    @overload
+    async def zrangebyscore(
+        self,
+        name: KeyT,
+        min: float | str | bytes,
+        max: float | str | bytes,
+        start: int | None = None,
+        num: int | None = None,
+        withscores: Literal[False] = False,
+        score_cast_func: type[float] = float,
+    ) -> list[bytes]: ...
+    async def zremrangebyscore(
+        self,
+        name: KeyT,
+        min: float | str | bytes,
+        max: float | str | bytes,
+    ) -> int: ...
+    async def zscore(self, name: KeyT, value: EncodableT) -> float | None: ...
+
+    # ----- Streams -----
+
+    async def xadd(
+        self,
+        name: KeyT,
+        fields: Mapping[KeyT, EncodableT],
+        id: StreamIDT = "*",
+        maxlen: int | None = None,
+        approximate: bool = True,
+        nomkstream: bool = False,
+        minid: StreamIDT | None = None,
+        limit: int | None = None,
+    ) -> bytes: ...
+    async def xack(self, name: KeyT, groupname: KeyT, *ids: StreamIDT) -> int: ...
+    async def xautoclaim(
+        self,
+        name: KeyT,
+        groupname: KeyT,
+        consumername: KeyT,
+        min_idle_time: int,
+        start_id: StreamIDT = "0-0",
+        count: int | None = None,
+        justid: bool = False,
+    ) -> tuple[bytes, RedisMessages, list[bytes]]: ...
+    async def xclaim(
+        self,
+        name: KeyT,
+        groupname: KeyT,
+        consumername: KeyT,
+        min_idle_time: int,
+        message_ids: Sequence[StreamIDT],
+        idle: int | None = None,
+        time: int | None = None,
+        retrycount: int | None = None,
+        force: bool = False,
+        justid: bool = False,
+    ) -> RedisMessages: ...
+    async def xread(
+        self,
+        streams: Mapping[KeyT, StreamIDT],
+        count: int | None = None,
+        block: int | None = None,
+    ) -> RedisReadGroupResponse | None: ...
+    async def xreadgroup(
+        self,
+        groupname: KeyT,
+        consumername: KeyT,
+        streams: Mapping[KeyT, StreamIDT],
+        count: int | None = None,
+        block: int | None = None,
+        noack: bool = False,
+    ) -> RedisReadGroupResponse | None: ...
+    async def xrange(
+        self,
+        name: KeyT,
+        min: StreamIDT = "-",
+        max: StreamIDT = "+",
+        count: int | None = None,
+    ) -> RedisMessages: ...
+    async def xlen(self, name: KeyT) -> int: ...
+    async def xtrim(
+        self,
+        name: KeyT,
+        maxlen: int | None = None,
+        approximate: bool = True,
+        minid: StreamIDT | None = None,
+        limit: int | None = None,
+    ) -> int: ...
+    async def xdel(self, name: KeyT, *ids: StreamIDT) -> int: ...
+    async def xpending(self, name: KeyT, groupname: KeyT) -> dict[str, Any]: ...
+    async def xpending_range(
+        self,
+        name: KeyT,
+        groupname: KeyT,
+        min: StreamIDT,
+        max: StreamIDT,
+        count: int,
+        consumername: KeyT | None = None,
+        idle: int | None = None,
+    ) -> list[RedisStreamPendingMessage]: ...
+    async def xinfo_groups(self, name: KeyT) -> list[dict[str, Any]]: ...
+    async def xinfo_consumers(
+        self, name: KeyT, groupname: KeyT
+    ) -> list[dict[str, Any]]: ...
+    async def xinfo_stream(self, name: KeyT) -> dict[str, Any]: ...
+    async def xgroup_create(
+        self,
+        name: KeyT,
+        groupname: KeyT,
+        id: StreamIDT = "$",
+        mkstream: bool = False,
+        entries_read: int | None = None,
+    ) -> bool: ...
+
+    # ----- Server / pub-sub / scripting -----
+
+    async def info(self, section: str | None = None) -> dict[str, Any]: ...
+    async def publish(self, channel: KeyT, message: EncodableT) -> int: ...
+    def pubsub(self, **kwargs: Any) -> PubSubClient: ...
+    def scan_iter(
+        self,
+        match: KeyT | None = None,
+        count: int | None = None,
+        _type: str | None = None,
+    ) -> AsyncIterator[bytes]: ...
+    def register_script(self, script: str | bytes) -> Script: ...
+    def pipeline(
+        self,
+        transaction: bool = True,
+        shard_hint: str | None = None,
+    ) -> Pipeline: ...
+    def lock(
+        self,
+        name: KeyT,
+        timeout: float | None = None,
+        sleep: float = 0.1,
+        blocking: bool = True,
+        blocking_timeout: float | None = None,
+    ) -> Lock: ...
 
 
 class MemoryRedisClient(RedisClient, AsyncCloseable, Protocol):
@@ -137,7 +541,7 @@ async def close_resource(resource: AsyncCloseable, name: str) -> None:
 _MemoryServerKey = tuple[str, int]
 _MemoryServerEntry = tuple[asyncio.AbstractEventLoop, MemoryRedisClient]
 _memory_servers: dict[_MemoryServerKey, _MemoryServerEntry] = {}
-_memory_servers_lock = Lock()
+_memory_servers_lock = _ThreadLock()
 
 
 def _memory_server_key(url: str, loop: asyncio.AbstractEventLoop) -> _MemoryServerKey:
@@ -389,7 +793,9 @@ class RedisConnection:
         Returns:
             A ConnectionPool ready for use with Redis clients
         """
-        return ConnectionPool.from_url(self.url, decode_responses=decode_responses)
+        return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
+            self.url, decode_responses=decode_responses
+        )
 
     async def _get_or_create_memory_client(self) -> MemoryRedisClient:
         """Get or create a BurnerRedis instance for a memory:// URL."""
@@ -410,21 +816,27 @@ class RedisConnection:
 
     @asynccontextmanager
     async def client(self) -> AsyncGenerator[RedisClient, None]:
-        """Get a Redis client, handling standalone, cluster, and memory modes."""
+        """Get a Redis client, handling standalone, cluster, and memory modes.
+
+        Casts at the redis-py boundary translate from redis-py's
+        ``Awaitable[T] | T`` dual-mode signatures into our async-only protocol.
+        At runtime the awaitables resolve correctly; the cast just bridges
+        the static-type mismatch.
+        """
         if self._cluster_client is not None:  # pragma: no cover
-            yield self._cluster_client
+            yield cast(RedisClient, self._cluster_client)
         elif self._memory_client is not None:
             yield self._memory_client
         else:
             async with Redis(connection_pool=self._connection_pool) as r:
-                yield r
+                yield cast(RedisClient, r)
 
     @asynccontextmanager
     async def pubsub(self) -> AsyncGenerator[PubSubClient, None]:
         """Get a pub/sub connection, handling standalone, cluster, and memory modes."""
         if self._cluster_client is not None:  # pragma: no cover
             async with self._cluster_pubsub() as ps:
-                yield ps
+                yield cast(PubSubClient, ps)
         elif self._memory_client is not None:
             ps = self._memory_client.pubsub()
             try:
@@ -433,19 +845,19 @@ class RedisConnection:
                 await ps.aclose()
         else:
             async with Redis(connection_pool=self._connection_pool) as r:
-                async with r.pubsub() as pubsub:
-                    yield pubsub
+                async with r.pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
+                    yield cast(PubSubClient, pubsub)
 
     async def publish(self, channel: str, message: str) -> int:
         """Publish a message to a pub/sub channel."""
         if self._cluster_client is not None:  # pragma: no cover
             async with Redis(connection_pool=self._node_pool) as r:
-                return await r.publish(channel, message)
+                return cast(int, await r.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
         elif self._memory_client is not None:
             return await self._memory_client.publish(channel, message)
         else:
             async with Redis(connection_pool=self._connection_pool) as r:
-                return await r.publish(channel, message)
+                return cast(int, await r.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
 
     @asynccontextmanager
     async def _cluster_pubsub(self) -> AsyncGenerator[PubSub, None]:  # pragma: no cover
@@ -459,7 +871,7 @@ class RedisConnection:
             A PubSub object connected to a cluster node
         """
         client = Redis(connection_pool=self._node_pool)
-        pubsub = client.pubsub()
+        pubsub = client.pubsub()  # pyright: ignore[reportUnknownMemberType]
         try:
             yield pubsub
         finally:

--- a/src/docket/_result_store.py
+++ b/src/docket/_result_store.py
@@ -72,7 +72,7 @@ class ClusterKeyValueStore:
         data = await self._client.get(redis_key)
         if data is None:
             return None
-        return json.loads(data)  # type: ignore[no-any-return]
+        return json.loads(data)
 
     async def ttl(
         self,

--- a/src/docket/dependencies/_concurrency.py
+++ b/src/docket/dependencies/_concurrency.py
@@ -211,6 +211,7 @@ class ConcurrencyLimit(Dependency["ConcurrencyLimit"]):
         If all slots are full, we scavenge any slot older than redelivery_timeout
         (meaning it hasn't been refreshed and the worker must be dead).
         """
+        assert self._concurrency_key and self._task_key
         # Lua script for atomic concurrency slot management.
         # KEYS[1]: concurrency_key (sorted set tracking slots)
         # ARGV[1]: max_concurrent, ARGV[2]: task_key, ARGV[3]: current_time,
@@ -306,6 +307,9 @@ class ConcurrencyLimit(Dependency["ConcurrencyLimit"]):
 
     async def _renew_lease_loop(self, redelivery_timeout: timedelta) -> None:
         """Periodically refresh slot timestamp to prevent expiration."""
+        # Lease renewal is only scheduled when a slot was acquired, which
+        # requires both keys to be set.
+        assert self._concurrency_key and self._task_key
         docket = current_docket.get()
         renewal_interval = redelivery_timeout.total_seconds() / LEASE_RENEWAL_FACTOR
         key_ttl = max(
@@ -320,9 +324,9 @@ class ConcurrencyLimit(Dependency["ConcurrencyLimit"]):
                     current_time = datetime.now(timezone.utc).timestamp()
                     await redis.zadd(
                         self._concurrency_key,
-                        {self._task_key: current_time},  # type: ignore
+                        {self._task_key: current_time},
                     )
-                    await redis.expire(self._concurrency_key, key_ttl)  # type: ignore
+                    await redis.expire(self._concurrency_key, key_ttl)
             except Exception:  # pragma: no cover
                 # Lease renewal is best-effort; if it fails, the slot will eventually
                 # be scavenged as stale and the task can be redelivered

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -12,8 +12,6 @@ from typing import (
     Mapping,
     ParamSpec,
     Protocol,
-    Sequence,
-    TypedDict,
     TypeVar,
     cast,
     overload,
@@ -28,7 +26,18 @@ from ._docket_snapshot import DocketSnapshot as DocketSnapshot
 from ._docket_snapshot import DocketSnapshotMixin
 from ._docket_snapshot import RunningExecution as RunningExecution
 from ._docket_snapshot import WorkerInfo as WorkerInfo
-from ._redis import PubSubClient, RedisClient, RedisConnection
+from ._redis import (
+    PubSubClient,
+    RedisClient,
+    RedisConnection,
+    RedisMessage as RedisMessage,
+    RedisMessageID as RedisMessageID,
+    RedisMessages as RedisMessages,
+    RedisReadGroupResponse as RedisReadGroupResponse,
+    RedisStream as RedisStream,
+    RedisStreamID as RedisStreamID,
+    RedisStreamPendingMessage as RedisStreamPendingMessage,
+)
 from ._result_store import ResultStorage
 from ._uuid7 import uuid7
 from .execution import (
@@ -64,20 +73,6 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 TaskCollection = Iterable[TaskFunction]
-
-RedisStreamID = bytes
-RedisMessageID = bytes
-RedisMessage = dict[bytes, bytes]
-RedisMessages = Sequence[tuple[RedisMessageID, RedisMessage]]
-RedisStream = tuple[RedisStreamID, RedisMessages]
-RedisReadGroupResponse = Sequence[RedisStream]
-
-
-class RedisStreamPendingMessage(TypedDict):
-    message_id: bytes
-    consumer: bytes
-    time_since_delivered: int
-    times_delivered: int
 
 
 class Docket(DocketSnapshotMixin):

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -831,7 +831,7 @@ class Execution:
                 if result_data and "data" in result_data:
                     # Base64-decode and unpickle
                     pickled_exception = base64.b64decode(result_data["data"])
-                    exception = cloudpickle.loads(pickled_exception)  # type: ignore[arg-type]
+                    exception = cloudpickle.loads(pickled_exception)
                     raise exception
             # If no stored exception, raise a generic error with the error message
             error_msg = self.error or "Task execution failed"
@@ -843,7 +843,7 @@ class Execution:
             if result_data is not None and "data" in result_data:
                 # Base64-decode and unpickle
                 pickled_result = base64.b64decode(result_data["data"])
-                return cloudpickle.loads(pickled_result)  # type: ignore[arg-type]
+                return cloudpickle.loads(pickled_result)
 
         # No result stored - task returned None
         return None

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -861,9 +861,7 @@ class Execution:
                     # Update state
                     state_value = data.get(b"state")
                     if state_value:
-                        if isinstance(state_value, bytes):
-                            state_value = state_value.decode()
-                        self.state = ExecutionState(state_value)
+                        self.state = ExecutionState(state_value.decode())
 
                     # Update metadata
                     self.worker = (

--- a/src/docket/strikelist.py
+++ b/src/docket/strikelist.py
@@ -599,7 +599,7 @@ class StrikeList:
 
         for _, messages in streams:
             for message_id, message in messages:
-                last_id = message_id  # type: ignore[assignment]
+                last_id = message_id
                 instruction = StrikeInstruction.from_message(message)
                 self.update(instruction)
                 logger.info(

--- a/tests/_container.py
+++ b/tests/_container.py
@@ -59,7 +59,7 @@ def sync_redis(url: str) -> Generator[Redis, None, None]:
     redis = Redis.from_url(url)  # type: ignore
     try:
         with redis:
-            pool = redis.connection_pool  # type: ignore
+            pool = redis.connection_pool
             yield redis
     finally:
         if pool:
@@ -235,9 +235,7 @@ def wait_for_cluster(port: int) -> None:
     while True:
         try:
             # Try to connect and verify cluster state
-            r: RedisCluster = RedisCluster.from_url(  # type: ignore[reportUnknownMemberType]
-                f"redis://localhost:{port}"
-            )
+            r: RedisCluster = RedisCluster.from_url(f"redis://localhost:{port}")
             info: dict[str, str] = r.cluster_info()  # type: ignore[reportUnknownMemberType]
             if info.get("cluster_state") != "ok":
                 r.close()
@@ -266,7 +264,7 @@ def cleanup_stale_containers(docker_client: DockerClient) -> None:
 
     containers: Iterable[Container] = cast(
         Iterable[Container],
-        docker_client.containers.list(  # type: ignore
+        docker_client.containers.list(
             all=True,
             filters={"label": "source=docket-unit-tests"},
         ),

--- a/tests/_key_leak_checker.py
+++ b/tests/_key_leak_checker.py
@@ -12,11 +12,9 @@ async def count_redis_keys_by_type(redis: RedisClient, prefix: str) -> dict[str,
     counts: dict[str, int] = {}
 
     # Use scan_iter instead of keys() for cluster compatibility
-    async for key in redis.scan_iter(match=pattern):  # type: ignore
-        key_type = await redis.type(key)  # type: ignore[reportUnknownArgumentType]
-        key_type_str = (
-            key_type.decode() if isinstance(key_type, bytes) else str(key_type)
-        )
+    async for key in redis.scan_iter(match=pattern):
+        key_type = await redis.type(key)
+        key_type_str = key_type.decode()
         counts[key_type_str] = counts.get(key_type_str, 0) + 1
 
     return counts

--- a/tests/_key_leak_checker.py
+++ b/tests/_key_leak_checker.py
@@ -81,7 +81,7 @@ class KeyCountChecker:
             keys_without_ttl: list[str] = []
 
             # Use scan_iter instead of keys() for cluster compatibility
-            async for key in redis.scan_iter(match=pattern):  # type: ignore
+            async for key in redis.scan_iter(match=pattern):
                 key_str = key.decode() if isinstance(key, bytes) else str(key)  # type: ignore[reportUnknownArgumentType]
 
                 # Skip explicitly permanent keys

--- a/tests/cli/test_watch.py
+++ b/tests/cli/test_watch.py
@@ -86,7 +86,7 @@ async def test_watch_running_task_until_completion(docket: Docket, worker: Worke
     async def coordinated_task():
         # Wait for watch to be subscribed before completing
         async with docket.redis() as redis:
-            while not await redis.get(ready_key):  # type: ignore[misc]
+            while not await redis.get(ready_key):
                 await asyncio.sleep(0.01)
         # Now do the work
         await asyncio.sleep(0.5)
@@ -434,7 +434,7 @@ async def test_watch_task_with_incomplete_data(
     # Manually create runs hash with incomplete data (missing function/args/kwargs)
     async with docket.redis() as redis:
         runs_key = f"{docket.name}:runs:incomplete-task"
-        await redis.hset(runs_key, mapping={"state": "scheduled"})  # type: ignore[misc]
+        await redis.hset(runs_key, mapping={"state": "scheduled"})
 
     result = await run_cli(
         "watch",

--- a/tests/cli/waiting.py
+++ b/tests/cli/waiting.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import time
-from typing import cast
 
 from docket import Docket
 from docket.execution import ExecutionState
@@ -38,10 +37,10 @@ async def wait_for_progress_data(
 
     while time.monotonic() - start_time < timeout:
         async with docket.redis() as redis:
-            data = await redis.hgetall(progress_key)  # type: ignore[misc]
+            data = await redis.hgetall(progress_key)
             if data:  # pragma: no branch
-                current = int(cast(bytes, data.get(b"current", b"0")))  # type: ignore[misc]
-                total = int(cast(bytes, data.get(b"total", b"100")))  # type: ignore[misc]
+                current = int(data.get(b"current", b"0"))
+                total = int(data.get(b"total", b"100"))
 
                 if current >= min_current and total >= min_total:  # pragma: no branch
                     return (current, total)
@@ -79,11 +78,11 @@ async def wait_for_execution_state(
 
     while time.monotonic() - start_time < timeout:
         async with docket.redis() as redis:
-            data = await redis.hgetall(execution_key)  # type: ignore[misc]
+            data = await redis.hgetall(execution_key)
             if data:  # pragma: no branch
-                state_value = data.get(b"state")  # type: ignore[misc]
+                state_value = data.get(b"state")
                 if state_value:  # pragma: no branch
-                    current_state = ExecutionState(cast(bytes, state_value).decode())
+                    current_state = ExecutionState(state_value.decode())
                     if current_state == state:  # pragma: no branch
                         return
 
@@ -120,11 +119,11 @@ async def wait_for_worker_assignment(
 
     while time.monotonic() - start_time < timeout:
         async with docket.redis() as redis:
-            data = await redis.hgetall(execution_key)  # type: ignore[misc]
+            data = await redis.hgetall(execution_key)
             if data:  # pragma: no branch
-                worker = data.get(b"worker")  # type: ignore[misc]
+                worker = data.get(b"worker")
                 if worker:  # pragma: no branch
-                    return cast(bytes, worker).decode()
+                    return worker.decode()
 
         await asyncio.sleep(interval)
 

--- a/tests/concurrency_limits/test_worker_mechanics.py
+++ b/tests/concurrency_limits/test_worker_mechanics.py
@@ -147,7 +147,7 @@ async def test_worker_concurrency_cleanup_after_task_completion(docket: Docket):
     async with Worker(docket) as worker:
         await worker.run_until_finished()
         async with docket.redis() as redis:
-            await redis.keys(f"{docket.name}:concurrency:*")  # type: ignore
+            await redis.keys(f"{docket.name}:concurrency:*")
             cleanup_verified = True
 
     assert cleanup_verified
@@ -237,11 +237,11 @@ async def test_stale_concurrency_slots_are_scavenged_when_full(docket: Docket):
 
     async with docket.redis() as redis:
         # Add two stale slots that fill up max_concurrent
-        await redis.zadd(concurrency_key, {"stale_task_1": stale_timestamp})  # type: ignore
-        await redis.zadd(concurrency_key, {"stale_task_2": stale_timestamp})  # type: ignore
+        await redis.zadd(concurrency_key, {"stale_task_1": stale_timestamp})
+        await redis.zadd(concurrency_key, {"stale_task_2": stale_timestamp})
 
         # Verify stale slots are present
-        count_before = await redis.zcard(concurrency_key)  # type: ignore
+        count_before = await redis.zcard(concurrency_key)
         assert count_before == 2
 
     # Run a task - this should scavenge ONE stale slot and execute
@@ -255,7 +255,7 @@ async def test_stale_concurrency_slots_are_scavenged_when_full(docket: Docket):
     # Verify: one stale slot was scavenged, task completed and released its slot,
     # so one stale slot should remain (we only scavenge what we need)
     async with docket.redis() as redis:
-        remaining = await redis.zrange(concurrency_key, 0, -1)  # type: ignore
+        remaining = await redis.zrange(concurrency_key, 0, -1)
         # One stale slot should remain (the other was scavenged)
         assert len(remaining) == 1
         # The remaining slot should be one of the stale ones

--- a/tests/instrumentation/test_counters.py
+++ b/tests/instrumentation/test_counters.py
@@ -401,9 +401,7 @@ async def test_superseded_task_increments_superseded_counter(
 
     # Bump the generation so the worker sees the message as superseded
     async with docket.redis() as redis:
-        await redis.hincrby(  # type: ignore[misc]
-            docket.key("runs:metrics-superseded"), "generation", 1
-        )
+        await redis.hincrby(docket.key("runs:metrics-superseded"), "generation", 1)
 
     await worker.run_until_finished()
 

--- a/tests/test_docket_clear.py
+++ b/tests/test_docket_clear.py
@@ -144,14 +144,14 @@ async def test_clear_no_redis_key_leaks(docket: Docket, the_task: AsyncMock):
     await docket.add(the_task, when=future + timedelta(seconds=1))("scheduled2")
 
     async with docket.redis() as r:
-        keys_before = cast(list[str], await r.keys("*"))  # type: ignore
+        keys_before = cast(list[str], await r.keys("*"))
         keys_before_count = len(keys_before)
 
     result = await docket.clear()
     assert result == 5
 
     async with docket.redis() as r:
-        keys_after = cast(list[str], await r.keys("*"))  # type: ignore
+        keys_after = cast(list[str], await r.keys("*"))
         keys_after_count = len(keys_after)
 
     assert keys_after_count <= keys_before_count

--- a/tests/test_docket_execution.py
+++ b/tests/test_docket_execution.py
@@ -150,7 +150,7 @@ async def test_get_execution_with_incomplete_data(
     # Manually create runs hash with missing fields
     async with docket.redis() as redis:
         # Only set state, missing function/args/kwargs
-        await redis.hset(runs_key, mapping={"state": "scheduled"})  # type: ignore[misc]
+        await redis.hset(runs_key, mapping={"state": "scheduled"})
 
     execution = await docket.get_execution("incomplete-task")
     assert execution is None
@@ -170,7 +170,7 @@ async def test_get_execution_with_missing_when(
 
     # Manually create runs hash with function/args/kwargs but no when
     async with docket.redis() as redis:
-        await redis.hset(  # type: ignore[misc]
+        await redis.hset(
             runs_key,
             mapping={
                 "state": "scheduled",
@@ -198,7 +198,7 @@ async def test_get_execution_with_unregistered_function_creates_placeholder(
 
     # Manually create runs hash with unregistered function
     async with docket.redis() as redis:
-        await redis.hset(  # type: ignore[misc]
+        await redis.hset(
             runs_key,
             mapping={
                 "state": "scheduled",

--- a/tests/test_execution_state.py
+++ b/tests/test_execution_state.py
@@ -220,36 +220,6 @@ async def test_execution_sync_with_missing_state_field(docket: Docket):
     assert execution.started_at is not None
 
 
-async def test_execution_sync_with_string_state_value(docket: Docket):
-    """Test sync() handles non-bytes state value (defensive coding)."""
-    from unittest.mock import AsyncMock, patch
-
-    execution = Execution(
-        docket, AsyncMock(), (), {}, "test-key", datetime.now(timezone.utc), 1
-    )
-
-    # Mock Redis to return string state (defensive code handles both bytes and str)
-    mock_data = {
-        b"state": "completed",  # String, not bytes!
-        b"worker": b"worker-1",
-        b"completed_at": b"2024-01-01T00:00:00+00:00",
-    }
-
-    with patch.object(execution.docket, "redis") as mock_redis_ctx:
-        mock_redis = AsyncMock()
-        mock_redis.hgetall.return_value = mock_data
-        mock_redis_ctx.return_value.__aenter__.return_value = mock_redis
-        mock_redis_ctx.return_value.__aexit__.return_value = None
-
-        # Mock progress sync
-        with patch.object(execution.progress, "sync"):
-            await execution.sync()
-
-    # Should handle string and set state correctly
-    assert execution.state == ExecutionState.COMPLETED
-    assert execution.worker == "worker-1"
-
-
 async def test_mark_as_failed_without_error_message(docket: Docket):
     """Test mark_as_failed with error=None."""
     execution = Execution(

--- a/tests/test_perpetual_race.py
+++ b/tests/test_perpetual_race.py
@@ -188,7 +188,7 @@ async def test_superseded_message_skipped_before_execution(
     # pending in the consumer group (e.g. redelivery after crash).
     runs_key = docket.key("runs:head-check")
     async with docket.redis() as redis:
-        await redis.hincrby(runs_key, "generation", 1)  # type: ignore[misc]
+        await redis.hincrby(runs_key, "generation", 1)
 
     await worker.run_until_finished()
 
@@ -225,7 +225,7 @@ async def test_old_message_without_generation_runs_normally(
         message_id = await redis.xadd(docket.stream_key, message)  # type: ignore[arg-type]
 
         # Set up runs hash without generation, as old code would
-        await redis.hset(  # type: ignore[misc]
+        await redis.hset(
             docket.key("runs:old-to-new"),
             mapping={
                 "state": "queued",
@@ -265,16 +265,16 @@ async def test_new_task_moved_by_old_scheduler_runs_normally(
 
     async with docket.redis() as redis:
         # Verify new code set generation=1 in the runs hash
-        gen = await redis.hget(docket.key("runs:new-old-new"), "generation")  # type: ignore[misc]
+        gen = await redis.hget(docket.key("runs:new-old-new"), "generation")
         assert gen == b"1"
 
         # Simulate old scheduler moving from queue to stream WITHOUT generation
-        parked_data: dict[bytes, bytes] = await redis.hgetall(  # type: ignore[misc]
+        parked_data: dict[bytes, bytes] = await redis.hgetall(
             docket.parked_task_key("new-old-new")
         )
         stream_message: dict[bytes, bytes] = {
             k: v
-            for k, v in parked_data.items()  # type: ignore[misc]
+            for k, v in parked_data.items()
             if k != b"generation"  # old scheduler doesn't know about this field
         }
         message_id = await redis.xadd(docket.stream_key, stream_message)  # type: ignore[arg-type]
@@ -282,7 +282,7 @@ async def test_new_task_moved_by_old_scheduler_runs_normally(
         # Clean up queue/parked state as the old scheduler would
         await redis.zrem(docket.queue_key, "new-old-new")
         await redis.delete(docket.parked_task_key("new-old-new"))
-        await redis.hset(  # type: ignore[misc]
+        await redis.hset(
             docket.key("runs:new-old-new"),
             mapping={"state": "queued", "stream_id": message_id},
         )
@@ -370,17 +370,17 @@ async def test_perpetual_successor_survives_mark_as_terminal(
     # not "completed" and not deleted.
     runs_key = docket.key(f"runs:{key}")
     async with docket.redis() as redis:
-        runs_data: dict[bytes, bytes] = await redis.hgetall(runs_key)  # type: ignore[misc]
+        runs_data: dict[bytes, bytes] = await redis.hgetall(runs_key)
 
     assert runs_data, (
         f"runs hash for {key!r} was deleted (execution_ttl={docket.execution_ttl})"
     )
-    state: str = runs_data[b"state"].decode()  # type: ignore[union-attr]
+    state: str = runs_data[b"state"].decode()
     assert state == "scheduled", (
         f"runs hash state is {state!r}, expected 'scheduled' "
         f"(execution_ttl={docket.execution_ttl})"
     )
-    when = float(runs_data[b"when"])  # type: ignore[arg-type]
+    when = float(runs_data[b"when"])
     expected_earliest = (before + timedelta(hours=1) - timedelta(seconds=5)).timestamp()
     expected_latest = (before + timedelta(hours=1) + timedelta(seconds=5)).timestamp()
     assert expected_earliest <= when <= expected_latest, (

--- a/tests/test_perpetual_state.py
+++ b/tests/test_perpetual_state.py
@@ -84,7 +84,7 @@ async def test_perpetual_task_no_state_accumulation_with_ttl_zero(
         # Check that we're not accumulating state records
         # With TTL=0, state records should be deleted immediately
         async with zero_ttl_docket.redis() as redis:  # pragma: no branch
-            keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")  # type: ignore
+            keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")
             assert len(keys) == 0, f"Should have no state records, found {len(keys)}"
 
 
@@ -144,8 +144,8 @@ async def test_perpetual_same_key_no_state_accumulation(
         # reliably in cluster mode (curly braces confuse pattern matching)
         pattern = f"{docket.prefix}:runs:*"
         keys: list[bytes] = []
-        async for key in redis.scan_iter(match=pattern):  # type: ignore
-            keys.append(key)  # type: ignore[reportUnknownArgumentType]
+        async for key in redis.scan_iter(match=pattern):
+            keys.append(key)
         assert len(keys) == 1, (
             f"Should have exactly one state record, found {len(keys)}"
         )
@@ -213,7 +213,7 @@ async def test_perpetual_publishes_completed_event(pubsub_docket: Docket):
     async def collect_events():
         async for event in execution.subscribe():  # pragma: no cover
             if event["type"] == "state":
-                state_events.append(event)  # type: ignore[arg-type]
+                state_events.append(event)
                 if event["state"] == ExecutionState.COMPLETED:
                     return
 

--- a/tests/test_redelivery.py
+++ b/tests/test_redelivery.py
@@ -366,7 +366,7 @@ async def test_lease_renewal_recovers_from_redis_error(
     original_cluster_xclaim = RedisCluster.xclaim
 
     async def mock_redis_xclaim(  # pragma: no cover
-        self: Redis,  # type: ignore[type-arg]
+        self: Redis,
         *args: object,
         **kwargs: object,
     ) -> object:
@@ -377,7 +377,7 @@ async def test_lease_renewal_recovers_from_redis_error(
         return await original_redis_xclaim(self, *args, **kwargs)  # type: ignore[arg-type]
 
     async def mock_cluster_xclaim(  # pragma: no cover
-        self: RedisCluster,  # type: ignore[type-arg]
+        self: RedisCluster,
         *args: object,
         **kwargs: object,
     ) -> object:

--- a/tests/test_results_storage.py
+++ b/tests/test_results_storage.py
@@ -216,8 +216,8 @@ async def test_result_storage_uses_provided_or_default(docket: Docket):
         assert isinstance(store, RedisStore)
 
         # Verify it's connected to the same Redis
-        result_client = store._client  # type: ignore[attr-defined]
-        pool_kwargs: dict[str, Any] = result_client.connection_pool.connection_kwargs  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        result_client = store._client
+        pool_kwargs: dict[str, Any] = result_client.connection_pool.connection_kwargs  # pyright: ignore[reportUnknownVariableType]
 
         parsed = urlparse(docket.url)
         assert pool_kwargs.get("host") == (parsed.hostname or "localhost")

--- a/tests/test_worker_dependencies.py
+++ b/tests/test_worker_dependencies.py
@@ -406,7 +406,7 @@ async def test_reserved_name_rejected_at_construction(docket: Docket):
 
 async def test_non_callable_factory_rejected_at_construction(docket: Docket):
     with pytest.raises(TypeError):
-        Worker(docket, dependencies={"bad": "not a function"})  # type: ignore[dict-item]
+        Worker(docket, dependencies={"bad": "not a function"})
 
 
 async def test_list_form_runs_in_order_with_internal_names(docket: Docket):

--- a/tests/test_worker_single_dependencies.py
+++ b/tests/test_worker_single_dependencies.py
@@ -20,6 +20,7 @@ from docket.dependencies import (
     ConcurrencyLimit,
     Debounce,
     Depends,
+    ExponentialRetry,
     Perpetual,
     RateLimit,
     Retry,
@@ -184,6 +185,38 @@ async def test_conflicting_retry_raises_and_task_fails(
 
     async def the_task(
         retry: Retry = Retry(attempts=2),
+    ) -> None:  # pragma: no cover - body must not run
+        pass
+
+    docket.register(the_task)
+
+    with caplog.at_level(logging.ERROR, logger="docket"):
+        async with Worker(
+            docket,
+            dependencies={"retry": Retry(attempts=5)},
+            minimum_check_interval=FAST,
+            scheduling_resolution=FAST,
+        ) as worker:
+            await docket.add(the_task)()
+            await worker.run_until_finished()
+
+    assert "Only one Retry dependency is allowed" in caplog.text
+
+
+async def test_conflicting_retry_subclass_at_worker_and_task_levels(
+    docket: Docket, caplog: pytest.LogCaptureFixture
+):
+    """Different concrete subclasses of the same single=True base (here, Retry
+    and ExponentialRetry, both rooted at FailureHandler) should still conflict
+    when split across worker- and task-scope.
+
+    Covers the cross-subclass branch of detect_single_conflicts that the
+    same-concrete-type tests don't reach.
+    """
+    import logging
+
+    async def the_task(
+        retry: Retry = ExponentialRetry(attempts=3),
     ) -> None:  # pragma: no cover - body must not run
         pass
 

--- a/tests/worker/test_bootstrap.py
+++ b/tests/worker/test_bootstrap.py
@@ -284,8 +284,8 @@ async def test_worker_handles_nogroup_in_xreadgroup(
         original_redis_xreadgroup = redis.asyncio.Redis.xreadgroup
         original_cluster_xreadgroup = redis.asyncio.RedisCluster.xreadgroup
 
-        async def mock_redis_xreadgroup(  # pragma: no cover  # pyright: ignore[reportUnknownParameterType]
-            self: redis.asyncio.Redis,  # type: ignore[type-arg]
+        async def mock_redis_xreadgroup(  # pragma: no cover
+            self: redis.asyncio.Redis,
             *args: object,
             **kwargs: object,
         ) -> object:
@@ -295,8 +295,8 @@ async def test_worker_handles_nogroup_in_xreadgroup(
                 raise ResponseError("NOGROUP No such key or consumer group")
             return await original_redis_xreadgroup(self, *args, **kwargs)  # type: ignore[arg-type]
 
-        async def mock_cluster_xreadgroup(  # pragma: no cover  # pyright: ignore[reportUnknownParameterType]
-            self: redis.asyncio.RedisCluster,  # type: ignore[type-arg]
+        async def mock_cluster_xreadgroup(  # pragma: no cover
+            self: redis.asyncio.RedisCluster,
             *args: object,
             **kwargs: object,
         ) -> object:

--- a/tests/worker/test_lifecycle.py
+++ b/tests/worker/test_lifecycle.py
@@ -211,7 +211,7 @@ async def test_cancellation_listener_handles_connection_error(docket: Docket):
                     raise ConnectionError("Test connection error")
                 # Signal that we got past the error handler
                 error_handled.set()
-                return await original_get_message(**kwargs)  # pyright: ignore[reportUnknownVariableType]
+                return await original_get_message(**kwargs)
 
             pubsub.get_message = failing_get_message  # type: ignore[method-assign]
             yield pubsub
@@ -254,7 +254,7 @@ async def test_cancellation_listener_handles_generic_exception(docket: Docket):
                     raise RuntimeError("Test generic error")
                 # Signal that we got past the error handler
                 error_handled.set()
-                return await original_get_message(**kwargs)  # pyright: ignore[reportUnknownVariableType]
+                return await original_get_message(**kwargs)
 
             pubsub.get_message = failing_get_message  # type: ignore[method-assign]
             yield pubsub

--- a/tests/worker/test_scheduling.py
+++ b/tests/worker/test_scheduling.py
@@ -305,7 +305,7 @@ async def test_wrongtype_error_with_legacy_known_task_key(
         await redis.set(known_task_key, str(when.timestamp()))
         await redis.zadd(docket.queue_key, {key: when.timestamp()})
 
-        await redis.hset(  # type: ignore
+        await redis.hset(
             docket.parked_task_key(key),
             mapping={
                 "key": key,

--- a/tests/worker/test_ttl_zero.py
+++ b/tests/worker/test_ttl_zero.py
@@ -45,7 +45,7 @@ async def test_state_record_expires_immediately_with_ttl_zero(
 
         # Verify no state records exist in Redis
         async with zero_ttl_docket.redis() as redis:  # pragma: no branch
-            keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")  # type: ignore
+            keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")
             assert len(keys) == 0, f"Should have no state records, found {len(keys)}"
 
 


### PR DESCRIPTION
The protocol in `src/docket/_redis.py` was declared with
`*args: Any, **kwargs: Any` on every method, plus `Any` returns from
`pubsub()` / `pipeline()` / `register_script()` / `lock()`. That made
`docket.redis()` an `Any`-shaped surface for downstream consumers and
silently swallowed real bugs in our own code (e.g. `data["pending"]`
against a `dict[bytes, bytes]`).

Now the protocol is async-only and committed to `decode_responses=False`:

- Mirrors redis-py's input domain (`KeyT`, `EncodableT`, `StreamIDT`,
  `ExpiryT`, `AbsExpiryT`).
- Consolidates the stream return-shape aliases (`RedisMessage`,
  `RedisMessages`, `RedisStream`, `RedisReadGroupResponse`,
  `RedisStreamPendingMessage`) here; `docket.py` re-exports them.
- Adds narrow companion protocols (`Pipeline`, `Script`, `Lock`)
  covering only the surface docket actually invokes, plus a tightened
  `PubSubClient`.
- Uses `@overload` on `lpop` / `rpop` / `zrange` / `zrangebyscore` so
  callers see the right return shape based on `count` / `withscores`.
- Includes the methods docket calls but the protocol was missing
  (`setex`, `mget`, `zremrangebyscore`, `xdel`, `xpending_range`).

The redis-py seam in `RedisConnection` uses targeted `cast` /
`# pyright: ignore[reportUnknownMemberType]` to bridge from redis-py's
dual-mode `Awaitable[T] | T` returns into the async-only protocol; that
mismatch is purely static and the awaitables resolve correctly at
runtime.

Falling out of the tighter typing:

- Removed redundant `cast(set[bytes], ...)` and `# type: ignore`s in
  `_docket_snapshot.py`, `tests/_key_leak_checker.py`, `tests/cli/waiting.py`.
- Deleted `test_execution_sync_with_string_state_value` and the
  `isinstance(state_value, bytes)` branch it guarded — dead now that
  `hgetall` is `dict[bytes, bytes]`.
- Added missing asserts in `_concurrency._acquire_slot` /
  `_renew_lease_loop` so pyright can narrow `_concurrency_key` /
  `_task_key` from `str | None`.
- New test covering the cross-subclass conflict branch of
  `detect_single_conflicts`, which brings coverage to 100%.

`_redis.py` grew past the 750-line source default; bumped its loq
baseline to 900. Added a `[tool.codespell]` ignore for `exat` / `pxat`,
which are real redis-py SET-command flags.

Follow-on to #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)