### PR TITLE
Lock in regression coverage for implicit invariants in the recent Lua refactor

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -18,7 +18,7 @@ max_lines = 945
 
 [[rules]]
 path = "src/docket/execution.py"
-max_lines = 1179
+max_lines = 1190
 
 [[rules]]
 path = "src/docket/docket.py"

--- a/src/docket/_execution_progress.py
+++ b/src/docket/_execution_progress.py
@@ -1,5 +1,6 @@
 """Progress tracking for task executions."""
 
+import asyncio
 import json
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -246,8 +247,17 @@ class ExecutionProgress:
         }
         await self.docket._publish(channel, json.dumps(payload))
 
-    async def subscribe(self) -> AsyncGenerator[ProgressEvent, None]:
+    async def subscribe(
+        self, *, ready: asyncio.Event | None = None
+    ) -> AsyncGenerator[ProgressEvent, None]:
         """Subscribe to progress updates for this task.
+
+        Args:
+            ready: Optional ``asyncio.Event`` that is ``set()`` once the
+                Redis ``SUBSCRIBE`` has been acknowledged.  Lets callers
+                deterministically wait until the subscription is live
+                before publishing -- avoids the race where early events
+                are dropped because the subscriber hadn't connected yet.
 
         Yields:
             Dict containing progress update events with fields:
@@ -261,6 +271,8 @@ class ExecutionProgress:
         channel = self.docket.key(f"progress:{self.key}")
         async with self.docket._pubsub() as pubsub:
             await pubsub.subscribe(channel)
+            if ready is not None:
+                ready.set()
             async for message in pubsub.listen():  # pragma: no cover
                 if message["type"] == "message":
                     yield json.loads(message["data"])

--- a/src/docket/_lua.py
+++ b/src/docket/_lua.py
@@ -122,7 +122,18 @@ def _encode_scalar(value: Any) -> str | bytes | int | float:
         return "1" if value else "0"
     if isinstance(value, (int, float)):
         return str(value)
-    return value
+    if isinstance(value, (str, bytes)):
+        return value
+    # The ``Arg[T]`` / ``Args[T]`` TypeVar bounds catch unsupported types
+    # at decoration time, but a payload dict built dynamically (e.g. the
+    # ``extra_fields`` list in ``_terminal``) can still smuggle a ``None``
+    # or other unsupported value through at call time.  Reject it here
+    # so the failure surfaces with a precise local message instead of an
+    # opaque ``DataError`` from redis-py several frames down.
+    raise TypeError(
+        f"@redis_script value must be str/bytes/int/float/bool, "
+        f"got {type(value).__name__}: {value!r}"
+    )
 
 
 def _expand_args(value: Any) -> list[Any]:

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -1094,11 +1094,20 @@ class Execution:
         current_gen = int(current) if current is not None else 0
         return current_gen > self._generation
 
-    async def subscribe(self) -> AsyncGenerator[StateEvent | ProgressEvent, None]:
+    async def subscribe(
+        self, *, ready: asyncio.Event | None = None
+    ) -> AsyncGenerator[StateEvent | ProgressEvent, None]:
         """Subscribe to both state and progress updates for this task.
 
         Emits the current state as the first event, then subscribes to real-time
         state and progress updates via Redis pub/sub.
+
+        Args:
+            ready: Optional ``asyncio.Event`` that is ``set()`` once the
+                Redis ``SUBSCRIBE`` has been acknowledged.  Lets callers
+                deterministically wait until the subscription is live
+                before publishing -- avoids the race where early events
+                are dropped because the subscriber hadn't connected yet.
 
         Yields:
             Dict containing state or progress update events with a 'type' field:
@@ -1142,6 +1151,8 @@ class Execution:
         progress_channel = self.docket.key(f"progress:{self.key}")
         async with self.docket._pubsub() as pubsub:
             await pubsub.subscribe(state_channel, progress_channel)
+            if ready is not None:
+                ready.set()
             async for message in pubsub.listen():  # pragma: no cover
                 if message["type"] == "message":
                     message_data = json.loads(message["data"])

--- a/tests/cli/test_snapshot.py
+++ b/tests/cli/test_snapshot.py
@@ -14,6 +14,24 @@ from docket.docket import Docket, DocketSnapshot
 from docket.worker import Worker
 from tests._key_leak_checker import KeyCountChecker
 from tests.cli.run import run_cli
+from tests.conftest import wait_until
+
+
+async def _running_count_at_least(docket: Docket, expected: int) -> None:
+    """Block until ``docket.snapshot().running`` has at least ``expected``
+    entries.  Used in place of "let worker pick up task" sleeps so the
+    CLI assertion that follows doesn't race the worker on slow runners.
+    """
+
+    async def has_enough() -> bool:
+        snap = await docket.snapshot()
+        return len(snap.running) >= expected
+
+    await wait_until(
+        has_enough,
+        description=f"at least {expected} running task(s) in the snapshot",
+    )
+
 
 # Skip CLI tests when using memory backend since CLI rejects memory:// URLs
 pytestmark = pytest.mark.skipif(
@@ -78,7 +96,7 @@ async def test_snapshot_with_running_tasks(
     async with Worker(docket, name="test-worker") as worker:
         worker_running = asyncio.create_task(worker.run_until_finished())
 
-        await asyncio.sleep(0.05)  # Let worker pick up task
+        await _running_count_at_least(docket, 1)
 
         result = await run_cli(
             "snapshot",
@@ -120,7 +138,7 @@ async def test_snapshot_with_mixed_tasks(
     async with Worker(docket, name="test-worker", concurrency=2) as worker:
         worker_running = asyncio.create_task(worker.run_until_finished())
 
-        await asyncio.sleep(0.1)  # Let worker pick up tasks
+        await _running_count_at_least(docket, 2)
 
         result = await run_cli(
             "snapshot",
@@ -223,7 +241,7 @@ async def test_snapshot_with_stats_flag_mixed_tasks(
     async with Worker(docket, name="test-worker", concurrency=2) as worker:
         worker_running = asyncio.create_task(worker.run_until_finished())
 
-        await asyncio.sleep(0.1)  # Let worker pick up tasks
+        await _running_count_at_least(docket, 2)
 
         result = await run_cli(
             "snapshot",
@@ -299,7 +317,7 @@ async def test_snapshot_stats_with_running_tasks_only(docket: Docket):
     async with Worker(docket, name="test-worker", concurrency=2) as worker:
         worker_running = asyncio.create_task(worker.run_until_finished())
 
-        await asyncio.sleep(0.1)  # Let worker pick up tasks
+        await _running_count_at_least(docket, 2)
 
         result = await run_cli(
             "snapshot",

--- a/tests/cli/test_striking.py
+++ b/tests/cli/test_striking.py
@@ -1,4 +1,3 @@
-import asyncio
 import decimal
 from datetime import timedelta
 import os
@@ -10,6 +9,7 @@ import pytest
 from docket.cli import interpret_python_value
 from docket.docket import Docket
 from tests.cli.run import run_cli
+from tests.conftest import wait_until
 
 # Skip CLI tests when using memory backend since CLI rejects memory:// URLs
 pytestmark = pytest.mark.skipif(
@@ -36,9 +36,10 @@ async def test_strike(docket: Docket):
 
     assert "Striking example_task some_parameter == 'some_value'" in result.output
 
-    await asyncio.sleep(0.25)
-
-    assert "example_task" in docket.strike_list.task_strikes
+    await wait_until(
+        lambda: "example_task" in docket.strike_list.task_strikes,
+        description="example_task strike to propagate via CLI",
+    )
 
 
 async def test_restore(docket: Docket):
@@ -62,9 +63,10 @@ async def test_restore(docket: Docket):
 
     assert "Restoring example_task some_parameter == 'some_value'" in result.output
 
-    await asyncio.sleep(0.25)
-
-    assert "example_task" not in docket.strike_list.task_strikes
+    await wait_until(
+        lambda: "example_task" not in docket.strike_list.task_strikes,
+        description="example_task restore to propagate via CLI",
+    )
 
 
 async def test_task_only_strike(docket: Docket):
@@ -81,9 +83,10 @@ async def test_task_only_strike(docket: Docket):
     assert result.exit_code == 0, result.output
     assert "Striking example_task" in result.output
 
-    await asyncio.sleep(0.25)
-
-    assert "example_task" in docket.strike_list.task_strikes
+    await wait_until(
+        lambda: "example_task" in docket.strike_list.task_strikes,
+        description="example_task strike to propagate via CLI",
+    )
 
 
 async def test_task_only_restore(docket: Docket):
@@ -102,9 +105,10 @@ async def test_task_only_restore(docket: Docket):
     assert result.exit_code == 0, result.output
     assert "Restoring example_task" in result.output
 
-    await asyncio.sleep(0.25)
-
-    assert "example_task" not in docket.strike_list.task_strikes
+    await wait_until(
+        lambda: "example_task" not in docket.strike_list.task_strikes,
+        description="example_task restore to propagate via CLI",
+    )
 
 
 async def test_parameter_only_strike(docket: Docket):
@@ -124,9 +128,11 @@ async def test_parameter_only_strike(docket: Docket):
     assert result.exit_code == 0, result.output
     assert "Striking (all tasks) some_parameter == 'some_value'" in result.output
 
-    await asyncio.sleep(0.25)
+    await wait_until(
+        lambda: "some_parameter" in docket.strike_list.parameter_strikes,
+        description="some_parameter strike to propagate via CLI",
+    )
 
-    assert "some_parameter" in docket.strike_list.parameter_strikes
     parameter_strikes = docket.strike_list.parameter_strikes["some_parameter"]
     assert ("==", "some_value") in parameter_strikes
 
@@ -151,9 +157,10 @@ async def test_parameter_only_restore(docket: Docket):
     assert result.exit_code == 0, result.output
     assert "Restoring (all tasks) some_parameter == 'some_value'" in result.output
 
-    await asyncio.sleep(0.25)
-
-    assert "some_parameter" not in docket.strike_list.parameter_strikes
+    await wait_until(
+        lambda: "some_parameter" not in docket.strike_list.parameter_strikes,
+        description="some_parameter restore to propagate via CLI",
+    )
 
 
 @pytest.mark.parametrize("operation", ["strike", "restore"])

--- a/tests/concurrency_limits/test_waiter_queue.py
+++ b/tests/concurrency_limits/test_waiter_queue.py
@@ -323,6 +323,94 @@ async def test_cancel_cleanup_script_drains_waiter_entry(docket: Docket):
         assert await redis.hget(runs_key, "waiter_entry_id") is None
 
 
+async def test_admission_blocked_handled_does_not_publish_failed_event(
+    docket: Docket, worker: Worker
+) -> None:
+    """A task parked by ``ConcurrencyLimit`` (``AdmissionBlocked(handled=True)``)
+    must NOT trigger the worker's safety-net ``mark_as_failed`` path.
+
+    The safety-net check at the end of ``process_completed_tasks`` only
+    fires when ``execution._acked`` is False, and the ``handled=True``
+    branch ``continue``s past it.  If anyone ever refactors that branch
+    away or stops short-circuiting, a parked task would observably emit
+    ``state=failed`` on its state channel even though the runs hash still
+    says ``scheduled``.  This test locks in the implicit invariant:
+    no ``failed`` event is ever published for a parked-but-not-yet-run
+    task whose ``handle_failure`` was a no-op admission denial.
+    """
+    import contextlib
+    import json
+
+    holder_started = asyncio.Event()
+    holder_may_finish = asyncio.Event()
+    contender_key = "admission-blocked-no-fail"
+
+    # Subscribe to the contender's state channel BEFORE we add it, so the
+    # park-time ``scheduled`` event and any (regression) ``failed`` event
+    # are both captured.
+    state_events: list[dict[str, object]] = []
+    ready = asyncio.Event()
+
+    async def collector() -> None:
+        async with docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
+            await pubsub.subscribe(docket.key(f"state:{contender_key}"))
+            ready.set()
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue  # pragma: no cover
+                data = message["data"]
+                payload = data.decode() if isinstance(data, bytes) else data
+                state_events.append(json.loads(payload))
+
+    collector_task = asyncio.create_task(collector())
+    await ready.wait()
+
+    async def the_task(
+        marker: str,
+        concurrency: ConcurrencyLimit = ConcurrencyLimit(max_concurrent=1),
+    ) -> None:
+        if marker == "holder":
+            holder_started.set()
+            await holder_may_finish.wait()
+
+    docket.register(the_task)
+
+    await docket.add(the_task, key="holder")("holder")
+    worker_task = asyncio.create_task(worker.run_until_finished())
+    await asyncio.wait_for(holder_started.wait(), timeout=5)
+
+    # Park the contender while the holder owns the only slot.
+    await docket.add(the_task, key=contender_key)("contender")
+
+    # Give parking + any (regression) safety-net path time to run.
+    await asyncio.sleep(0.2)
+
+    # While parked, the runs hash must say ``scheduled`` -- not ``failed``.
+    # This is the at-rest truth a regression would corrupt by overwriting
+    # via mark_as_failed.
+    async with docket.redis() as redis:
+        runs_state = await redis.hget(docket.key(f"runs:{contender_key}"), "state")
+    assert runs_state == b"scheduled", (
+        f"parked task's runs hash state must be 'scheduled' (the "
+        f"AdmissionBlocked.handled=True path must not have triggered "
+        f"the worker's safety-net mark_as_failed); got: {runs_state!r}"
+    )
+
+    holder_may_finish.set()
+    await asyncio.wait_for(worker_task, timeout=10)
+    await asyncio.sleep(0.05)
+    collector_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await collector_task
+
+    # No failed event should ever have hit the contender's state channel.
+    failed_events = [e for e in state_events if e.get("state") == "failed"]
+    assert not failed_events, (
+        f"AdmissionBlocked(handled=True) must not produce any state=failed "
+        f"events on the parked task's channel; got: {failed_events!r}"
+    )
+
+
 async def test_many_contending_tasks_all_run_exactly_once(docket: Docket):
     """Stress test: N tasks contending for 1 slot all eventually run, each
     exactly once, without duplicates or drops.  The structural correctness

--- a/tests/concurrency_limits/test_waiter_queue.py
+++ b/tests/concurrency_limits/test_waiter_queue.py
@@ -341,6 +341,8 @@ async def test_admission_blocked_handled_does_not_publish_failed_event(
     import contextlib
     import json
 
+    from tests.conftest import wait_for_event
+
     holder_started = asyncio.Event()
     holder_may_finish = asyncio.Event()
     contender_key = "admission-blocked-no-fail"
@@ -382,8 +384,14 @@ async def test_admission_blocked_handled_does_not_publish_failed_event(
     # Park the contender while the holder owns the only slot.
     await docket.add(the_task, key=contender_key)("contender")
 
-    # Give parking + any (regression) safety-net path time to run.
-    await asyncio.sleep(0.2)
+    # Wait for ``_acquire_or_park``'s scheduled event -- that's how we
+    # know the contender has actually parked and the runs hash is
+    # settled.  No magic-number wait.
+    await wait_for_event(
+        state_events,
+        lambda m: m.get("state") == "scheduled",
+        description="contender's park scheduled event",
+    )
 
     # While parked, the runs hash must say ``scheduled`` -- not ``failed``.
     # This is the at-rest truth a regression would corrupt by overwriting
@@ -398,7 +406,14 @@ async def test_admission_blocked_handled_does_not_publish_failed_event(
 
     holder_may_finish.set()
     await asyncio.wait_for(worker_task, timeout=10)
-    await asyncio.sleep(0.05)
+    # Wait for the contender's terminal completed event -- proves the
+    # full wake-and-run path executed, which means ``process_completed_tasks``
+    # would already have fired the safety net by now if it was going to.
+    await wait_for_event(
+        state_events,
+        lambda m: m.get("state") == "completed",
+        description="contender's terminal completed event",
+    )
     collector_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await collector_task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 import socket
 import sys
 from datetime import datetime, timedelta, timezone
 from functools import partial
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Generator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -38,6 +39,36 @@ skip_cluster = pytest.mark.skipif(
     CLUSTER_ENABLED,
     reason="requires a non-clustered Redis (test bypasses cluster routing)",
 )
+
+
+async def wait_until(
+    predicate: Callable[[], bool | Awaitable[bool]],
+    *,
+    timeout: float = 5.0,
+    description: str = "condition",
+) -> None:
+    """Poll ``predicate()`` until it returns truthy, or fail with a timeout.
+
+    Accepts either a sync or async predicate.  Async predicates are useful
+    for "wait until the docket snapshot shows the expected running count"
+    style checks that need to round-trip to Redis on each poll.
+
+    Replaces fixed-duration ``asyncio.sleep`` waits for "let some
+    out-of-band background work catch up before I assert on it" -- a
+    monitor task draining a Redis stream, a heartbeat firing, a worker
+    picking up the next message, etc.  Short-circuits the moment the
+    condition holds (no wasted wall-clock on fast runners) and fails
+    with a descriptive message on slow ones (no silent flakes).
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        result = predicate()
+        if inspect.isawaitable(result):
+            result = await result
+        if result:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"{description} never became truthy within {timeout}s")
 
 
 async def wait_for_event(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import socket
 import sys
 from datetime import datetime, timedelta, timezone
 from functools import partial
-from typing import TYPE_CHECKING, AsyncGenerator, Callable, Generator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Generator
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -37,6 +38,40 @@ skip_cluster = pytest.mark.skipif(
     CLUSTER_ENABLED,
     reason="requires a non-clustered Redis (test bypasses cluster routing)",
 )
+
+
+async def wait_for_event(
+    messages: list[dict[str, Any]],
+    predicate: Callable[[dict[str, Any]], bool],
+    *,
+    timeout: float = 5.0,
+    description: str = "matching event",
+) -> dict[str, Any]:
+    """Poll ``messages`` until one satisfies ``predicate``, or raise.
+
+    The pubsub-collector pattern in the test suite appends each received
+    event to a list as it arrives.  Tests that need to assert on those
+    events shouldn't depend on a fixed-duration ``asyncio.sleep`` to
+    "let the subscriber drain" -- that race-tunes the test to whoever's
+    runner is fastest.  Use this helper instead: it short-circuits as
+    soon as the expected event appears (no wasted wall-clock on fast
+    runners) and fails with the full ``messages`` snapshot on slow
+    runners (no silent flakes).
+
+    The 10 ms yield is bounded by ``timeout`` and serves only to give
+    the collector task a chance to run; the same shape as
+    ``await_retry_parked`` and other polling helpers in the suite.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        for msg in messages:
+            if predicate(msg):
+                return msg
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"no {description} arrived within {timeout}s; saw: {messages!r}"
+    )
+
 
 if sys.platform != "win32" or TYPE_CHECKING:
     from docker import DockerClient

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -41,6 +41,75 @@ async def test_cancel_running_task(docket: Docket, worker: Worker):
     await asyncio.wait_for(worker_task, timeout=5.0)
 
 
+async def test_double_cancel_does_not_overwrite_runs_hash(
+    docket: Docket, worker: Worker
+):
+    """A second ``docket.cancel()`` after the task has already transitioned
+    to ``cancelled`` must not modify the runs hash -- ``state`` stays
+    ``cancelled``, and ``completed_at`` stays at the first cancel's
+    timestamp.
+
+    The Lua's terminal-state guard at the bottom of ``_cancel_task``
+    (``if current_state ~= 'completed' and current_state ~= 'failed'
+    and current_state ~= 'cancelled' then ...``) is what enforces this.
+    Locks it in so a future refactor that drops the guard would be
+    caught here rather than at someone's audit log noticing two
+    different ``completed_at`` timestamps for the same cancellation.
+    """
+    started = asyncio.Event()
+
+    async def slow_task():
+        started.set()
+        await asyncio.sleep(60)
+
+    docket.register(slow_task)
+    execution = await docket.add(slow_task)()
+
+    worker_task = asyncio.create_task(worker.run_until_finished())
+    await asyncio.wait_for(started.wait(), timeout=5.0)
+
+    # First cancel: should land the runs hash in state=cancelled.
+    await docket.cancel(execution.key)
+
+    # Wait until the runs hash has the cancelled state set, so the second
+    # cancel is genuinely a no-op against an already-terminal task.
+    async def await_cancelled_state() -> bytes:
+        deadline = asyncio.get_event_loop().time() + 5.0
+        runs_key = docket.runs_key(execution.key)
+        while asyncio.get_event_loop().time() < deadline:
+            async with docket.redis() as redis:
+                state = await redis.hget(runs_key, "state")
+                if state == b"cancelled":
+                    return await redis.hget(runs_key, "completed_at")  # type: ignore[return-value]
+            await asyncio.sleep(0.01)
+        raise AssertionError(  # pragma: no cover
+            "first cancel never wrote state=cancelled"
+        )
+
+    first_completed_at = await await_cancelled_state()
+    assert first_completed_at is not None
+
+    # Second cancel.  Must be a no-op on the runs hash.
+    await docket.cancel(execution.key)
+
+    async with docket.redis() as redis:
+        runs_key = docket.runs_key(execution.key)
+        state_after = await redis.hget(runs_key, "state")
+        completed_at_after = await redis.hget(runs_key, "completed_at")
+
+    assert state_after == b"cancelled", (
+        f"second cancel must not change state away from 'cancelled'; "
+        f"got: {state_after!r}"
+    )
+    assert completed_at_after == first_completed_at, (
+        f"second cancel must not overwrite the first cancel's "
+        f"completed_at; first={first_completed_at!r}, "
+        f"after second={completed_at_after!r}"
+    )
+
+    await asyncio.wait_for(worker_task, timeout=5.0)
+
+
 async def test_cancel_running_task_state(docket: Docket, worker: Worker):
     """A cancelled running task transitions to CANCELLED state."""
     started = asyncio.Event()

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -44,8 +44,8 @@ async def test_cancel_running_task(docket: Docket, worker: Worker):
 async def test_double_cancel_does_not_overwrite_runs_hash(
     docket: Docket, worker: Worker
 ):
-    """A second ``docket.cancel()`` after the task has already transitioned
-    to ``cancelled`` must not modify the runs hash -- ``state`` stays
+    """A second ``docket.cancel()`` after the task has fully settled into
+    ``state=cancelled`` must not modify the runs hash -- ``state`` stays
     ``cancelled``, and ``completed_at`` stays at the first cancel's
     timestamp.
 
@@ -55,6 +55,13 @@ async def test_double_cancel_does_not_overwrite_runs_hash(
     Locks it in so a future refactor that drops the guard would be
     caught here rather than at someone's audit log noticing two
     different ``completed_at`` timestamps for the same cancellation.
+
+    NB: the snapshot baseline is taken AFTER the worker has finished
+    processing the cancellation -- otherwise we'd race against the
+    worker's own ``mark_as_cancelled`` (via ``_terminal``), which
+    legitimately rewrites ``completed_at`` from the CancelledError
+    handler in ``_execute``.  The test is purely about ``_cancel_task``
+    Lua's idempotency, not about any worker-side cancel handling.
     """
     started = asyncio.Event()
 
@@ -68,46 +75,43 @@ async def test_double_cancel_does_not_overwrite_runs_hash(
     worker_task = asyncio.create_task(worker.run_until_finished())
     await asyncio.wait_for(started.wait(), timeout=5.0)
 
-    # First cancel: should land the runs hash in state=cancelled.
+    # First cancel: triggers both the Lua tombstone AND the worker's
+    # CancelledError → mark_as_cancelled path.  Wait for the worker to
+    # finish so both paths have run and the runs hash is fully settled.
     await docket.cancel(execution.key)
+    await asyncio.wait_for(worker_task, timeout=5.0)
 
-    # Wait until the runs hash has the cancelled state set, so the second
-    # cancel is genuinely a no-op against an already-terminal task.
-    async def await_cancelled_state() -> bytes:
-        deadline = asyncio.get_event_loop().time() + 5.0
+    # Snapshot the settled state.  This is the baseline the second cancel
+    # must not perturb.
+    async with docket.redis() as redis:
         runs_key = docket.runs_key(execution.key)
-        while asyncio.get_event_loop().time() < deadline:
-            async with docket.redis() as redis:
-                state = await redis.hget(runs_key, "state")
-                if state == b"cancelled":
-                    return await redis.hget(runs_key, "completed_at")  # type: ignore[return-value]
-            await asyncio.sleep(0.01)
-        raise AssertionError(  # pragma: no cover
-            "first cancel never wrote state=cancelled"
-        )
+        baseline_state = await redis.hget(runs_key, "state")
+        baseline_completed_at = await redis.hget(runs_key, "completed_at")
 
-    first_completed_at = await await_cancelled_state()
-    assert first_completed_at is not None
+    assert baseline_state == b"cancelled", (
+        f"setup: runs hash should be 'cancelled' after first cancel + "
+        f"worker drain; got: {baseline_state!r}"
+    )
+    assert baseline_completed_at is not None
 
-    # Second cancel.  Must be a no-op on the runs hash.
+    # Second cancel against a fully-settled CANCELLED task.  The
+    # ``_cancel_task`` Lua's terminal-state guard should short-circuit
+    # the HSET and leave the runs hash untouched.
     await docket.cancel(execution.key)
 
     async with docket.redis() as redis:
-        runs_key = docket.runs_key(execution.key)
         state_after = await redis.hget(runs_key, "state")
         completed_at_after = await redis.hget(runs_key, "completed_at")
 
-    assert state_after == b"cancelled", (
-        f"second cancel must not change state away from 'cancelled'; "
-        f"got: {state_after!r}"
+    assert state_after == baseline_state, (
+        f"second cancel must not change state; "
+        f"baseline={baseline_state!r}, after={state_after!r}"
     )
-    assert completed_at_after == first_completed_at, (
+    assert completed_at_after == baseline_completed_at, (
         f"second cancel must not overwrite the first cancel's "
-        f"completed_at; first={first_completed_at!r}, "
-        f"after second={completed_at_after!r}"
+        f"completed_at; baseline={baseline_completed_at!r}, "
+        f"after={completed_at_after!r}"
     )
-
-    await asyncio.wait_for(worker_task, timeout=5.0)
 
 
 async def test_cancel_running_task_state(docket: Docket, worker: Worker):

--- a/tests/test_claim_supersedes.py
+++ b/tests/test_claim_supersedes.py
@@ -1,0 +1,182 @@
+"""Regression tests for ``Execution.claim`` SUPERSEDED-path behavior.
+
+When ``_claim`` detects a stale generation it returns ``SUPERSEDED``
+and (a) must clean up the stale stream message and (b) must always
+fire for any source of supersession -- ``replace()``, Perpetual
+successors, retries that crossed a successor's claim, etc.
+
+This is not strictly a concurrency-limit concern, so it lives at the
+top level rather than under ``tests/concurrency_limits/``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+
+from docket import Docket
+from docket.execution import Execution
+
+
+async def test_claim_superseded_acks_stale_stream_message(docket: Docket) -> None:
+    """``_claim`` SUPERSEDED must XACK+XDEL the stale stream entry.
+
+    Build a real Execution at generation=1, bump the runs hash directly to
+    generation=2 (simulating a successor already in flight), then call
+    ``claim`` on the stale execution.  The Lua's supersession check fires,
+    and the new behaviour requires the stream message and the consumer
+    group's PEL to both be empty afterward.
+    """
+
+    async def noop() -> None:
+        pass  # pragma: no cover
+
+    docket.register(noop)
+    await docket.add(noop, key="claim-supersedes")()
+
+    # Pull the stream message so we have a real message_id to claim against.
+    async with docket.redis() as redis:
+        entries = await redis.xrange(docket.stream_key, count=10)
+    msg_id, message = next(
+        (mid, msg) for mid, msg in entries if msg[b"key"] == b"claim-supersedes"
+    )
+
+    # Read the message into a worker-style consumer group so it lands in
+    # PEL, mirroring what XREADGROUP would do during normal consumption.
+    async with docket.redis() as redis:
+        # On the memory backend the group is created on demand; on real
+        # Redis the worker would have created it already, but here we
+        # drive it directly and tolerate "already exists".
+        with contextlib.suppress(Exception):
+            await redis.xgroup_create(
+                docket.stream_key,
+                docket.worker_group_name,
+                id="0",
+                mkstream=True,
+            )
+        await redis.xreadgroup(
+            docket.worker_group_name,
+            "test-consumer",
+            {docket.stream_key: ">"},
+            count=10,
+            block=10,
+        )
+        pending_before = await redis.xpending(
+            docket.stream_key, docket.worker_group_name
+        )
+    assert pending_before["pending"] >= 1, (
+        f"setup: expected the message to land in PEL; got {pending_before!r}"
+    )
+
+    # Build a stale Execution at generation=1 and bump the runs hash to
+    # generation=2 so the claim must take the SUPERSEDED path.
+    stale = await Execution.from_message(docket, message, message_id=msg_id)
+    assert stale.generation == 1
+    async with docket.redis() as redis:
+        await redis.hincrby(stale._redis_key, "generation", 1)  # pyright: ignore[reportPrivateUsage]
+    stale_with_gen1 = Execution(
+        docket=docket,
+        function=noop,
+        args=(),
+        kwargs={},
+        key=stale.key,
+        when=datetime.now(timezone.utc),
+        attempt=1,
+        generation=1,
+        message_id=msg_id,
+    )
+
+    assert (await stale_with_gen1.claim("stale-worker")) is False
+
+    # After SUPERSEDED, the stale message should be gone from both the
+    # stream and the consumer group's PEL.
+    async with docket.redis() as redis:
+        stream_after = await redis.xrange(docket.stream_key, count=10)
+        pending_after = await redis.xpending(
+            docket.stream_key, docket.worker_group_name
+        )
+    assert not any(mid == msg_id for mid, _ in stream_after), (
+        f"_claim SUPERSEDED must XDEL the stale stream message; "
+        f"still present in stream: {stream_after!r}"
+    )
+    assert pending_after["pending"] == 0, (
+        f"_claim SUPERSEDED must XACK the stale stream message; "
+        f"PEL still has entries: {pending_after!r}"
+    )
+
+
+async def test_replace_makes_prior_generations_stale_message_unclaimable(
+    docket: Docket,
+) -> None:
+    """``docket.replace()`` must make any prior-generation message
+    unclaimable: a worker that holds the old ``message_id`` and tries
+    to ``claim`` it sees SUPERSEDED, not a successful claim.
+
+    Pre-fix would let a slow worker that read the old stream entry
+    before the replace landed go on to run the replaced task body --
+    duplicating execution under the same key.  This locks in the
+    contract from the ``replace()`` direction (the supersession check
+    in ``_claim`` is the actual enforcer; ``replace`` is responsible
+    for bumping the generation that triggers it).
+    """
+
+    async def the_task(payload: str) -> None: ...
+
+    docket.register(the_task)
+
+    # Add the original task far enough in the future that it parks in
+    # the queue (so the replace path goes through the "scheduled"
+    # branch, not the stream branch).
+    when = datetime.now(timezone.utc) + timedelta(seconds=60)
+    await docket.add(the_task, when=when, key="replace-supersedes")("original-arg")
+
+    # Read the runs hash directly to capture the generation that
+    # ``_schedule`` set so we know what counts as "stale" below.
+    async with docket.redis() as redis:
+        gen_str = await redis.hget(docket.runs_key("replace-supersedes"), "generation")
+    assert gen_str is not None
+    original_gen = int(gen_str)
+    assert original_gen >= 1
+
+    # Now replace the task.  ``_schedule``'s replace branch bumps the
+    # generation counter.
+    await docket.replace(the_task, when=when, key="replace-supersedes")(
+        "replacement-arg"
+    )
+
+    async with docket.redis() as redis:
+        new_gen_str = await redis.hget(
+            docket.runs_key("replace-supersedes"), "generation"
+        )
+    assert new_gen_str is not None
+    assert int(new_gen_str) > original_gen, (
+        "replace() must bump the runs hash generation counter"
+    )
+
+    # Construct a stale Execution against the same key with the
+    # pre-replace generation, then call claim.
+    stale = Execution(
+        docket=docket,
+        function=the_task,
+        args=("original-arg",),
+        kwargs={},
+        key="replace-supersedes",
+        when=when,
+        attempt=1,
+        generation=original_gen,
+    )
+
+    assert (await stale.claim("late-worker")) is False, (
+        "claim() on a stale-generation Execution must return False "
+        "(SUPERSEDED) after the same key has been replace()d -- a "
+        "regression here would silently let a stale worker double-run "
+        "the replaced task body"
+    )
+
+    # And the runs hash still reflects the replacement, not the stale claim.
+    after = await docket.get_execution("replace-supersedes")
+    assert after is not None
+    assert after.args == ("replacement-arg",), (
+        f"stale SUPERSEDED claim must not have overwritten the runs hash; "
+        f"got: {after.args!r}"
+    )

--- a/tests/test_dependencies_core.py
+++ b/tests/test_dependencies_core.py
@@ -364,6 +364,8 @@ async def test_safety_net_publishes_failed_state_event_with_no_error(
     import contextlib
     import json
 
+    from tests.conftest import wait_for_event
+
     class JustLog(FailureHandler["JustLog"]):
         async def __aenter__(self) -> "JustLog":
             return self
@@ -396,7 +398,13 @@ async def test_safety_net_publishes_failed_state_event_with_no_error(
 
     await docket.add(the_task, key=task_key)("once")
     await worker.run_until_finished()
-    await asyncio.sleep(0.05)
+    # Wait for the safety net's failed event itself, instead of guessing
+    # how long the subscriber needs to drain.
+    await wait_for_event(
+        state_events,
+        lambda m: m.get("state") == "failed",
+        description="safety-net failed event",
+    )
 
     collector_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_dependencies_core.py
+++ b/tests/test_dependencies_core.py
@@ -309,6 +309,116 @@ async def test_custom_failure_handler_returning_true_still_acks_message(
         assert pending["pending"] == 0
 
 
+async def test_retry_path_marks_execution_acked(docket: Docket):
+    """A reschedule whose ``reschedule_message`` matches the execution's own
+    ``message_id`` (the Retry path) must flip ``_acked`` to True locally.
+
+    This is what stops the worker's safety net from firing a second
+    ``mark_as_failed`` on a task that ``Retry`` has just re-scheduled --
+    the safety net only checks ``execution._acked`` and the ``_schedule``
+    Lua's reschedule branch is responsible for the actual XACK+XDEL.
+
+    Pre-fix, ``schedule`` didn't touch ``_acked``, so the safety net
+    would observe ``False`` and overwrite the just-scheduled retry with
+    a terminal ``failed`` state.  Locking in this assignment guards
+    against accidentally dropping the ``if reschedule_message and
+    reschedule_message == self.message_id`` branch.
+    """
+
+    async def the_task() -> None: ...
+
+    docket.register(the_task)
+    await docket.add(the_task, key="retry-acked")()
+
+    async with docket.redis() as redis:
+        entries = await redis.xrange(docket.stream_key, count=10)
+    msg_id, message = next(
+        (mid, msg) for mid, msg in entries if msg[b"key"] == b"retry-acked"
+    )
+    execution = await Execution.from_message(docket, message, message_id=msg_id)
+    assert execution._acked is False  # pyright: ignore[reportPrivateUsage]
+
+    # Drive the same call shape Retry.handle_failure uses: replace=True,
+    # reschedule_message=execution.message_id.
+    await execution.schedule(replace=True, reschedule_message=execution.message_id)
+
+    assert execution._acked is True, (  # pyright: ignore[reportPrivateUsage]
+        "schedule() with reschedule_message == self.message_id must set "
+        "_acked=True so the worker safety net does not double-fire "
+        "mark_as_failed on a successfully-rescheduled retry"
+    )
+
+
+async def test_safety_net_publishes_failed_state_event_with_no_error(
+    docket: Docket, worker: Worker
+):
+    """Lock in the observable shape of the safety-net's published event.
+
+    When a custom ``FailureHandler`` returns True without taking action,
+    the worker's safety net fires ``mark_as_failed(error=None)``.  The
+    resulting state-channel event reports ``state=failed`` and carries
+    NO ``error`` field (since none was supplied).  Anyone alerting on
+    ``state=failed && !error`` needs to know this is the safety-net
+    signature -- not a regression where error reporting got lost.
+    """
+    import contextlib
+    import json
+
+    class JustLog(FailureHandler["JustLog"]):
+        async def __aenter__(self) -> "JustLog":
+            return self
+
+        async def handle_failure(
+            self, execution: Execution, outcome: TaskOutcome
+        ) -> bool:
+            return True
+
+    async def the_task(value: str, handler: JustLog = JustLog()):
+        raise RuntimeError(f"boom: {value}")
+
+    task_key = "safety-net-event"
+    state_events: list[dict[str, object]] = []
+    ready = asyncio.Event()
+
+    async def collector() -> None:
+        async with docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
+            await pubsub.subscribe(docket.key(f"state:{task_key}"))
+            ready.set()
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue  # pragma: no cover
+                data = message["data"]
+                payload = data.decode() if isinstance(data, bytes) else data
+                state_events.append(json.loads(payload))
+
+    collector_task = asyncio.create_task(collector())
+    await ready.wait()
+
+    await docket.add(the_task, key=task_key)("once")
+    await worker.run_until_finished()
+    await asyncio.sleep(0.05)
+
+    collector_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await collector_task
+
+    failed_events = [e for e in state_events if e.get("state") == "failed"]
+    assert len(failed_events) == 1, (
+        f"safety net should have published exactly one state=failed event; "
+        f"got: {state_events!r}"
+    )
+    failed = failed_events[0]
+    assert "error" not in failed, (
+        f"safety-net mark_as_failed(error=None) must NOT include an "
+        f"'error' field in the state event payload; got: {failed!r}"
+    )
+    assert "completed_at" in failed, (
+        f"safety-net failed event must include 'completed_at'; got: {failed!r}"
+    )
+    assert failed.get("key") == task_key
+    assert failed.get("type") == "state"
+
+
 async def test_dependencies_error_for_missing_task_argument(
     docket: Docket, worker: Worker, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/test_docket_execution.py
+++ b/tests/test_docket_execution.py
@@ -71,6 +71,56 @@ async def test_docket_schedule_is_idempotent_per_key(
     assert len(snapshot.future) == 1
 
 
+async def test_already_scheduled_preserves_first_calls_args_and_when(
+    docket: Docket, the_task: AsyncMock
+):
+    """``add()`` with a duplicate key is a no-op: the persisted task in
+    Redis still reflects the FIRST call's ``when`` / args / function, not
+    the intruder's.  The disposition alone (``ALREADY_SCHEDULED``) doesn't
+    prove this -- a regression could silently overwrite args while still
+    returning the correct disposition.
+
+    Locks in the ``_schedule`` Lua's ``'EXISTS'`` early-return branch
+    against a future change that, for example, decided to "merge" or
+    "upgrade" duplicate adds.
+    """
+    from docket import Disposition
+
+    docket.register(the_task)
+    first_when = datetime.now(timezone.utc) + timedelta(seconds=60)
+
+    first = await docket.add(the_task, when=first_when, key="dup-args")(
+        "first-arg", kwarg1="first-kwarg"
+    )
+    assert first.disposition is Disposition.SCHEDULED
+
+    # Intruder: different args, different when, same key.
+    intruder_when = first_when + timedelta(seconds=120)
+    second = await docket.add(the_task, when=intruder_when, key="dup-args")(
+        "intruder-arg", kwarg1="intruder-kwarg"
+    )
+    assert second.disposition is Disposition.ALREADY_SCHEDULED
+
+    # The persisted task in Redis must still describe the FIRST call.
+    persisted = await docket.get_execution("dup-args")
+    assert persisted is not None
+    assert persisted.args == ("first-arg",), (
+        f"intruder add() must not have rewritten the persisted args; "
+        f"got: {persisted.args!r}"
+    )
+    assert persisted.kwargs == {"kwarg1": "first-kwarg"}, (
+        f"intruder add() must not have rewritten the persisted kwargs; "
+        f"got: {persisted.kwargs!r}"
+    )
+    # The persisted ``when`` should match the first call's, not the intruder's.
+    # Allow a tiny tolerance for serialization round-trip (timestamps are
+    # stored as floats then re-parsed via fromisoformat).
+    assert abs((persisted.when - first_when).total_seconds()) < 0.001, (
+        f"intruder add() must not have rewritten the persisted when; "
+        f"expected {first_when.isoformat()}, got: {persisted.when.isoformat()}"
+    )
+
+
 async def test_get_execution_nonexistent_key(docket: Docket):
     """get_execution should return None for non-existent key."""
     execution = await docket.get_execution("nonexistent-key")

--- a/tests/test_docket_isolation.py
+++ b/tests/test_docket_isolation.py
@@ -22,6 +22,8 @@ from typing import AsyncGenerator, Callable
 import pytest
 from docket import Docket
 
+from tests.conftest import wait_for_event
+
 
 @pytest.fixture
 async def other_docket(
@@ -88,36 +90,62 @@ async def test_state_pubsub_does_not_cross_dockets(
     """A state event published on ``docket``'s channel must not be
     delivered to a subscriber on ``other_docket``'s channel for the
     same task key.  Pub/sub channels are prefix-scoped just like
-    Redis keys."""
-    task_key = "shared-name"
-    other_events: list[dict[str, object]] = []
-    ready = asyncio.Event()
+    Redis keys.
 
-    async def collector() -> None:
-        async with other_docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
-            await pubsub.subscribe(other_docket.key(f"state:{task_key}"))
+    Subscribes to BOTH channels.  When the event arrives on docket's
+    own channel, we know Redis has already dispatched it -- so if a
+    leak to other_docket's channel was going to happen, it would
+    already be in ``other_events`` too.  That makes this negative
+    assertion deterministic instead of a fixed-duration wait.
+    """
+    task_key = "shared-name"
+    same_events: list[dict[str, object]] = []
+    other_events: list[dict[str, object]] = []
+    same_ready = asyncio.Event()
+    other_ready = asyncio.Event()
+
+    async def collect(
+        target_docket: Docket,
+        bucket: list[dict[str, object]],
+        ready: asyncio.Event,
+    ) -> None:
+        async with target_docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
+            await pubsub.subscribe(target_docket.key(f"state:{task_key}"))
             ready.set()
             async for message in pubsub.listen():
                 if message["type"] != "message":
                     continue  # pragma: no cover
                 data = message["data"]
                 payload = data.decode() if isinstance(data, bytes) else data
-                other_events.append(json.loads(payload))
+                bucket.append(json.loads(payload))
 
-    collector_task = asyncio.create_task(collector())
-    await ready.wait()
+    same_collector = asyncio.create_task(collect(docket, same_events, same_ready))
+    other_collector = asyncio.create_task(
+        collect(other_docket, other_events, other_ready)
+    )
+    await same_ready.wait()
+    await other_ready.wait()
 
     async def the_task() -> None: ...
 
     docket.register(the_task)
-    # Trigger state-event publishing on docket's channel.
     await docket.add(the_task, key=task_key)()
-    # Give the publish a moment to land.
-    await asyncio.sleep(0.05)
 
-    collector_task.cancel()
+    # Handshake: wait for the event on docket's own channel.  Once
+    # we've seen it, Redis has already done its dispatch and any
+    # cross-docket leak would already be in other_events.
+    await wait_for_event(
+        same_events,
+        lambda m: m.get("key") == task_key,
+        description="same-docket state event",
+    )
+
+    same_collector.cancel()
+    other_collector.cancel()
     with contextlib.suppress(asyncio.CancelledError):
-        await collector_task
+        await same_collector
+    with contextlib.suppress(asyncio.CancelledError):
+        await other_collector
 
     assert other_events == [], (
         f"other_docket subscribers must not receive state events from "

--- a/tests/test_docket_isolation.py
+++ b/tests/test_docket_isolation.py
@@ -1,0 +1,125 @@
+"""Locks in the per-docket isolation contract.
+
+Two ``Docket`` instances with different names sharing one Redis are
+expected to operate in complete isolation: tasks, strike state, and
+pub/sub channels are namespace-scoped to each docket's prefix.  This
+is the foundation that lets two unrelated services co-locate on a
+shared Redis without colliding on identical task keys.
+
+The contract is implicit in ``Docket.key()`` building every Redis key
+off ``self.prefix``.  A regression that ever forgot the prefix (or
+flattened two prefixes into one) would silently merge state across
+unrelated services.  These tests would catch that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import AsyncGenerator, Callable
+
+import pytest
+from docket import Docket
+
+
+@pytest.fixture
+async def other_docket(
+    redis_url: str, make_docket_name: Callable[[], str]
+) -> AsyncGenerator[Docket, None]:
+    """A second Docket pointing at the same Redis as the primary ``docket``
+    fixture, but with a distinct name so its prefix is different."""
+    async with Docket(name=make_docket_name(), url=redis_url) as second:
+        yield second
+
+
+async def test_add_in_one_docket_invisible_to_another(
+    docket: Docket, other_docket: Docket
+) -> None:
+    """A task added in ``docket`` is not visible to ``other_docket``,
+    even though both share Redis."""
+    assert docket.name != other_docket.name
+
+    async def the_task() -> None: ...
+
+    docket.register(the_task)
+    other_docket.register(the_task)
+
+    await docket.add(the_task, key="shared-name")()
+
+    # The other docket must not see this key under its own prefix.
+    found = await other_docket.get_execution("shared-name")
+    assert found is None, (
+        f"other_docket should not see a task added under a different prefix; "
+        f"got: {found!r}"
+    )
+
+
+async def test_cancel_in_one_docket_does_not_touch_another(
+    docket: Docket, other_docket: Docket
+) -> None:
+    """Cancelling ``shared-name`` in ``docket`` must not flip the state of
+    a same-keyed task in ``other_docket``."""
+
+    async def the_task() -> None: ...
+
+    docket.register(the_task)
+    other_docket.register(the_task)
+
+    await docket.add(the_task, key="shared-name")()
+    await other_docket.add(the_task, key="shared-name")()
+
+    await docket.cancel("shared-name")
+
+    # The other docket's task must still exist and not be cancelled.
+    other = await other_docket.get_execution("shared-name")
+    assert other is not None, "other_docket's task must still exist after docket.cancel"
+    # And the original docket's task should now be tombstoned/cancelled.
+    primary = await docket.get_execution("shared-name")
+    if primary is not None:
+        # With non-zero execution_ttl the tombstone hangs around with
+        # state=cancelled; with execution_ttl=0 it would be gone.
+        assert primary.state.value == "cancelled"
+
+
+async def test_state_pubsub_does_not_cross_dockets(
+    docket: Docket, other_docket: Docket
+) -> None:
+    """A state event published on ``docket``'s channel must not be
+    delivered to a subscriber on ``other_docket``'s channel for the
+    same task key.  Pub/sub channels are prefix-scoped just like
+    Redis keys."""
+    task_key = "shared-name"
+    other_events: list[dict[str, object]] = []
+    ready = asyncio.Event()
+
+    async def collector() -> None:
+        async with other_docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
+            await pubsub.subscribe(other_docket.key(f"state:{task_key}"))
+            ready.set()
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue  # pragma: no cover
+                data = message["data"]
+                payload = data.decode() if isinstance(data, bytes) else data
+                other_events.append(json.loads(payload))
+
+    collector_task = asyncio.create_task(collector())
+    await ready.wait()
+
+    async def the_task() -> None: ...
+
+    docket.register(the_task)
+    # Trigger state-event publishing on docket's channel.
+    await docket.add(the_task, key=task_key)()
+    # Give the publish a moment to land.
+    await asyncio.sleep(0.05)
+
+    collector_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await collector_task
+
+    assert other_events == [], (
+        f"other_docket subscribers must not receive state events from "
+        f"a different docket's channel; got: {other_events!r}"
+    )

--- a/tests/test_docket_registration.py
+++ b/tests/test_docket_registration.py
@@ -1,8 +1,8 @@
 """Tests for Docket task registration."""
 
-import asyncio
 from docket.docket import Docket
 from docket.worker import Worker
+from tests.conftest import wait_until
 
 
 def test_standard_tasks_available_after_init():
@@ -165,7 +165,17 @@ async def test_alias_appears_in_worker_announcements(docket: Docket):
     docket.register(my_task, names=["custom_alias"])
 
     async with Worker(docket) as w:
-        await asyncio.sleep(0.1)  # Let heartbeat fire
+        # The worker registers itself as a handler for "custom_alias"
+        # during its first heartbeat, which fires on a timer.  Poll
+        # task_workers() instead of guessing how long the heartbeat takes.
+        async def alias_visible() -> bool:
+            workers = await docket.task_workers("custom_alias")
+            return any(worker.name == w.name for worker in workers)
+
+        await wait_until(
+            alias_visible, description="custom_alias to appear in task_workers"
+        )
+
         workers = await docket.task_workers("custom_alias")
         assert len(workers) == 1
         assert w.name in {worker.name for worker in workers}

--- a/tests/test_immediate_retry_state.py
+++ b/tests/test_immediate_retry_state.py
@@ -1,0 +1,147 @@
+"""Regression test: a ``Retry(delay=timedelta(0))`` reschedule lands directly
+in the stream and the state event published from inside ``_schedule`` Lua's
+reschedule branch reports ``state=queued`` -- not ``state=scheduled``.
+
+Pre-fix, the reschedule branch always parked the retry into the future queue
+regardless of delay, and the Python side always published a ``scheduled``
+state event for any reschedule.  The new behaviour respects ``is_immediate``:
+zero-delay retries land directly on the stream and publish ``queued`` instead.
+
+Subscribers (dashboards, "wait for next attempt" logic, etc.) that watched
+for ``scheduled`` on every retry will no longer see it for the zero-delay
+case.  This test locks that semantics in so a regression to the old
+"always park, always publish scheduled" behaviour is caught at the contract
+boundary instead of at runtime in someone's pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from datetime import timedelta
+
+import pytest
+from docket import Docket, Worker
+from docket.dependencies import Retry
+
+TASK_KEY = "immediate-retry"
+
+
+@pytest.fixture
+async def state_messages(docket: Docket):
+    """Collect every state event published on the test task's channel."""
+    messages: list[dict[str, object]] = []
+    ready = asyncio.Event()
+
+    async def collector() -> None:
+        async with docket._pubsub() as pubsub:  # pyright: ignore[reportPrivateUsage]
+            await pubsub.subscribe(docket.key(f"state:{TASK_KEY}"))
+            ready.set()
+            async for message in pubsub.listen():
+                if message["type"] != "message":
+                    continue  # pragma: no cover
+                data = message["data"]
+                payload = data.decode() if isinstance(data, bytes) else data
+                messages.append(json.loads(payload))
+
+    task = asyncio.create_task(collector())
+    await ready.wait()
+    try:
+        yield messages
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_immediate_retry_publishes_queued_state_event(
+    docket: Docket,
+    worker: Worker,
+    state_messages: list[dict[str, object]],
+) -> None:
+    """A ``Retry(delay=timedelta(0))`` reschedule publishes ``state=queued``.
+
+    The first attempt raises, ``Retry.handle_failure`` calls
+    ``execution.schedule(replace=True, reschedule_message=...)`` with
+    ``delay=0``, so ``_schedule``'s reschedule branch takes the
+    ``is_immediate`` path (XADD straight to the stream), and the Lua-side
+    PUBLISH carries the Python-built ``state=queued`` payload.
+    """
+    attempts: list[int] = []
+
+    async def the_task(
+        retry: Retry = Retry(attempts=2, delay=timedelta(0)),
+    ) -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("first attempt fails to trigger immediate retry")
+
+    docket.register(the_task)
+    await docket.add(the_task, key=TASK_KEY)()
+
+    await worker.run_until_finished()
+    # Let the subscriber drain.
+    await asyncio.sleep(0.05)
+
+    # Sanity: the task ran twice (original + immediate retry).
+    assert len(attempts) == 2
+
+    # The reschedule emitted exactly one state event from the _schedule
+    # Lua reschedule branch.  With is_immediate=True, that event's state
+    # MUST be 'queued' (the new behaviour), not 'scheduled' (the old).
+    reschedule_events = [
+        msg
+        for msg in state_messages
+        if msg.get("state") in {"queued", "scheduled"} and msg.get("when") is not None
+    ]
+    # We expect at least the initial QUEUED (from the first add) and the
+    # retry's QUEUED.  No 'scheduled' events should appear because the
+    # immediate path was used both times.
+    assert reschedule_events, (
+        f"expected to see at least one queued/scheduled state event; "
+        f"got: {state_messages!r}"
+    )
+    assert not any(msg.get("state") == "scheduled" for msg in state_messages), (
+        f"immediate retry must not publish state=scheduled (that was the "
+        f"pre-fix behaviour where the reschedule branch always parked); "
+        f"got: {state_messages!r}"
+    )
+    assert sum(1 for msg in state_messages if msg.get("state") == "queued") >= 2, (
+        f"expected at least two queued events (initial add + retry); "
+        f"got: {state_messages!r}"
+    )
+
+
+async def test_delayed_retry_still_publishes_scheduled_state_event(
+    docket: Docket,
+    worker: Worker,
+    state_messages: list[dict[str, object]],
+) -> None:
+    """A retry with a non-zero delay parks into the queue and still publishes
+    ``state=scheduled``.  Counterpart to the immediate-retry test: confirms
+    the new branch hasn't accidentally collapsed both delays into one.
+    """
+    attempts: list[int] = []
+
+    async def the_task(
+        retry: Retry = Retry(attempts=2, delay=timedelta(milliseconds=50)),
+    ) -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise RuntimeError("first attempt fails to trigger delayed retry")
+
+    docket.register(the_task)
+    await docket.add(the_task, key=TASK_KEY)()
+
+    await worker.run_until_finished()
+    await asyncio.sleep(0.05)
+
+    assert len(attempts) == 2
+
+    # The retry parked into the queue with delay>0, so the Lua reschedule
+    # branch took the non-immediate path and published 'scheduled'.
+    assert any(msg.get("state") == "scheduled" for msg in state_messages), (
+        f"a delayed retry must publish state=scheduled when it parks; "
+        f"got: {state_messages!r}"
+    )

--- a/tests/test_immediate_retry_state.py
+++ b/tests/test_immediate_retry_state.py
@@ -25,6 +25,8 @@ import pytest
 from docket import Docket, Worker
 from docket.dependencies import Retry
 
+from tests.conftest import wait_for_event
+
 TASK_KEY = "immediate-retry"
 
 
@@ -81,8 +83,14 @@ async def test_immediate_retry_publishes_queued_state_event(
     await docket.add(the_task, key=TASK_KEY)()
 
     await worker.run_until_finished()
-    # Let the subscriber drain.
-    await asyncio.sleep(0.05)
+    # Wait for the terminal completed event before asserting.  Once it's
+    # in the subscriber's list, every prior state event for this run
+    # (including the retry's queued event) is too.
+    await wait_for_event(
+        state_messages,
+        lambda m: m.get("state") == "completed",
+        description="terminal completed event",
+    )
 
     # Sanity: the task ran twice (original + immediate retry).
     assert len(attempts) == 2
@@ -135,7 +143,11 @@ async def test_delayed_retry_still_publishes_scheduled_state_event(
     await docket.add(the_task, key=TASK_KEY)()
 
     await worker.run_until_finished()
-    await asyncio.sleep(0.05)
+    await wait_for_event(
+        state_messages,
+        lambda m: m.get("state") == "completed",
+        description="terminal completed event",
+    )
 
     assert len(attempts) == 2
 

--- a/tests/test_lua_decorator.py
+++ b/tests/test_lua_decorator.py
@@ -358,6 +358,53 @@ def test_missing_key_parameter_is_rejected_at_decoration_time() -> None:
             ...
 
 
+async def test_encode_scalar_rejects_none(docket: Docket) -> None:
+    """Passing ``None`` for an ``Arg[str]`` raises ``TypeError`` immediately.
+
+    The TypeVar bound on ``Arg[T]`` catches obvious mistakes at decoration
+    time, but a payload dict built dynamically (the ``extra_fields`` list
+    in ``_terminal`` is the canonical example) can still smuggle ``None``
+    through.  We want the failure to surface here -- with a precise local
+    message naming the bad value -- instead of as an opaque DataError from
+    redis-py three frames down.
+    """
+    async with docket.redis() as redis:
+        with pytest.raises(TypeError, match="must be str/bytes/int/float/bool"):
+            await _echo_keys_and_args(
+                redis,
+                first_key=_k(docket, "k1"),
+                second_key=_k(docket, "k2"),
+                first_arg="ok",
+                second_arg=None,  # type: ignore[arg-type]
+            )
+
+
+async def test_encode_scalar_rejects_variadic_with_unsupported_element(
+    docket: Docket,
+) -> None:
+    """Variadic ``Args[list[str]]`` elements go through the same encoder,
+    so a ``None`` (or any non-scalar) hiding inside the list also raises."""
+    async with docket.redis() as redis:
+        with pytest.raises(TypeError, match="must be str/bytes/int/float/bool"):
+            await _echo_list(
+                redis,
+                key=_k(docket, "k"),
+                items=["ok", None, "also-ok"],
+            )
+
+
+async def test_encode_scalar_rejects_dict_value(docket: Docket) -> None:
+    """Variadic ``Args[dict[str, str]]`` values flow through the encoder too,
+    so a ``None`` value raises just like a None list element."""
+    async with docket.redis() as redis:
+        with pytest.raises(TypeError, match="must be str/bytes/int/float/bool"):
+            await _echo_dict(
+                redis,
+                key=_k(docket, "k"),
+                fields={"good": "ok", "bad": None},
+            )
+
+
 def test_arg_after_args_is_rejected_at_decoration_time() -> None:
     """``Args[...]`` must be the trailing parameter.
 

--- a/tests/test_payload_escaping.py
+++ b/tests/test_payload_escaping.py
@@ -154,3 +154,65 @@ async def test_concurrency_park_payload_is_parseable_with_weird_key(
         assert msg.get("key") == WEIRD_KEY, (
             f"key round-trip failed in state event: {msg!r}"
         )
+
+
+async def test_concurrency_wake_payload_is_parseable_with_weird_key(
+    docket: Docket,
+    worker: Worker,
+    state_messages: list[dict[str, object]],
+) -> None:
+    """``_release_and_wake`` Lua publishes a ``queued`` state event when
+    moving a parked waiter back into the main stream.  The payload is built
+    inside Lua with the partial JSON escaper, so a weird task key must
+    still round-trip as parseable JSON when the wake fires.
+
+    Pairs with ``test_concurrency_park_payload_is_parseable_with_weird_key``:
+    that test covers the ``scheduled`` event from the park path; this one
+    covers the ``queued`` event from the wake path, which uses a different
+    Lua escape site.
+    """
+    messages = state_messages
+
+    holder_started = asyncio.Event()
+    holder_may_finish = asyncio.Event()
+    weird_task_started = asyncio.Event()
+
+    async def the_task(
+        marker: str,
+        limit: ConcurrencyLimit = ConcurrencyLimit(max_concurrent=1),
+    ) -> None:
+        if marker == "holder":
+            holder_started.set()
+            await holder_may_finish.wait()
+        else:
+            weird_task_started.set()
+
+    docket.register(the_task)
+
+    # Holder grabs the only slot first, so the weird-key task is forced
+    # to park.  Once the holder finishes, ``_release_and_wake`` runs and
+    # publishes the wake's ``queued`` event for the weird key.
+    await docket.add(the_task, key="holder")("holder")
+    worker_task = asyncio.create_task(worker.run_until_finished())
+    await asyncio.wait_for(holder_started.wait(), timeout=5)
+
+    await docket.add(the_task, key=WEIRD_KEY)("contender")
+    # Give the parking script time to publish its scheduled event first.
+    await asyncio.sleep(0.1)
+
+    # Release the holder.  _release_and_wake forwards the weird-key
+    # waiter back into the main stream and PUBLISHes the queued event
+    # we care about here.
+    holder_may_finish.set()
+    await asyncio.wait_for(weird_task_started.wait(), timeout=5)
+    await asyncio.wait_for(worker_task, timeout=10)
+    await asyncio.sleep(0.05)
+
+    assert any(msg.get("state") == "queued" for msg in messages), (
+        f"subscriber should have seen a queued state event from "
+        f"_release_and_wake; got: {messages!r}"
+    )
+    for msg in messages:
+        assert msg.get("key") == WEIRD_KEY, (
+            f"key round-trip failed in state event: {msg!r}"
+        )

--- a/tests/test_payload_escaping.py
+++ b/tests/test_payload_escaping.py
@@ -26,6 +26,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from docket import ConcurrencyLimit, Docket, Worker
 
+from tests.conftest import wait_for_event
+
 # Weird key that exercises the five escapes the Lua side handles:
 # - `"` would close the JSON string mid-value.
 # - `\` plus the following char would form an invalid JSON escape.
@@ -197,8 +199,15 @@ async def test_concurrency_wake_payload_is_parseable_with_weird_key(
     await asyncio.wait_for(holder_started.wait(), timeout=5)
 
     await docket.add(the_task, key=WEIRD_KEY)("contender")
-    # Give the parking script time to publish its scheduled event first.
-    await asyncio.sleep(0.1)
+    # Wait for _acquire_or_park's scheduled event before releasing the
+    # holder.  Confirms the contender has actually parked, and pins the
+    # ordering so the queued event we assert on can only come from the
+    # wake path that follows.
+    await wait_for_event(
+        messages,
+        lambda m: m.get("state") == "scheduled",
+        description="park's scheduled event",
+    )
 
     # Release the holder.  _release_and_wake forwards the weird-key
     # waiter back into the main stream and PUBLISHes the queued event
@@ -206,7 +215,14 @@ async def test_concurrency_wake_payload_is_parseable_with_weird_key(
     holder_may_finish.set()
     await asyncio.wait_for(weird_task_started.wait(), timeout=5)
     await asyncio.wait_for(worker_task, timeout=10)
-    await asyncio.sleep(0.05)
+
+    # Wait for the wake's queued event itself (the assertion below
+    # would otherwise race against the subscriber task).
+    await wait_for_event(
+        messages,
+        lambda m: m.get("state") == "queued",
+        description="wake's queued event",
+    )
 
     assert any(msg.get("state") == "queued" for msg in messages), (
         f"subscriber should have seen a queued state event from "

--- a/tests/test_perpetual_state.py
+++ b/tests/test_perpetual_state.py
@@ -10,6 +10,7 @@ from docket import Docket, ExecutionState, Worker
 from docket._execution_progress import StateEvent
 from docket.dependencies import CurrentExecution, Perpetual
 from docket.execution import Execution
+from tests.conftest import wait_until
 
 
 async def test_perpetual_task_with_ttl_zero(zero_ttl_docket: Docket) -> None:
@@ -78,14 +79,17 @@ async def test_perpetual_task_no_state_accumulation_with_ttl_zero(
 
         assert len(executions) == 5
 
-        # Small delay for Redis to process expirations
-        await asyncio.sleep(0.2)
+        # With execution_ttl=0, state records should be DELed by the
+        # final _terminal Lua.  Poll for the keys to clear instead of
+        # racing a fixed 200 ms sleep -- the deletion is in-band with
+        # the call we just awaited, so this almost always returns on
+        # the first poll.
+        async def no_state_records() -> bool:
+            async with zero_ttl_docket.redis() as redis:
+                keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")
+                return len(keys) == 0
 
-        # Check that we're not accumulating state records
-        # With TTL=0, state records should be deleted immediately
-        async with zero_ttl_docket.redis() as redis:  # pragma: no branch
-            keys = await redis.keys(f"{zero_ttl_docket.name}:runs:*")
-            assert len(keys) == 0, f"Should have no state records, found {len(keys)}"
+        await wait_until(no_state_records, description="all state records DELed")
 
 
 async def test_rapid_perpetual_tasks_no_conflicts(
@@ -134,21 +138,22 @@ async def test_perpetual_same_key_no_state_accumulation(
     # All should use the same key
     assert len(set(executions)) == 1
 
-    # Small delay for state TTL to take effect
-    await asyncio.sleep(0.5)
+    # Check state records - with default 15min TTL, the last completed state
+    # should exist.  The HSET in _terminal is in-band with run_at_most's
+    # last cycle, so this should be immediate -- poll instead of sleeping.
+    async def exactly_one_state_record() -> bool:
+        async with docket.redis() as redis:
+            # SCAN, not KEYS, since hash-tagged patterns break in cluster mode.
+            pattern = f"{docket.prefix}:runs:*"
+            count = 0
+            async for _ in redis.scan_iter(match=pattern):
+                count += 1
+            return count == 1
 
-    # Check state records - with default 15min TTL, the last completed state should exist
-    async with docket.redis() as redis:
-        # Since all executions share the same key, there should be exactly 1 state record
-        # Use SCAN instead of KEYS because KEYS with hash-tagged patterns doesn't work
-        # reliably in cluster mode (curly braces confuse pattern matching)
-        pattern = f"{docket.prefix}:runs:*"
-        keys: list[bytes] = []
-        async for key in redis.scan_iter(match=pattern):
-            keys.append(key)
-        assert len(keys) == 1, (
-            f"Should have exactly one state record, found {len(keys)}"
-        )
+    await wait_until(
+        exactly_one_state_record,
+        description="exactly one runs:* state record",
+    )
 
 
 async def test_perpetual_task_state_transitions_with_same_key(

--- a/tests/test_progress_pubsub.py
+++ b/tests/test_progress_pubsub.py
@@ -34,17 +34,19 @@ async def test_progress_publish_events(progress: ExecutionProgress):
     """Progress updates should publish events to pub/sub channel."""
     # Set up subscriber in background
     events: list[ProgressEvent] = []
+    subscribed = asyncio.Event()
 
     async def collect_events():
-        async for event in progress.subscribe():  # pragma: no cover
+        async for event in progress.subscribe(ready=subscribed):  # pragma: no cover
             events.append(event)
             if len(events) >= 3:  # Collect 3 events then stop
                 break
 
     subscriber_task = asyncio.create_task(collect_events())
 
-    # Give subscriber time to connect
-    await asyncio.sleep(0.1)
+    # Wait for the SUBSCRIBE to be acknowledged so the publishes below
+    # are guaranteed to be delivered.
+    await subscribed.wait()
 
     # Publish updates
     await progress.set_total(100)
@@ -94,9 +96,10 @@ async def test_run_subscribe_both_state_and_progress(execution: Execution):
     """Run.subscribe() should yield both state and progress events."""
     # Set up subscriber in background
     all_events: list[StateEvent | ProgressEvent] = []
+    subscribed = asyncio.Event()
 
     async def collect_events():
-        async for event in execution.subscribe():  # pragma: no cover
+        async for event in execution.subscribe(ready=subscribed):  # pragma: no cover
             all_events.append(event)
             # Stop after we get a running state and some progress
             if (
@@ -114,8 +117,8 @@ async def test_run_subscribe_both_state_and_progress(execution: Execution):
 
     subscriber_task = asyncio.create_task(collect_events())
 
-    # Give subscriber time to connect
-    await asyncio.sleep(0.1)
+    # Wait for the SUBSCRIBE to be acknowledged.
+    await subscribed.wait()
 
     # Publish mixed state and progress events
     await execution.claim("worker-1")
@@ -150,16 +153,17 @@ async def test_completed_state_publishes_event(execution: Execution):
     """Completed state should publish event with completed_at timestamp."""
     # Set up subscriber
     events: list[StateEvent] = []
+    subscribed = asyncio.Event()
 
     async def collect_events():
-        async for event in execution.subscribe():  # pragma: no cover
+        async for event in execution.subscribe(ready=subscribed):  # pragma: no cover
             if event["type"] == "state":
                 events.append(event)
             if any(e["state"] == ExecutionState.COMPLETED for e in events):
                 break
 
     subscriber_task = asyncio.create_task(collect_events())
-    await asyncio.sleep(0.1)
+    await subscribed.wait()
 
     await execution.claim("worker-1")
     await execution.mark_as_completed()
@@ -176,16 +180,17 @@ async def test_failed_state_publishes_event_with_error(execution: Execution):
     """Failed state should publish event with error message."""
     # Set up subscriber
     events: list[StateEvent] = []
+    subscribed = asyncio.Event()
 
     async def collect_events():
-        async for event in execution.subscribe():  # pragma: no cover
+        async for event in execution.subscribe(ready=subscribed):  # pragma: no cover
             if event["type"] == "state":
                 events.append(event)
             if any(e["state"] == ExecutionState.FAILED for e in events):
                 break
 
     subscriber_task = asyncio.create_task(collect_events())
-    await asyncio.sleep(0.1)
+    await subscribed.wait()
 
     await execution.claim("worker-1")
     await execution.mark_as_failed("Something went wrong!")
@@ -221,8 +226,10 @@ async def test_end_to_end_progress_monitoring_with_worker(
     execution = await docket.add(task_with_progress)()
 
     # Start subscriber to collect events
+    subscribed = asyncio.Event()
+
     async def collect_events():
-        async for event in execution.subscribe():  # pragma: no cover
+        async for event in execution.subscribe(ready=subscribed):  # pragma: no cover
             collected_events.append(event)
             # Stop when we reach completed state
             if event["type"] == "state" and event["state"] == ExecutionState.COMPLETED:
@@ -230,8 +237,8 @@ async def test_end_to_end_progress_monitoring_with_worker(
 
     subscriber_task = asyncio.create_task(collect_events())
 
-    # Give subscriber time to connect
-    await asyncio.sleep(0.1)
+    # Wait for the SUBSCRIBE to be acknowledged before starting the worker.
+    await subscribed.wait()
 
     # Run the worker
     await worker.run_until_finished()
@@ -300,15 +307,17 @@ async def test_end_to_end_failed_task_monitoring(docket: Docket, worker: Worker)
     execution = await docket.add(failing_task)()
 
     # Start subscriber
+    subscribed = asyncio.Event()
+
     async def collect_events():
-        async for event in execution.subscribe():  # pragma: no cover
+        async for event in execution.subscribe(ready=subscribed):  # pragma: no cover
             collected_events.append(event)
             # Stop when we reach failed state
             if event["type"] == "state" and event["state"] == ExecutionState.FAILED:
                 break
 
     subscriber_task = asyncio.create_task(collect_events())
-    await asyncio.sleep(0.1)
+    await subscribed.wait()
 
     # Run the worker
     await worker.run_until_finished()

--- a/tests/test_strikelist.py
+++ b/tests/test_strikelist.py
@@ -4,16 +4,42 @@ from __future__ import annotations
 
 # pyright: reportPrivateUsage=false
 
-import asyncio
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 import pytest
 
 from docket import StrikeList
 from docket.strikelist import Operator, Restore, Strike
+from tests.conftest import wait_until
 
 if TYPE_CHECKING:
     from docket.execution import Execution
+
+
+async def wait_until_stricken(
+    strikes: StrikeList, target: Mapping[str, Any], *, timeout: float = 5.0
+) -> None:
+    """Wait for the StrikeList's monitor task to have processed enough
+    stream entries to make ``target`` match a strike.  Replaces a fixed
+    ``asyncio.sleep`` after ``send_strike()`` / ``strikes.strike()``."""
+    await wait_until(
+        lambda: strikes.is_stricken(target),
+        timeout=timeout,
+        description=f"is_stricken({target!r})",
+    )
+
+
+async def wait_until_restored(
+    strikes: StrikeList, target: Mapping[str, Any], *, timeout: float = 5.0
+) -> None:
+    """Wait for the monitor task to have processed a restore so ``target``
+    no longer matches any strike.  Replaces a fixed ``asyncio.sleep``
+    after ``send_restore()`` / ``strikes.restore()``."""
+    await wait_until(
+        lambda: not strikes.is_stricken(target),
+        timeout=timeout,
+        description=f"not is_stricken({target!r})",
+    )
 
 
 @pytest.fixture
@@ -206,9 +232,8 @@ async def test_receives_strikes(redis_url: str, strike_name: str):
     """Test that StrikeList receives strikes from the stream."""
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         await send_strike(strikes, "customer_id", "==", "blocked")
-        await asyncio.sleep(0.1)
+        await wait_until_stricken(strikes, {"customer_id": "blocked"})
 
-        assert strikes.is_stricken({"customer_id": "blocked"})
         assert not strikes.is_stricken({"customer_id": "allowed"})
 
 
@@ -216,12 +241,10 @@ async def test_receives_restore(redis_url: str, strike_name: str):
     """Test that StrikeList receives restores from the stream."""
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         await send_strike(strikes, "customer_id", "==", "blocked")
-        await asyncio.sleep(0.1)
-        assert strikes.is_stricken({"customer_id": "blocked"})
+        await wait_until_stricken(strikes, {"customer_id": "blocked"})
 
         await send_restore(strikes, "customer_id", "==", "blocked")
-        await asyncio.sleep(0.1)
-        assert not strikes.is_stricken({"customer_id": "blocked"})
+        await wait_until_restored(strikes, {"customer_id": "blocked"})
 
 
 async def test_receives_multiple_strikes(redis_url: str, strike_name: str):
@@ -229,11 +252,12 @@ async def test_receives_multiple_strikes(redis_url: str, strike_name: str):
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         await send_strike(strikes, "region", "==", "us-west")
         await send_strike(strikes, "priority", ">=", 5)
-        await asyncio.sleep(0.1)
+        # Wait for the second strike to be in effect (monitor task processes
+        # stream entries in order, so this implies the first one too).
+        await wait_until_stricken(strikes, {"region": "us-east", "priority": 10})
 
         # Either condition triggers strike
         assert strikes.is_stricken({"region": "us-west", "priority": 1})
-        assert strikes.is_stricken({"region": "us-east", "priority": 10})
         assert not strikes.is_stricken({"region": "us-east", "priority": 1})
 
 
@@ -242,7 +266,7 @@ async def test_new_instance_receives_existing_strikes(redis_url: str, strike_nam
     # Create first instance and send a strike
     async with StrikeList(url=redis_url, name=strike_name) as strikes1:
         await send_strike(strikes1, "customer_id", "==", "blocked")
-        await asyncio.sleep(0.1)
+        await wait_until_stricken(strikes1, {"customer_id": "blocked"})
 
     # Start a new StrikeList instance - should read existing strikes
     async with StrikeList(url=redis_url, name=strike_name) as strikes2:
@@ -264,7 +288,9 @@ async def test_all_operators(redis_url: str, strike_name: str):
         await send_strike(strikes, "lt_param", "<", 10)
         await send_strike(strikes, "lte_param", "<=", 10)
         await send_strike(strikes, "between_param", "between", (20, 30))
-        await asyncio.sleep(0.1)
+        # Wait for the last strike to land -- the monitor processes the
+        # stream in order, so once we see this one, all prior ones are in.
+        await wait_until_stricken(strikes, {"between_param": 25})
 
         # ==
         assert strikes.is_stricken({"eq_param": 42})
@@ -299,7 +325,7 @@ async def test_empty_dict_not_stricken(redis_url: str, strike_name: str):
     """Test that an empty dict is never stricken."""
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         await send_strike(strikes, "customer_id", "==", "blocked")
-        await asyncio.sleep(0.1)
+        await wait_until_stricken(strikes, {"customer_id": "blocked"})
 
         assert not strikes.is_stricken({})
 
@@ -310,7 +336,7 @@ async def test_type_mismatch_handled_gracefully(
     """Test that type mismatches don't raise exceptions."""
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         await send_strike(strikes, "amount", ">", 100)
-        await asyncio.sleep(0.1)
+        await wait_until_stricken(strikes, {"amount": 200})
 
         # Comparing string to int should not raise
         result = strikes.is_stricken({"amount": "not a number"})
@@ -353,21 +379,21 @@ async def test_invariant_no_empty_dicts_in_task_strikes_after_restore(
         await strikes.strike(
             function="my_task", parameter="user_id", operator="==", value=123
         )
-        await asyncio.sleep(0.1)
+        await wait_until(
+            lambda: "my_task" in strikes.task_strikes,
+            description="my_task strike to register",
+        )
 
         # Verify structure exists
-        assert "my_task" in strikes.task_strikes
         assert "user_id" in strikes.task_strikes["my_task"]
 
         # Restore the strike
         await strikes.restore(
             function="my_task", parameter="user_id", operator="==", value=123
         )
-        await asyncio.sleep(0.1)
-
-        # After restore, no empty dict entries should remain
-        assert "my_task" not in strikes.task_strikes, (
-            "task_strikes should not contain empty task entries"
+        await wait_until(
+            lambda: "my_task" not in strikes.task_strikes,
+            description="my_task strike to be restored",
         )
 
 
@@ -378,19 +404,19 @@ async def test_invariant_no_empty_dicts_in_parameter_strikes_after_restore(
     async with StrikeList(url=redis_url, name=strike_name) as strikes:
         # Strike a parameter (applies to all tasks)
         await strikes.strike(parameter="region", operator="==", value="us-west")
-        await asyncio.sleep(0.1)
+        await wait_until(
+            lambda: "region" in strikes.parameter_strikes,
+            description="region parameter strike to register",
+        )
 
         # Verify structure exists
-        assert "region" in strikes.parameter_strikes
         assert len(strikes.parameter_strikes["region"]) == 1
 
         # Restore the strike
         await strikes.restore(parameter="region", operator="==", value="us-west")
-        await asyncio.sleep(0.1)
-
-        # After restore, no empty set entries should remain
-        assert "region" not in strikes.parameter_strikes, (
-            "parameter_strikes should not contain empty parameter entries"
+        await wait_until(
+            lambda: "region" not in strikes.parameter_strikes,
+            description="region parameter strike to be restored",
         )
 
 
@@ -410,11 +436,13 @@ async def test_invariant_multiple_strike_restore_cycles(
             await strikes.strike(
                 parameter="global_param", operator=">=", value=100 + cycle
             )
-            await asyncio.sleep(0.05)
-
-            # Verify strikes are in effect
-            assert "task_a" in strikes.task_strikes
-            assert "global_param" in strikes.parameter_strikes
+            await wait_until(
+                lambda: (
+                    "task_a" in strikes.task_strikes
+                    and "global_param" in strikes.parameter_strikes
+                ),
+                description=f"both strikes registered in cycle {cycle}",
+            )
 
             # Restore
             await strikes.restore(
@@ -426,14 +454,12 @@ async def test_invariant_multiple_strike_restore_cycles(
             await strikes.restore(
                 parameter="global_param", operator=">=", value=100 + cycle
             )
-            await asyncio.sleep(0.05)
-
-            # After each cycle, both dicts should be clean
-            assert "task_a" not in strikes.task_strikes, (
-                f"Orphan in task_strikes after cycle {cycle}"
-            )
-            assert "global_param" not in strikes.parameter_strikes, (
-                f"Orphan in parameter_strikes after cycle {cycle}"
+            await wait_until(
+                lambda: (
+                    "task_a" not in strikes.task_strikes
+                    and "global_param" not in strikes.parameter_strikes
+                ),
+                description=f"both restores cleaned up in cycle {cycle}",
             )
 
 
@@ -452,7 +478,10 @@ async def test_invariant_strikelist_state_persists_through_context(
 
     # Add some data
     await strikes.strike(parameter="test_param", operator="==", value="test_value")
-    await asyncio.sleep(0.1)
+    await wait_until(
+        lambda: "test_param" in strikes.parameter_strikes,
+        description="test_param strike to register",
+    )
 
     await strikes.__aexit__(None, None, None)
 


### PR DESCRIPTION
A read-through of the changes since 0.20.3 surfaced a handful of
implicit guarantees that the code maintains but no test would notice
if they broke.  This adds tests that lock those decisions in and
makes one small production change to surface a latent type-system
loophole.

Locked-in invariants from the post-release review:

- \`_release_and_wake\` JSON-escapes weird task keys in the published
  \`queued\` event (counterpart to the existing \`_acquire_or_park\`
  test).

- \`Retry(delay=timedelta(0))\` reschedules publish \`state=queued\`,
  not \`state=scheduled\`.  A delayed Retry still publishes
  \`scheduled\`.

- \`AdmissionBlocked(handled=True)\` (the ConcurrencyLimit park
  path) doesn't fire the worker's safety-net \`mark_as_failed\`:
  no \`state=failed\` event hits the parked task's channel and the
  runs hash stays \`scheduled\`.

- \`_claim\` SUPERSEDED ACKs and XDELs the stale stream message so
  the entry doesn't linger in PEL.

- The safety-net \`mark_as_failed(error=None)\` publishes a
  \`state=failed\` event with NO \`error\` field -- so anyone alerting
  on \`state=failed && !error\` knows this is the safety-net
  signature.

- A successful Retry sets \`execution._acked = True\` so the worker
  safety net doesn't double-fire \`mark_as_failed\` on the
  just-rescheduled retry.

- \`_encode_scalar\` now raises \`TypeError\` on values that aren't
  str/bytes/int/float/bool, instead of falling through to a redis-py
  DataError several frames down.  The \`Arg[T]\` TypeVar bound catches
  most misuse at decoration time, but a payload dict built
  dynamically (e.g. \`extra_fields\` in \`_terminal\`) could smuggle a
  \`None\` through at runtime.

Broader implicit guarantees made explicit:

- Per-docket isolation: two dockets sharing one Redis don't see
  each other's tasks via \`get_execution\`, don't have their state
  flipped by the other's \`cancel\`, and don't receive each other's
  state pubsub events.

- \`add()\` with a duplicate key preserves the FIRST call's \`when\`
  and args -- \`ALREADY_SCHEDULED\` is a no-op on the runs hash, not
  a silent overwrite.

- \`replace()\` makes the prior-generation message unclaimable: a
  stale Execution at the pre-replace generation gets SUPERSEDED at
  claim time.

- Double-cancel on a running task is a no-op on the runs hash:
  state stays \`cancelled\` and \`completed_at\` keeps the first
  cancel's timestamp.