### PR TITLE
Surface the run_at_most rule in docstrings and docs

### DIFF
--- a/docs/task-behaviors.md
+++ b/docs/task-behaviors.md
@@ -111,6 +111,17 @@ async def resilient_sync(
 
 You don't need try/except blocks to ensure rescheduling - Docket handles this automatically. Whether the task completes successfully or raises an exception, the next execution will be scheduled according to the `every` interval.
 
+### Testing perpetual tasks
+
+Perpetual tasks usually reschedule themselves on completion, so unless the task cancels itself `worker.run_until_finished()` will not return — there is more work in the queue. For tests, use [`run_at_most()`](api-reference.md#docket.Worker.run_at_most) to bound how many times each task runs:
+
+```python
+execution = await docket.add(my_perpetual)()
+await worker.run_at_most({execution.key: 3})
+```
+
+See [Testing with Docket](testing.md#controlling-perpetual-tasks) for the full testing guide.
+
 ## Cron Tasks
 
 For tasks that need to run at specific wall-clock times rather than at fixed intervals, use the `Cron` dependency. It extends `Perpetual` with cron expression support, scheduling the next run at the exact matching time after each execution.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -225,7 +225,7 @@ async def test_task_registration_by_name(test_docket: Docket, test_worker: Worke
 
 ## Controlling Perpetual Tasks
 
-Use [`run_at_most()`](api-reference.md#docket.Worker.run_at_most) to limit how many times specific tasks run, which is essential for testing perpetual tasks:
+Perpetual tasks usually reschedule themselves on completion, so unless they cancel themselves a worker running them via `run_until_finished()` will not finish — there is more work in the queue. Use [`run_at_most()`](api-reference.md#docket.Worker.run_at_most) to bound iterations per task key for testing:
 
 ```python
 async def test_perpetual_monitoring(test_docket: Docket, test_worker: Worker) -> None:

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1195
+max_lines = 1196
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
@@ -18,12 +18,12 @@ max_lines = 945
 
 [[rules]]
 path = "src/docket/execution.py"
-max_lines = 1014
+max_lines = 1012
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 870
+max_lines = 861
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 900
+max_lines = 885

--- a/src/docket/dependencies/_perpetual.py
+++ b/src/docket/dependencies/_perpetual.py
@@ -35,6 +35,10 @@ class Perpetual(CompletionHandler["Perpetual"]):
     async def my_task(perpetual: Perpetual = Perpetual()) -> None:
         ...
     ```
+
+    When testing perpetuals, use `Worker.run_at_most({key: N})` to bound iterations.
+    Unless the task cancels itself, `run_until_finished()` will not return for a task
+    that uses `Perpetual`, since the task usually reschedules itself on completion.
     """
 
     every: timedelta

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -403,7 +403,13 @@ class Worker:
                             pass
 
     async def run_until_finished(self) -> None:
-        """Run the worker until there are no more tasks to process."""
+        """Run the worker until there are no more tasks to process.
+
+        Note: this will not return if any task uses the `Perpetual` dependency
+        and does not cancel itself, since perpetuals usually reschedule themselves
+        on completion.  For testing perpetual tasks, use `run_at_most` to bound
+        iterations per key.
+        """
         return await self._run(forever=False)
 
     async def run_forever(self) -> None:
@@ -422,6 +428,13 @@ class Worker:
 
         Args:
             iterations_by_key: Maps task keys to their maximum allowed executions
+
+        Example:
+
+        ```python
+        execution = await docket.add(my_perpetual)()
+        await worker.run_at_most({execution.key: 3})
+        ```
         """
         self._execution_counts = {key: 0 for key in iterations_by_key}
 


### PR DESCRIPTION
Testing perpetual tasks needs `Worker.run_at_most({key: N})` rather than `run_until_finished()`, since perpetuals usually reschedule themselves on completion.  This was documented in `docs/testing.md` but invisible from the docstrings of `Perpetual`, `run_until_finished`, and `run_at_most`, which is where most readers (and AI agents) look first — so they reach for `run_until_finished()` and the test silently hangs.

Add the testing note to the `Perpetual` class docstring, expand the `run_until_finished` docstring with the hazard, give `run_at_most` a copy-pasteable example, add a "Testing perpetual tasks" subsection to the Perpetual section in `docs/task-behaviors.md`, and explain the *why* in the existing testing-guide section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)