### PR TITLE
Surface a disposition on Execution to confirm the handoff

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,21 @@ async with Docket() as docket:
     await docket.add(process_order, key=key)(12345)  # Ignored - key already exists
 ```
 
+If you need to confirm whether your call actually placed a task or was a no-op (for audit logs, dead-man switches, or any handoff where safety matters), inspect the returned execution's `disposition`:
+
+```python
+from docket import Disposition
+
+execution = await docket.add(process_order, key=key)(12345)
+
+if execution.disposition is Disposition.SCHEDULED:
+    log.info("handoff confirmed", key=execution.key)
+elif execution.disposition is Disposition.ALREADY_SCHEDULED:
+    log.info("duplicate handoff, prior schedule preserved", key=execution.key)
+elif execution.disposition is Disposition.STRUCK:
+    log.warning("blocked by a strike rule", key=execution.key)
+```
+
 This is especially valuable for web APIs where client retries or network issues might cause the same request to arrive multiple times:
 
 ```python

--- a/loq.toml
+++ b/loq.toml
@@ -18,11 +18,11 @@ max_lines = 945
 
 [[rules]]
 path = "src/docket/execution.py"
-max_lines = 1014
+max_lines = 1057
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 870
+max_lines = 902
 
 [[rules]]
 path = "src/docket/_redis.py"

--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -31,7 +31,7 @@ from .dependencies import (
     Timeout,
 )
 from .docket import Docket
-from .execution import Execution, ExecutionCancelled, ExecutionState
+from .execution import Disposition, Execution, ExecutionCancelled, ExecutionState
 from .strikelist import StrikeList
 from .worker import Worker
 from . import testing
@@ -48,6 +48,7 @@ __all__ = [
     "CurrentExecution",
     "CurrentWorker",
     "Depends",
+    "Disposition",
     "Docket",
     "Execution",
     "ExecutionCancelled",

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -41,6 +41,7 @@ from ._redis import (
 from ._result_store import ResultStorage
 from ._uuid7 import uuid7
 from .execution import (
+    Disposition,
     Execution,
     TaskFunction,
 )
@@ -318,6 +319,15 @@ class Docket(DocketSnapshotMixin):
             function: The task to add.
             when: The time to schedule the task.
             key: The key to schedule the task under.
+
+        Returns:
+            A callable that, when invoked with the task's arguments, returns
+            an :class:`Execution`. The returned execution's ``disposition``
+            reports the outcome of the scheduling attempt:
+            ``Disposition.SCHEDULED`` if the task was placed,
+            ``Disposition.ALREADY_SCHEDULED`` if a task with the same key was
+            already known and the prior schedule was preserved, or
+            ``Disposition.STRUCK`` if a strike rule blocked the call.
         """
         function_name: str | None = None
         if isinstance(function, str):
@@ -351,7 +361,7 @@ class Docket(DocketSnapshotMixin):
                     **execution.specific_labels(),
                     "code.function.name": execution.function_name,
                 },
-            ):
+            ) as span:
                 # Check if task is stricken before scheduling
                 if self.strike_list.is_stricken(execution):
                     logger.warning(
@@ -367,13 +377,19 @@ class Docket(DocketSnapshotMixin):
                             "docket.where": "docket",
                         },
                     )
+                    execution.disposition = Disposition.STRUCK
+                    span.set_attribute(
+                        "docket.disposition", execution.disposition.value
+                    )
                     return execution
 
                 # Schedule atomically (includes state record write)
                 await execution.schedule(replace=False)
+                span.set_attribute("docket.disposition", execution.disposition.value)
 
             TASKS_ADDED.add(1, {**self.labels(), **execution.general_labels()})
-            TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
+            if execution.disposition is Disposition.SCHEDULED:
+                TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
 
             return execution
 
@@ -421,6 +437,13 @@ class Docket(DocketSnapshotMixin):
             function: The task to replace.
             when: The time to schedule the task.
             key: The key to schedule the task under.
+
+        Returns:
+            A callable that, when invoked with the task's arguments, returns
+            an :class:`Execution`. The returned execution's ``disposition`` is
+            ``Disposition.SCHEDULED`` if the task was placed (overwriting any
+            prior schedule for ``key``), or ``Disposition.STRUCK`` if a strike
+            rule blocked the call.
         """
         function_name: str | None = None
         if isinstance(function, str):
@@ -448,7 +471,7 @@ class Docket(DocketSnapshotMixin):
                     **execution.specific_labels(),
                     "code.function.name": execution.function_name,
                 },
-            ):
+            ) as span:
                 # Check if task is stricken before scheduling
                 if self.strike_list.is_stricken(execution):
                     logger.warning(
@@ -464,10 +487,15 @@ class Docket(DocketSnapshotMixin):
                             "docket.where": "docket",
                         },
                     )
+                    execution.disposition = Disposition.STRUCK
+                    span.set_attribute(
+                        "docket.disposition", execution.disposition.value
+                    )
                     return execution
 
                 # Schedule atomically (includes state record write)
                 await execution.schedule(replace=True)
+                span.set_attribute("docket.disposition", execution.disposition.value)
 
             TASKS_REPLACED.add(1, {**self.labels(), **execution.general_labels()})
             TASKS_CANCELLED.add(1, {**self.labels(), **execution.general_labels()})
@@ -485,7 +513,7 @@ class Docket(DocketSnapshotMixin):
                 **execution.specific_labels(),
                 "code.function.name": execution.function_name,
             },
-        ):
+        ) as span:
             # Check if task is stricken before scheduling
             if self.strike_list.is_stricken(execution):
                 logger.warning(
@@ -501,12 +529,16 @@ class Docket(DocketSnapshotMixin):
                         "docket.where": "docket",
                     },
                 )
+                execution.disposition = Disposition.STRUCK
+                span.set_attribute("docket.disposition", execution.disposition.value)
                 return
 
             # Schedule atomically (includes state record write)
             await execution.schedule(replace=False)
+            span.set_attribute("docket.disposition", execution.disposition.value)
 
-        TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
+        if execution.disposition is Disposition.SCHEDULED:
+            TASKS_SCHEDULED.add(1, {**self.labels(), **execution.general_labels()})
 
     async def cancel(self, key: str) -> None:
         """Cancel a previously scheduled task on the Docket.

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -57,7 +57,7 @@ Message = dict[bytes, bytes]
 class _schedule_task(Protocol):
     async def __call__(
         self, keys: list[str], args: list[str | float | bytes]
-    ) -> str: ...  # pragma: no cover
+    ) -> bytes | str: ...  # pragma: no cover
 
 
 def get_signature(function: Callable[..., Any]) -> inspect.Signature:
@@ -86,6 +86,32 @@ class ExecutionState(enum.Enum):
 
     CANCELLED = "cancelled"
     """Task was explicitly cancelled before completion."""
+
+
+class Disposition(enum.Enum):
+    """Outcome of a scheduling attempt for an Execution.
+
+    This is distinct from ExecutionState: ExecutionState tracks the lifecycle
+    of the task itself (scheduled → queued → running → completed / failed /
+    cancelled), while Disposition records what happened the moment a caller
+    tried to schedule it via Docket.add or Docket.replace.
+    """
+
+    LOADED = "loaded"
+    """This Execution was not produced by a fresh scheduling attempt. Default
+    for any Execution constructed outside of ``Docket.add`` / ``Docket.replace``
+    (for example, one reconstructed from a stream message inside the worker)."""
+
+    SCHEDULED = "scheduled"
+    """The task was placed on the queue (or stream, for immediate tasks)."""
+
+    ALREADY_SCHEDULED = "already_scheduled"
+    """A task with the same key was already known to the docket; the prior
+    schedule was preserved and this attempt was a no-op. Only possible with
+    ``Docket.add`` (``Docket.replace`` overwrites)."""
+
+    STRUCK = "struck"
+    """A strike rule blocked the call before any Redis state was touched."""
 
 
 class Execution:
@@ -131,6 +157,7 @@ class Execution:
         self.completed_at: datetime | None = None
         self.error: str | None = None
         self.result_key: str | None = None
+        self.disposition: Disposition = Disposition.LOADED
 
         # Progress tracking
         self.progress: ExecutionProgress = ExecutionProgress(docket, key)
@@ -283,7 +310,7 @@ class Execution:
 
     async def schedule(
         self, replace: bool = False, reschedule_message: "RedisMessageID | None" = None
-    ) -> None:
+    ) -> Disposition:
         """Schedule this task atomically in Redis.
 
         This performs an atomic operation that:
@@ -306,6 +333,13 @@ class Execution:
             reschedule_message: If provided, atomically acknowledges and deletes
                     this stream message ID before rescheduling the task to the queue.
                     Used when a task needs to be rescheduled from an active stream message.
+
+        Returns:
+            ``Disposition.SCHEDULED`` if the task was placed on the queue/stream,
+            or ``Disposition.ALREADY_SCHEDULED`` if a task with the same key was
+            already known and ``replace=False`` (in which case the existing
+            schedule is preserved and no local state changes are published).
+            Sets ``self.disposition`` to the same value.
         """
         message: dict[bytes, bytes] = self.as_message()
         propagate.inject(message, setter=message_setter)
@@ -479,7 +513,7 @@ class Execution:
                     ),
                 )
 
-                await schedule_script(
+                reply = await schedule_script(
                     keys=[
                         self.docket.stream_key,
                         known_task_key,
@@ -503,6 +537,12 @@ class Execution:
                     ],
                 )
 
+        if reply in (b"EXISTS", "EXISTS"):
+            # The Lua script kept the prior schedule untouched; leave local
+            # state alone and do not publish a misleading state event.
+            self.disposition = Disposition.ALREADY_SCHEDULED
+            return self.disposition
+
         # Update local state based on whether task is immediate, scheduled, or being rescheduled
         if reschedule_message:
             # When rescheduling from stream, task is always parked and queued (never immediate)
@@ -520,6 +560,9 @@ class Execution:
             await self._publish_state(
                 {"state": ExecutionState.SCHEDULED.value, "when": when.isoformat()}
             )
+
+        self.disposition = Disposition.SCHEDULED
+        return self.disposition
 
     async def claim(self, worker: str) -> bool:
         """Atomically check supersession and claim task in a single round-trip.

--- a/tests/fundamentals/test_idempotency.py
+++ b/tests/fundamentals/test_idempotency.py
@@ -5,7 +5,7 @@ from typing import Callable
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
-from docket import Docket, Worker, testing
+from docket import Disposition, Docket, Worker, testing
 
 
 async def test_adding_is_idempotent(
@@ -99,3 +99,35 @@ async def test_task_keys_are_idempotent_in_the_present(
     await worker.run_until_finished()
 
     the_task.assert_awaited_once_with("d", "e", c="f")
+
+
+async def test_disposition_reports_whether_a_handoff_was_accepted(
+    docket: Docket, the_task: AsyncMock
+):
+    """The Execution returned by docket.add reports whether the call actually
+    placed a task on the queue or was a no-op because a task with the same
+    key was already known."""
+
+    key = f"my-cool-task:{uuid4()}"
+
+    first = await docket.add(the_task, key=key)("first")
+    assert first.disposition is Disposition.SCHEDULED
+
+    second = await docket.add(the_task, key=key)("second")
+    assert second.disposition is Disposition.ALREADY_SCHEDULED
+
+
+async def test_replace_disposition_is_always_scheduled(
+    docket: Docket, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """docket.replace overwrites any prior schedule for the key, so its
+    disposition is always SCHEDULED (the no-op path doesn't apply)."""
+
+    key = f"my-cool-task:{uuid4()}"
+    soon = now() + timedelta(seconds=60)
+
+    first = await docket.add(the_task, when=soon, key=key)("first")
+    assert first.disposition is Disposition.SCHEDULED
+
+    second = await docket.replace(the_task, when=soon, key=key)("second")
+    assert second.disposition is Disposition.SCHEDULED

--- a/tests/fundamentals/test_striking.py
+++ b/tests/fundamentals/test_striking.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, call
 
-from docket import Docket, Worker
+from docket import Disposition, Docket, Worker
 from tests._key_leak_checker import KeyCountChecker
 
 
@@ -221,3 +221,17 @@ async def test_striking_tasks_for_specific_parameters(
         ],
         any_order=True,
     )
+
+
+async def test_disposition_reports_struck_on_blocked_add(
+    docket: Docket, the_task: AsyncMock
+):
+    """When a strike rule blocks a docket.add, the returned Execution reports
+    Disposition.STRUCK so callers can distinguish a refused handoff from a
+    successful one without inspecting Redis."""
+
+    await docket.strike(the_task)
+
+    execution = await docket.add(the_task)("anything")
+
+    assert execution.disposition is Disposition.STRUCK

--- a/tests/test_docket_execution.py
+++ b/tests/test_docket_execution.py
@@ -48,6 +48,29 @@ async def test_docket_schedule_with_stricken_task(docket: Docket, the_task: Asyn
     assert len(snapshot.future) == 0
 
 
+async def test_docket_schedule_is_idempotent_per_key(
+    docket: Docket, the_task: AsyncMock
+):
+    """A second docket.schedule for the same key is a no-op; the prior
+    schedule is preserved and the new execution reports ALREADY_SCHEDULED."""
+    from docket import Disposition
+
+    docket.register(the_task)
+
+    when = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    first = Execution(docket, the_task, ("first",), {}, "dup-key", when, 1)
+    await docket.schedule(first)
+    assert first.disposition is Disposition.SCHEDULED
+
+    second = Execution(docket, the_task, ("second",), {}, "dup-key", when, 1)
+    await docket.schedule(second)
+    assert second.disposition is Disposition.ALREADY_SCHEDULED
+
+    snapshot = await docket.snapshot()
+    assert len(snapshot.future) == 1
+
+
 async def test_get_execution_nonexistent_key(docket: Docket):
     """get_execution should return None for non-existent key."""
     execution = await docket.get_execution("nonexistent-key")


### PR DESCRIPTION
## Summary

Today, `Docket.add()` returns the same `Execution` whether the call actually placed a task on the queue, was a no-op because a task with the same key was already known, or was blocked by a strike rule. The Lua script already distinguishes `'OK'` from `'EXISTS'` but the result is dropped, and strikes are caught earlier in Python without surfacing back to the caller. For systems where handoff confirmation matters (audit logs, dead-man switches, "did the backstop actually take over"), this opacity forces a second round-trip to Redis or trusting the call without verification.

This adds a `disposition: Disposition` attribute on `Execution` that names the outcome of the scheduling attempt:

- `Disposition.SCHEDULED` — the task was placed on the queue (or stream)
- `Disposition.ALREADY_SCHEDULED` — a task with the same key was already known; the prior schedule was preserved (only with `replace=False`)
- `Disposition.STRUCK` — a strike rule blocked the call before any Redis state was touched
- `Disposition.LOADED` — default for an Execution that wasn't produced by a fresh `add` / `replace` (e.g. one reconstructed from a stream message inside the worker)

Disposition is in-memory only — it's not persisted to Redis or carried in messages.

## Drift fixes that ride along

- The `docket.add` / `docket.replace` OTel spans now record the actual disposition as `docket.disposition`, instead of always implying success.
- `Execution.schedule()` no longer updates local state or publishes a "this execution is queued" event when the call was actually a no-op due to an existing task.
- `TASKS_SCHEDULED` fires only when the task was really scheduled. `TASKS_ADDED` still fires on every attempt, so the `ALREADY_SCHEDULED` count is derivable as `TASKS_ADDED - TASKS_SCHEDULED - TASKS_STRICKEN`. If anything is dashboarding on `TASKS_SCHEDULED` today and expects it to count every `add()`, that count will now be lower by the prior over-count.

## Usage

```python
from docket import Disposition

execution = await docket.add(process_order, key=key)(12345)

if execution.disposition is Disposition.SCHEDULED:
    log.info("handoff confirmed", key=execution.key)
elif execution.disposition is Disposition.ALREADY_SCHEDULED:
    log.info("duplicate handoff, prior schedule preserved", key=execution.key)
elif execution.disposition is Disposition.STRUCK:
    log.warning("blocked by a strike rule", key=execution.key)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)