### PR TITLE
Add the audit-docs skill and apply its first findings

### DIFF
--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: audit-docs
+description: As you edit pydocket — change a function body, modify a signature, alter a Lua script, refactor a public method, rewrite a docs section — verify that the docstrings and narrative docs touching that change are still accurate, and fix them in the same edit. This is a habit, not a deliverable. Apply it continuously while working on `src/docket/`, `docs/*.md`, or `README.md`. Surface findings inline as you make changes; do not produce a separate "audit report" unless the user explicitly asks for one. Trigger phrases that mean the user wants the explicit audit-as-deliverable mode include "audit the docs", "check docstring drift", "produce an audit report", "are the docs still accurate".
+---
+
+# Keep docs honest as you work
+
+The default mode of this skill is integrated, not batch. While you're editing pydocket, watch for changes that could invalidate a docstring or a documentation section, and fix them in the same edit — same commit, same PR. The goal is to prevent drift from accumulating, not to clean it up later.
+
+If the user asks explicitly for an audit report (phrases like "audit the docs", "check docstring drift", "find stale documentation"), shift into the explicit report mode at the bottom of this file.
+
+## What counts as "touching" docs
+
+Any of these edits should make you re-read the affected docstring and any narrative-doc section that mentions the API:
+
+- Editing the body of a function/method/class that has a docstring.
+- Changing a function or method signature: added, removed, or renamed parameters; changed defaults; changed return type or shape.
+- Changing a Lua script in `src/docket/execution.py` or `src/docket/_redis.py` — atomicity, ordering, and consistency claims in docstrings are usually pinned to the Lua, not the Python.
+- Renaming or removing a public class, function, method, exception, or enum value.
+- Changing a public exception type, error message, or condition under which something is raised.
+- Changing a side effect on shared state (Redis keys, channels, sorted sets, streams).
+- Adding or removing a behavior callers might rely on (e.g., idempotency on duplicate inputs, retry semantics, cancellation behavior).
+- Editing a `## section` of a `docs/*.md` file or `README.md` — verify the surrounding code still does what the prose now claims.
+
+## What to check, in order
+
+When you've made one of the changes above:
+
+1. **The item's own docstring.** Read it. Does it still match what the code does? Watch specifically for:
+   - "raises X" claims when the code never raises X (or vice versa).
+   - "returns Y" descriptions when the code returns Z.
+   - Listed parameters or enum values that no longer exist.
+   - Behavior described in present tense that has actually changed.
+   - Silence on a load-bearing contract a caller would be surprised by — idempotency on duplicate keys is the canonical example: `Docket.add()` is idempotent on duplicate keys (no-ops), but the docstring used to be silent on that, leading callers to either avoid the pattern or learn it the hard way.
+2. **Tests that pin the contract.** If a test exists for the changed behavior, the test is the contract. When the docstring and the test disagree, the test wins (or both are wrong, in which case raise that with the user — don't paper over it). Useful test directories:
+   - `tests/fundamentals/` — core lifecycle, scheduling, retries, idempotency.
+   - `tests/concurrency_limits/`, `tests/cron/`, `tests/perpetual/`, `tests/debounce/`, `tests/cooldown/`, `tests/rate_limit/`, `tests/strike/` — corresponding dependency docstrings.
+3. **Call sites.** If a method's docstring says it raises an exception but the only caller never inspects the return value, the "raises" claim is suspect.
+4. **Narrative docs.** Grep `docs/*.md` and `README.md` for the symbol you changed. For each hit, read the surrounding section and verify the prose still matches the code.
+
+## How to fix
+
+Make the smallest edit that restores accuracy:
+
+- If a docstring asserts something the code doesn't do, replace just that claim. Don't rewrite the surrounding documentation.
+- If a docstring is silent on a load-bearing contract, add one terse sentence. Don't expand into a manual.
+- If a narrative docs section is now wrong, fix the wrong sentence(s). Don't restructure the section.
+- Never modify code to match a docstring — if the code is right and the docstring is wrong, fix the docstring; if the code is wrong, that's a separate decision to surface to the user.
+
+## What not to flag
+
+- **Stylistic differences.** If a docstring is accurate but you'd phrase it differently, leave it alone.
+- **Brevity.** A two-sentence docstring that's accurate is better than a paragraph that drifts. Don't expand a docstring just to mention every parameter.
+- **Imprecise but not misleading.** "Schedules a task" is fine even if the implementation is more nuanced — only flag claims that are wrong, not claims that are incomplete.
+- **`pydocket` vs `docket`.** The package is `pydocket` on PyPI; the import is `import docket`. Both terms appear deliberately throughout the docs. Don't "fix" one to the other.
+
+## Where this habit applies
+
+- **`src/docket/`** — every public class, function, method, and module with a docstring. Skip names with a leading underscore in any segment of the qualified name (except dunders), and skip the vendored modules: `_prometheus_exporter.py`, `_telemetry.py`, `_uuid7.py`.
+- **`docs/*.md`** — every section, except `docs/api-reference.md` (auto-rendered from source docstrings via mkdocstrings; auditing it separately would double-count).
+- **`README.md`** — top-level overview claims.
+
+## Quality gate
+
+After applying any doc edits, run:
+
+```bash
+uv run prek run --all-files
+```
+
+This covers ruff, ruff-format, codespell, loq (file-size limit), and pyright. Pure docstring edits should pass cleanly. If `loq` flags a file as over its limit because a docstring grew it past the threshold, prefer to *trim* the docstring before bumping the loq baseline.
+
+For a cheap behavior-preservation sanity check after touching a lot of docstrings, run:
+
+```bash
+REDIS_VERSION=memory uv run pytest -x --no-cov -q
+```
+
+Docstring edits shouldn't move the test suite — but the check is fast and catches accidents.
+
+## Explicit report mode
+
+If the user asks for a standalone audit ("audit the docs", "produce an audit report", "find every stale docstring"), switch styles:
+
+1. **Discover the surface.** `Glob` `src/docket/**/*.py` (skipping vendored modules) and walk each file for public docstrings. `Glob` `docs/*.md` and `README.md`, splitting markdown by `## ` headings.
+2. **Verify each item** using the rubric below — read the implementation, the embedded Lua where relevant, and at least one test before classifying as `stale` or `silent`.
+3. **Classify** each item:
+   - `accurate` — consistent with the code (default when in doubt).
+   - `stale` — asserts something the code does not do.
+   - `silent` — silent on a load-bearing contract callers measurably depend on, where the omission is non-obvious *and* surprising.
+   - `uncertain` — cannot determine after reading the implementation, the Lua, the tests, and the call sites.
+4. **Group findings by file** and present file:line + verdict + one-sentence explanation + suggested fix.
+5. **Offer to apply** only after the user has seen the report.
+
+The seed example for the report mode is `src/docket/execution.py` around `Execution.schedule`: the docstring says `replace=False` raises an error if the task already exists, but the Lua script returns `'EXISTS'`, the Python caller never inspects it, and `Docket.add` silently no-ops on duplicate keys (pinned by `tests/fundamentals/test_idempotency.py`). If a "find every stale docstring" run does *not* surface that item, the audit missed something.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,17 @@ uv run prek install
 - This project uses Github for issue tracking
 - This project can use git worktrees under .worktrees/
 
+### Keeping docs honest as you edit
+
+While editing `src/docket/`, `docs/*.md`, or `README.md`, follow the
+**`audit-docs`** skill at `.claude/skills/audit-docs/SKILL.md`. It is a
+*habit*, not a deliverable: when you change a function body, signature,
+Lua script, or any public contract, re-read the affected docstring and
+any narrative-docs section that mentions the API, and fix any drift in
+the same edit. The aim is to never let stale docstrings or wrong doc
+prose ride along to a PR. Only switch into the skill's standalone
+"report" mode if the user explicitly asks for an audit pass.
+
 ## Core Architecture
 
 ### Key Classes

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ async with Docket() as docket:
 from docket import Docket, Worker
 
 async with Docket() as docket:
+    docket.register(greet)
     async with Worker(docket) as worker:
-        worker.register(greet)
         await worker.run_until_finished()
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,7 +111,7 @@ await docket.replace(send_reminder, when=next_month, key=key)(
 await docket.cancel(key)
 ```
 
-Note that canceling only works for tasks scheduled in the future. Tasks that are ready for immediate execution cannot be canceled once they've been added to the processing queue.
+Cancellation is best-effort: tasks waiting in the stream or queue are removed atomically, but a task already running by the time the cancel arrives may complete before the signal is processed.
 
 ## Running Tasks: Workers
 
@@ -205,11 +205,10 @@ Long-running tasks can report their progress to provide visibility:
 
 ```python
 from docket import Progress
-from docket.execution import ExecutionProgress
 
 async def import_records(
     file_path: str,
-    progress: ExecutionProgress = Progress()
+    progress: Progress = Progress()
 ) -> None:
     records = await load_records(file_path)
     await progress.set_total(len(records))

--- a/docs/task-behaviors.md
+++ b/docs/task-behaviors.md
@@ -205,7 +205,7 @@ async def call_external_api(
         maximum_delay=timedelta(minutes=5)
     )
 ) -> None:
-    # Retries with delays: 1s, 2s, 4s, 8s, 16s (but capped at 5 minutes)
+    # Retries with delays: 1s, 2s, 4s, 8s (capped at 5 minutes)
     try:
         response = await http_client.get(url)
         response.raise_for_status()

--- a/loq.toml
+++ b/loq.toml
@@ -18,11 +18,11 @@ max_lines = 945
 
 [[rules]]
 path = "src/docket/execution.py"
-max_lines = 1012
+max_lines = 1014
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 861
+max_lines = 870
 
 [[rules]]
 path = "src/docket/_redis.py"

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -276,6 +276,9 @@ class Docket(DocketSnapshotMixin):
     ) -> Callable[P, Awaitable[Execution]]:
         """Add a task to the Docket.
 
+        If a task with the same key is already scheduled or running, this is
+        a no-op; use `replace()` to overwrite.
+
         Args:
             function: The task function to add.
             when: The time to schedule the task.
@@ -291,6 +294,9 @@ class Docket(DocketSnapshotMixin):
     ) -> Callable[..., Awaitable[Execution]]:
         """Add a task to the Docket.
 
+        If a task with the same key is already scheduled or running, this is
+        a no-op; use `replace()` to overwrite.
+
         Args:
             function: The name of a task to add.
             when: The time to schedule the task.
@@ -304,6 +310,9 @@ class Docket(DocketSnapshotMixin):
         key: str | None = None,
     ) -> Callable[..., Awaitable[Execution]]:
         """Add a task to the Docket.
+
+        If a task with the same key is already scheduled or running, this is
+        a no-op; use `replace()` to overwrite.
 
         Args:
             function: The task to add.

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -301,7 +301,8 @@ class Execution:
 
         Args:
             replace: If True, replaces any existing task with the same key.
-                    If False, raises an error if the task already exists.
+                    If False and the task already exists, this is a no-op
+                    (the existing schedule is preserved).
             reschedule_message: If provided, atomically acknowledges and deletes
                     this stream message ID before rescheduling the task to the queue.
                     Used when a task needs to be rescheduled from an active stream message.
@@ -771,6 +772,7 @@ class Execution:
 
         Raises:
             ValueError: If both timeout and deadline are provided
+            ExecutionCancelled: If the execution was cancelled before completing
             Exception: If the task failed, raises the stored exception
             TimeoutError: If timeout/deadline is reached before execution completes
         """


### PR DESCRIPTION
Introduces a habit-style skill at `.claude/skills/audit-docs/SKILL.md` that keeps docstrings and narrative docs in sync with the code. As you edit a function body, signature, Lua script, or any public contract, the skill asks you to re-read the affected docstring and any narrative-doc section that mentions the API, and fix any drift in the same edit — so stale docs don't ride along to a PR. `AGENTS.md` gets a short pointer so future agents see it.

The skill also has a standalone "report" mode for one-shot audit passes. Running that against this branch surfaced seven items, all applied here:

- `Execution.schedule` said `replace=False` raises on duplicate keys; in fact the Lua returns `'EXISTS'` silently and `Docket.add` never inspects it (pinned by `tests/fundamentals/test_idempotency.py`).
- `Docket.add` (all three overloads) was silent on this idempotency contract — production callers downstream depend on same-key adds being no-ops.
- `Execution.get_result`'s `Raises` section was missing `ExecutionCancelled`.
- README's quick-start called `worker.register()`; that method lives on `Docket`, not `Worker`.
- `getting-started.md` said immediate tasks can't be cancelled, but `Docket.cancel` does `XDEL` on stream messages and signals running tasks.
- `getting-started.md`'s `Progress` example was annotated `ExecutionProgress`, but `Progress.__aenter__` returns a `Progress` instance.
- `task-behaviors.md`'s `ExponentialRetry` comment listed 1s/2s/4s/8s/16s for `attempts=5`, but only four delays apply between five attempts.

The docstring additions pushed `docket.py` and `execution.py` just over their loq baselines; bumped accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)