### PR TITLE
fix: disable Redis socket timeout

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -26,7 +26,7 @@ max_lines = 905
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 882
+max_lines = 883
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -850,12 +850,12 @@ class RedisConnection:
         """Publish a message to a pub/sub channel."""
         if self._cluster_client is not None:  # pragma: no cover
             async with Redis(connection_pool=self._node_pool) as r:
-                return cast(int, await r.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
+                return await r.publish(channel, message)  # pyright: ignore[reportUnknownMemberType]
         elif self._memory_client is not None:
             return await self._memory_client.publish(channel, message)
         else:
             async with Redis(connection_pool=self._connection_pool) as r:
-                return cast(int, await r.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
+                return await r.publish(channel, message)  # pyright: ignore[reportUnknownMemberType]
 
     @asynccontextmanager
     async def _cluster_pubsub(self) -> AsyncGenerator[PubSub, None]:  # pragma: no cover

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -746,7 +746,7 @@ class RedisConnection:
         Returns:
             An initialized RedisCluster client ready for use
         """
-        client: RedisCluster = RedisCluster.from_url(self._normalized_url())
+        client = RedisCluster.from_url(self._normalized_url(), socket_timeout=None)
         await client.initialize()
         return client
 
@@ -774,6 +774,7 @@ class RedisConnection:
             if self._parsed.scheme == "rediss+cluster"
             else Connection,
             decode_responses=False,
+            socket_timeout=None,
         )
 
     async def _connection_pool_from_url(
@@ -791,7 +792,7 @@ class RedisConnection:
             A ConnectionPool ready for use with Redis clients
         """
         return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
-            self.url, decode_responses=decode_responses
+            self.url, decode_responses=decode_responses, socket_timeout=None
         )
 
     async def _get_or_create_memory_client(self) -> MemoryRedisClient:

--- a/tests/_container.py
+++ b/tests/_container.py
@@ -236,7 +236,7 @@ def wait_for_cluster(port: int) -> None:
         try:
             # Try to connect and verify cluster state
             r: RedisCluster = RedisCluster.from_url(f"redis://localhost:{port}")
-            info: dict[str, str] = r.cluster_info()  # type: ignore[reportUnknownMemberType]
+            info: dict[str, str] = r.cluster_info()
             if info.get("cluster_state") != "ok":
                 r.close()
                 time.sleep(0.1)

--- a/tests/test_docket_keys.py
+++ b/tests/test_docket_keys.py
@@ -2,13 +2,15 @@
 
 # pyright: reportPrivateUsage=false
 
-from typing import cast
+import time
 
 import pytest
 import redis.exceptions
+from redis.asyncio import Redis
 
 from docket._redis import RedisConnection
 from docket.docket import Docket
+from tests.conftest import skip_cluster, skip_memory
 
 
 # Tests for prefix property and key() method
@@ -236,10 +238,11 @@ async def test_redis_connection_pool_disables_socket_timeout():
     connection = RedisConnection("redis://localhost:6379/0")
     pool = await connection._connection_pool_from_url()
 
+    redis_connection = pool.make_connection()
     try:
-        connection_kwargs = cast(dict[str, object], getattr(pool, "connection_kwargs"))
-        assert connection_kwargs["socket_timeout"] is None
+        assert redis_connection.socket_timeout is None
     finally:
+        await redis_connection.disconnect()
         await pool.aclose()
 
 
@@ -248,8 +251,30 @@ async def test_redis_connection_pool_respects_url_socket_timeout():
     connection = RedisConnection("redis://localhost:6379/0?socket_timeout=15")
     pool = await connection._connection_pool_from_url()
 
+    redis_connection = pool.make_connection()
     try:
-        connection_kwargs = cast(dict[str, object], getattr(pool, "connection_kwargs"))
-        assert connection_kwargs["socket_timeout"] == 15.0
+        assert redis_connection.socket_timeout == 15.0
+    finally:
+        await redis_connection.disconnect()
+        await pool.aclose()
+
+
+@skip_memory
+@skip_cluster
+async def test_redis_blocking_read_outlasts_redis_py_default_socket_timeout(
+    redis_url: str,
+):
+    """Docket Redis connections should allow blocking reads longer than 5s."""
+    connection = RedisConnection(redis_url)
+    pool = await connection._connection_pool_from_url()
+
+    try:
+        async with Redis(connection_pool=pool) as redis:
+            started = time.monotonic()
+            result = await redis.xread({"docket-test-missing-stream": "$"}, block=6000)
+            elapsed = time.monotonic() - started
     finally:
         await pool.aclose()
+
+    assert result == []
+    assert elapsed >= 5.0

--- a/tests/test_docket_keys.py
+++ b/tests/test_docket_keys.py
@@ -2,6 +2,8 @@
 
 # pyright: reportPrivateUsage=false
 
+from typing import cast
+
 import pytest
 import redis.exceptions
 
@@ -227,3 +229,27 @@ def test_redis_connection_normalized_url_returns_original_for_non_cluster():
 
     connection2 = RedisConnection("memory://")
     assert connection2._normalized_url() == "memory://"
+
+
+async def test_redis_connection_pool_disables_socket_timeout():
+    """Redis blocking reads should not be cut short by client socket timeout."""
+    connection = RedisConnection("redis://localhost:6379/0")
+    pool = await connection._connection_pool_from_url()
+
+    try:
+        connection_kwargs = cast(dict[str, object], getattr(pool, "connection_kwargs"))
+        assert connection_kwargs["socket_timeout"] is None
+    finally:
+        await pool.aclose()
+
+
+async def test_redis_connection_pool_respects_url_socket_timeout():
+    """Explicit Redis URL socket_timeout should override Docket's default."""
+    connection = RedisConnection("redis://localhost:6379/0?socket_timeout=15")
+    pool = await connection._connection_pool_from_url()
+
+    try:
+        connection_kwargs = cast(dict[str, object], getattr(pool, "connection_kwargs"))
+        assert connection_kwargs["socket_timeout"] == 15.0
+    finally:
+        await pool.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -1719,14 +1719,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Docket uses Redis blocking reads and pubsub listeners as its worker/monitor wait mechanism. Redis-py 8.0.0 changed the default `socket_timeout` from `None` to `5`, which can cut off expected idle waits like `XREAD BLOCK` / `XREADGROUP BLOCK` with `TimeoutError` before Redis returns.

This explicitly keeps Docket Redis client socket reads unbounded unless callers opt into a timeout through the Redis URL. That preserves the pre-redis-py-8 behavior while still allowing explicit URL overrides like `?socket_timeout=15`.

Bumps the `src/docket/_redis.py` loq baseline by one line for this targeted fix.

Fixes #425.