### PR TITLE
Pin uncalled-for>=0.3.2 for bare-class Annotated shorthand

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -362,6 +362,36 @@ async def fetch_pages(
         await process_response(response)
 ```
 
+### As `Annotated` metadata
+
+When a dependency **wraps** the task's execution rather than supplying a value — tracing, validation, audit logging — attach it as `Annotated[T, ...]` metadata on the parameter you want to scope it to. Docket calls `bind_to_parameter(name, value)` so the dependency can capture context, then enters it as an async context manager around the task body. The parameter still receives its real value from the caller.
+
+```python
+from typing import Annotated, Any
+from docket.dependencies import Dependency
+
+class Traced(Dependency):
+    """Wraps the task body in a trace span tagged with the parameter."""
+
+    def bind_to_parameter(self, name: str, value: Any) -> "Traced":
+        copy = Traced()
+        copy._tag = (name, value)
+        return copy
+
+    async def __aenter__(self) -> None:
+        self._span = tracer.start_span("task", attributes=dict([self._tag]))
+
+    async def __aexit__(self, *exc: Any) -> None:
+        self._span.end()
+
+async def fetch_pages(
+    urls: Annotated[list[str], Traced],
+) -> None:
+    ...
+```
+
+For parameterless subclasses the bare class is shorthand: `Annotated[list[str], Traced]` and `Annotated[list[str], Traced()]` are equivalent.
+
 Inside `__aenter__`, you can access the current execution context through the
 module-level context variables `current_docket`, `current_worker`, and
 `current_execution`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "typer>=0.15.1",
     "typing_extensions>=4.12.0",
     "tzdata>=2025.2; sys_platform == 'win32'",
-    "uncalled-for>=0.2.0",
+    "uncalled-for>=0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_uncalled_for_contract.py
+++ b/tests/test_uncalled_for_contract.py
@@ -106,6 +106,29 @@ def test_extracts_from_multiple_parameters():
     assert "b" in deps
 
 
+def test_extracts_bare_dependency_class_from_annotated():
+    async def func(x: Annotated[int, StubDependency]) -> None: ...
+
+    deps = get_annotation_dependencies(func)
+
+    assert "x" in deps
+    assert len(deps["x"]) == 1
+    assert isinstance(deps["x"][0], StubDependency)
+
+
+def test_mixes_bare_class_and_instance_metadata():
+    async def func(
+        x: Annotated[int, StubDependency, TrackingDependency()],
+    ) -> None: ...
+
+    deps = get_annotation_dependencies(func)
+
+    assert "x" in deps
+    assert len(deps["x"]) == 2
+    assert isinstance(deps["x"][0], StubDependency)
+    assert isinstance(deps["x"][1], TrackingDependency)
+
+
 # --- get_dependency_parameters ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1569,7 +1569,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.15.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2025.2" },
-    { name = "uncalled-for", specifier = ">=0.2.0" },
+    { name = "uncalled-for", specifier = ">=0.3.2" },
 ]
 provides-extras = ["metrics"]
 
@@ -2113,11 +2113,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
uncalled-for 0.3.2 (chrisguidry/uncalled-for#9) accepts bare `Dependency` subclasses as `Annotated[T, ...]` metadata, instantiating them automatically — so `Annotated[UUID, MyDep]` works the same as `Annotated[UUID, MyDep()]` for parameterless subclasses.

Bump the pin to record the new minimum, add contract tests so we'd catch a regression in uncalled-for, and document the Annotated-metadata form in the dependency-injection guide (which previously only covered the default-value form for user `Dependency` subclasses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)