### PR TITLE
Let Agenda callers supply their own task keys

### DIFF
--- a/docs/task-patterns.md
+++ b/docs/task-patterns.md
@@ -121,6 +121,30 @@ agenda.add(process_item)(item_id=42)
 await agenda.scatter(docket, over=timedelta(minutes=10))
 ```
 
+### Idempotent Scatter with Stable Keys
+
+By default, every task scattered from an `Agenda` is assigned a fresh `uuid7`
+key, so re-running the same find-and-flood job enqueues a duplicate batch.
+Pass an explicit `key` to `Agenda.add()` when you have a stable identifier
+for each unit of work — re-scattering then becomes idempotent, because the
+Docket preserves the existing schedule for any key it already knows:
+
+```python
+agenda = Agenda()
+for item in items_needing_processing:
+    agenda.add(process_item, key=f"process-item:{item.id}")(item.id)
+
+executions = await agenda.scatter(docket, over=timedelta(minutes=10))
+
+# Running the same scan again — anything still pending stays where it was.
+executions = await agenda.scatter(docket, over=timedelta(minutes=10))
+```
+
+Each returned `Execution` carries a `disposition` (`SCHEDULED`,
+`ALREADY_SCHEDULED`, or `STRUCK`) so you can tell which tasks were newly
+placed and which were no-ops. Explicit and generated keys can be mixed
+freely inside the same agenda.
+
 ### Agenda Reusability
 
 Agendas can be reused for multiple scatter operations:

--- a/src/docket/agenda.py
+++ b/src/docket/agenda.py
@@ -30,12 +30,19 @@ class Agenda:
         >>> agenda.add(process_item)(item2)
         >>> agenda.add(send_email)(email)
         >>> await agenda.scatter(docket, over=timedelta(minutes=50))
+
+        Pass a stable ``key`` to make a re-scatter idempotent — the second
+        scatter will preserve the first schedule rather than enqueue a
+        duplicate::
+
+            >>> for item in items:
+            ...     agenda.add(process_item, key=f"item-{item.id}")(item)
     """
 
     def __init__(self) -> None:
         """Initialize an empty Agenda."""
         self._tasks: list[
-            tuple[TaskFunction | str, tuple[Any, ...], dict[str, Any]]
+            tuple[TaskFunction | str, tuple[Any, ...], dict[str, Any], str | None]
         ] = []
 
     def __len__(self) -> int:
@@ -44,7 +51,9 @@ class Agenda:
 
     def __iter__(
         self,
-    ) -> Iterator[tuple[TaskFunction | str, tuple[Any, ...], dict[str, Any]]]:
+    ) -> Iterator[
+        tuple[TaskFunction | str, tuple[Any, ...], dict[str, Any], str | None]
+    ]:
         """Iterate over tasks in the agenda."""
         return iter(self._tasks)
 
@@ -52,11 +61,17 @@ class Agenda:
     def add(
         self,
         function: Callable[P, Awaitable[R]],
+        key: str | None = None,
     ) -> Callable[P, None]:
         """Add a task function to the agenda.
 
         Args:
             function: The task function to add.
+            key: Optional explicit key for the scheduled execution. If omitted,
+                a fresh uuid7 is generated at scatter time. Supplying a stable
+                key makes a re-scatter of this entry idempotent against the
+                Docket — a colliding key preserves the prior schedule rather
+                than queuing a duplicate.
 
         Returns:
             A callable that accepts the task arguments.
@@ -66,11 +81,17 @@ class Agenda:
     def add(
         self,
         function: str,
+        key: str | None = None,
     ) -> Callable[..., None]:
         """Add a task by name to the agenda.
 
         Args:
             function: The name of a registered task.
+            key: Optional explicit key for the scheduled execution. If omitted,
+                a fresh uuid7 is generated at scatter time. Supplying a stable
+                key makes a re-scatter of this entry idempotent against the
+                Docket — a colliding key preserves the prior schedule rather
+                than queuing a duplicate.
 
         Returns:
             A callable that accepts the task arguments.
@@ -79,18 +100,21 @@ class Agenda:
     def add(
         self,
         function: Callable[P, Awaitable[R]] | str,
+        key: str | None = None,
     ) -> Callable[..., None]:
         """Add a task to the agenda.
 
         Args:
             function: The task function or name to add.
+            key: Optional explicit key for the scheduled execution. If omitted,
+                a fresh uuid7 is generated at scatter time.
 
         Returns:
             A callable that accepts the task arguments and adds them to the agenda.
         """
 
         def scheduler(*args: Any, **kwargs: Any) -> None:
-            self._tasks.append((function, args, kwargs))
+            self._tasks.append((function, args, kwargs, key))
 
         return scheduler
 
@@ -162,41 +186,30 @@ class Agenda:
                 jittered_times.append(jittered_time)
             schedule_times = jittered_times
 
-        # Build all Execution objects first, validating as we go
-        executions: list[Execution] = []
-        for (task_func, args, kwargs), schedule_time in zip(
+        # Validate and resolve every task first, so an unregistered name fails
+        # before we schedule anything.
+        planned: list[
+            tuple[TaskFunction, tuple[Any, ...], dict[str, Any], str, datetime]
+        ] = []
+        for (task_func, args, kwargs, explicit_key), schedule_time in zip(
             self._tasks, schedule_times
         ):
-            # Resolve task function if given by name
             if isinstance(task_func, str):
                 if task_func not in docket.tasks:
                     raise KeyError(f"Task '{task_func}' is not registered")
                 resolved_func = docket.tasks[task_func]
             else:
-                # Ensure task is registered
                 if task_func not in docket.tasks.values():
                     docket.register(task_func)
                 resolved_func = task_func
 
-            # Create execution with unique key
-            key = str(uuid7())
-            execution = Execution(
-                docket=docket,
-                function=resolved_func,
-                args=args,
-                kwargs=kwargs,
-                key=key,
-                when=schedule_time,
-                attempt=1,
-            )
-            executions.append(execution)
+            key = explicit_key if explicit_key is not None else str(uuid7())
+            planned.append((resolved_func, args, kwargs, key, schedule_time))
 
-        # Schedule all tasks - if any fail, some tasks may have been scheduled
-        for execution in executions:
-            scheduler = docket.add(
-                execution.function, when=execution.when, key=execution.key
-            )
-            # Actually schedule the task - if this fails, earlier tasks remain scheduled
-            await scheduler(*execution.args, **execution.kwargs)
+        # Schedule each task; if one fails partway, earlier ones stay scheduled.
+        executions: list[Execution] = []
+        for resolved_func, args, kwargs, key, schedule_time in planned:
+            scheduler = docket.add(resolved_func, when=schedule_time, key=key)
+            executions.append(await scheduler(*args, **kwargs))
 
         return executions

--- a/tests/test_agenda.py
+++ b/tests/test_agenda.py
@@ -6,6 +6,7 @@ import pytest
 
 from docket import Docket
 from docket.agenda import Agenda
+from docket.execution import Disposition
 
 
 @pytest.fixture
@@ -29,6 +30,7 @@ async def test_agenda_add_single_task(agenda: Agenda, the_task: AsyncMock):
     assert tasks[0][0] == the_task
     assert tasks[0][1] == ("arg1",)
     assert tasks[0][2] == {"kwarg1": "value1"}
+    assert tasks[0][3] is None
 
 
 async def test_agenda_add_multiple_tasks(
@@ -389,6 +391,82 @@ async def test_agenda_scatter_auto_registers_unregistered_functions(
     # Verify tasks were scheduled
     snapshot = await docket.snapshot()
     assert len(snapshot.future) == 2
+
+
+async def test_agenda_add_records_explicit_key(agenda: Agenda, the_task: AsyncMock):
+    """An explicit key on add() should be retained on the agenda tuple."""
+    agenda.add(the_task, key="stable-1")("arg1")
+    agenda.add(the_task)("arg2")
+
+    tasks = list(agenda)
+    assert tasks[0] == (the_task, ("arg1",), {}, "stable-1")
+    assert tasks[1] == (the_task, ("arg2",), {}, None)
+
+
+async def test_agenda_scatter_uses_explicit_keys(
+    docket: Docket, agenda: Agenda, the_task: AsyncMock
+):
+    """Explicit keys should flow through to the resulting Execution.key."""
+    docket.register(the_task)
+
+    agenda.add(the_task, key="item-1")("one")
+    agenda.add(the_task, key="item-2")("two")
+
+    executions = await agenda.scatter(docket, over=timedelta(seconds=30))
+
+    assert [e.key for e in executions] == ["item-1", "item-2"]
+
+
+async def test_agenda_scatter_explicit_key_is_idempotent(
+    docket: Docket, agenda: Agenda, the_task: AsyncMock
+):
+    """Rescattering with the same explicit keys should not duplicate tasks."""
+    docket.register(the_task)
+
+    agenda.add(the_task, key="item-1")("one")
+    agenda.add(the_task, key="item-2")("two")
+
+    first = await agenda.scatter(docket, over=timedelta(seconds=30))
+    assert all(e.disposition is Disposition.SCHEDULED for e in first)
+
+    second = await agenda.scatter(docket, over=timedelta(seconds=30))
+    assert all(e.disposition is Disposition.ALREADY_SCHEDULED for e in second)
+
+    snapshot = await docket.snapshot()
+    assert len(snapshot.future) == 2
+
+
+async def test_agenda_scatter_mixes_explicit_and_generated_keys(
+    docket: Docket, agenda: Agenda, the_task: AsyncMock
+):
+    """Tasks without a key should still get a generated uuid7."""
+    docket.register(the_task)
+
+    agenda.add(the_task, key="stable")("one")
+    agenda.add(the_task)("two")
+
+    executions = await agenda.scatter(docket, over=timedelta(seconds=30))
+
+    assert executions[0].key == "stable"
+    assert executions[1].key != "stable"
+    assert len(executions[1].key) > 0
+
+
+async def test_agenda_add_by_name_with_key(
+    docket: Docket, agenda: Agenda, the_task: AsyncMock
+):
+    """Adding a task by name should also accept an explicit key."""
+    docket.register(the_task)
+
+    agenda.add("the_task", key="named-key")("arg1", flag=True)
+
+    executions = await agenda.scatter(docket, over=timedelta(seconds=30))
+
+    assert len(executions) == 1
+    assert executions[0].key == "named-key"
+    assert executions[0].function == the_task
+    assert executions[0].args == ("arg1",)
+    assert executions[0].kwargs == {"flag": True}
 
 
 async def test_agenda_clear(agenda: Agenda, the_task: AsyncMock):


### PR DESCRIPTION
`Agenda.scatter` hardcoded `str(uuid7())` for every execution key, so a
re-run of a find-and-flood job enqueued a duplicate batch — there was no
way to express "this task represents item N, schedule it once."

`Agenda.add(func, key=...)` now accepts an optional explicit key.
Omitting it keeps the per-scatter uuid7 default (so the reusable-agenda
pattern in `test_agenda_reusability` still gets fresh keys per scatter).
Passing one routes straight through to `docket.add(..., key=...)`,
making a re-scatter idempotent — colliding keys yield
`Disposition.ALREADY_SCHEDULED` and the prior schedule is preserved.

While wiring tests for that I noticed `scatter()` was building its own
`Execution` objects up front and then ignoring the ones `docket.add()`
returns, so the returned executions always carried the default
`LOADED` disposition. Reworked the loop to collect the executions
`docket.add()` actually returns; validation-first ordering (so an
unregistered name fails before anything is scheduled) is preserved.

Heads-up for anyone iterating an `Agenda`: the internal tuple is now
4-wide (`func, args, kwargs, key | None`) instead of 3-wide. The
`__iter__` type hint reflects that.

## Coverage caveat

Locally `pytest` reports 99.96% coverage on this branch, missing two
lines each in `worker.py:653->651` and
`dependencies/_concurrency.py:679-695, 685-686`. I verified the same
gap exists on a clean `main` checkout with the same seed, so it's not
caused by this change — but it may block the 100% gate. Curious to see
whether CI hits it too or whether it's seed-specific to my box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)