### PR TITLE
Add Redis Sentinel support via redis+sentinel:// URLs

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -135,6 +135,41 @@ When using cluster mode, Docket automatically:
 
 **Note:** All Docket data for a single docket name will be stored on the same cluster shard. This ensures atomicity for Lua scripts and simplifies data management, but means individual dockets don't benefit from cluster data distribution.
 
+### Redis Sentinel Support
+
+Docket supports [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/)
+master discovery using the `redis+sentinel://` URL scheme. The URL lists the
+Sentinel daemons (defaulting to port 26379) and names the monitored master
+group; Docket resolves the current master through the Sentinels and follows
+failover automatically:
+
+```python
+# Discover the master named "mymaster" through two Sentinels
+async with Docket(
+    name="orders",
+    url="redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0"
+) as docket:
+    pass
+
+# With authentication: the URL credentials apply to the data nodes, and the
+# sentinel_username/sentinel_password query parameters to the Sentinels
+async with Docket(
+    name="orders",
+    url=(
+        "redis+sentinel://user:password@sentinel-a:26379,sentinel-b:26379"
+        "/mymaster/0?sentinel_password=sentinelsecret"
+    ),
+) as docket:
+    pass
+
+# TLS for both the data nodes and the Sentinels
+async with Docket(
+    name="orders",
+    url="rediss+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0"
+) as docket:
+    pass
+```
+
 ### Authentication
 
 Docket supports Redis authentication via URL credentials:

--- a/docs/production.md
+++ b/docs/production.md
@@ -170,6 +170,11 @@ async with Docket(
     pass
 ```
 
+Standard redis-py connection options in the query string (see
+[Redis Connection Pools](#redis-connection-pools) above) apply to the data-node
+pool just as they do for standalone URLs — for example
+`redis+sentinel://sentinel-a:26379/mymaster/0?max_connections=50`.
+
 ### Authentication
 
 Docket supports Redis authentication via URL credentials:

--- a/docs/production.md
+++ b/docs/production.md
@@ -173,7 +173,15 @@ async with Docket(
 Standard redis-py connection options in the query string (see
 [Redis Connection Pools](#redis-connection-pools) above) apply to the data-node
 pool just as they do for standalone URLs — for example
-`redis+sentinel://sentinel-a:26379/mymaster/0?max_connections=50`.
+`redis+sentinel://sentinel-a:26379/mymaster/0?max_connections=50`. The database
+index comes from the path (`/mymaster/0`) and the data-node credentials from the
+URL userinfo.
+
+Because Docket disables the read timeout for its long blocking reads, the
+Sentinel data-node pool defaults to tight TCP keepalive so that a master which
+dies *silently* — a network partition or frozen host that never closes the
+connection — is noticed within seconds rather than waiting on the OS-default
+keepalive, letting the worker follow the Sentinel failover promptly.
 
 ### Authentication
 

--- a/loq.toml
+++ b/loq.toml
@@ -26,7 +26,7 @@ max_lines = 907
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 1075
+max_lines = 1095
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"

--- a/loq.toml
+++ b/loq.toml
@@ -26,7 +26,7 @@ max_lines = 907
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 1116
+max_lines = 922
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"

--- a/loq.toml
+++ b/loq.toml
@@ -22,11 +22,11 @@ max_lines = 1190
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 905
+max_lines = 907
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 896
+max_lines = 1075
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"

--- a/loq.toml
+++ b/loq.toml
@@ -26,7 +26,7 @@ max_lines = 907
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 1095
+max_lines = 1116
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -34,12 +34,12 @@ from typing import (
     overload,
     runtime_checkable,
 )
-from urllib.parse import ParseResult, parse_qs, unquote, urlparse, urlunparse
+from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urlparse, urlunparse
 
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import PubSub
 from redis.asyncio.cluster import RedisCluster
-from redis.asyncio.connection import Connection, SSLConnection
+from redis.asyncio.connection import Connection, SSLConnection, parse_url
 from redis.asyncio.sentinel import Sentinel, SentinelConnectionPool
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -619,8 +619,9 @@ class SentinelConfiguration:
 
     ``connection_kwargs`` applies to the data-node (master) connections and
     ``sentinel_kwargs`` to the connections to the Sentinel daemons themselves;
-    both hold redis-py-native keys (``username``, ``password``, ``ssl``) so a
-    caller can splat them directly.
+    both hold redis-py-native keys (``username``, ``password``, ``ssl``, plus
+    any standard connection options from the URL query string) so a caller can
+    splat them directly.
     """
 
     sentinels: list[tuple[str, int]]
@@ -642,9 +643,14 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
     authentication to the Sentinel daemons separately. A ``rediss`` prefix
     turns on TLS for both the data nodes and the Sentinel daemons.
 
+    All other query parameters are standard redis-py connection options
+    (``max_connections``, ``socket_timeout``, ``health_check_interval``, ...)
+    and apply to the data-node connections with exactly the same parsing as a
+    standalone ``redis://`` URL.
+
     Raises:
         ValueError: for a missing host, malformed port, missing service name,
-            or malformed database index
+            malformed database index, or malformed connection option
     """
     parsed = urlparse(url)
 
@@ -683,10 +689,10 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
             "e.g. redis+sentinel://localhost:26379/mymaster"
         )
     service_name = segments[0]
-    db = 0
+    path_db = 0
     if len(segments) > 1:
         try:
-            db = int(segments[1])
+            path_db = int(segments[1])
         except ValueError:
             raise ValueError(
                 f"Invalid database index {segments[1]!r} in sentinel URL"
@@ -694,24 +700,37 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
 
     tls = parsed.scheme == "rediss+sentinel"
 
-    connection_kwargs: dict[str, Any] = {}
-    if parsed.username:
-        connection_kwargs["username"] = unquote(parsed.username)
-    if parsed.password:
-        connection_kwargs["password"] = unquote(parsed.password)
-    if tls:
-        connection_kwargs["ssl"] = True
-
     query = parse_qs(parsed.query, keep_blank_values=True)
     sentinel_kwargs: dict[str, Any] = {}
-    sentinel_username = query.get("sentinel_username", [""])[0]
-    sentinel_password = query.get("sentinel_password", [""])[0]
+    sentinel_username = query.pop("sentinel_username", [""])[0]
+    sentinel_password = query.pop("sentinel_password", [""])[0]
     if sentinel_username:
         sentinel_kwargs["username"] = sentinel_username
     if sentinel_password:
         sentinel_kwargs["password"] = sentinel_password
     if tls:
         sentinel_kwargs["ssl"] = True
+
+    # The remaining query parameters are standard redis-py connection options
+    # (max_connections, socket_timeout, health_check_interval, ...).  Funnel
+    # them through redis-py's parse_url on a synthetic standalone URL so they
+    # get exactly the same type conversion and validation as redis:// URLs.
+    connection_kwargs: dict[str, Any] = {}
+    if query:
+        remaining_query = urlencode(
+            [(name, value) for name, values in query.items() for value in values]
+        )
+        connection_kwargs.update(parse_url(f"redis:///?{remaining_query}"))
+
+    # Mirror redis-py's precedence: a db query parameter wins over the path,
+    # and userinfo credentials win over username/password query parameters.
+    db = connection_kwargs.pop("db", path_db)
+    if parsed.username:
+        connection_kwargs["username"] = unquote(parsed.username)
+    if parsed.password:
+        connection_kwargs["password"] = unquote(parsed.password)
+    if tls:
+        connection_kwargs["ssl"] = True
 
     return SentinelConfiguration(
         sentinels=sentinels,
@@ -978,14 +997,15 @@ class RedisConnection:
         """
         config = parse_sentinel_url(self.url)
         sentinel = Sentinel(config.sentinels, sentinel_kwargs=config.sentinel_kwargs)
-        return OwnedSentinelConnectionPool(
-            config.service_name,
-            sentinel,
-            db=config.db,
-            decode_responses=decode_responses,
-            socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
+        # URL query options override the defaults, just as ConnectionPool.from_url
+        # lets a socket_timeout in a standalone URL take precedence.
+        pool_kwargs: dict[str, Any] = {
+            "db": config.db,
+            "decode_responses": decode_responses,
+            "socket_timeout": BLOCKING_READ_SOCKET_TIMEOUT,
             **config.connection_kwargs,
-        )
+        }
+        return OwnedSentinelConnectionPool(config.service_name, sentinel, **pool_kwargs)
 
     async def _get_or_create_memory_client(self) -> MemoryRedisClient:
         """Get or create a BurnerRedis instance for a memory:// URL."""

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -14,6 +14,7 @@ import asyncio
 import importlib
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from threading import Lock as _ThreadLock
 from types import TracebackType
@@ -33,12 +34,13 @@ from typing import (
     overload,
     runtime_checkable,
 )
-from urllib.parse import ParseResult, urlparse, urlunparse
+from urllib.parse import ParseResult, parse_qs, unquote, urlparse, urlunparse
 
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import PubSub
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
+from redis.asyncio.sentinel import Sentinel, SentinelConnectionPool
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -606,13 +608,157 @@ def get_memory_server(url: str) -> MemoryRedisClient | None:
     return entry[1]
 
 
+# Redis Sentinel daemons listen on 26379 by default, so sentinel members
+# without an explicit port assume that rather than the data-node port 6379.
+DEFAULT_SENTINEL_PORT = 26379
+
+
+@dataclass(frozen=True)
+class SentinelConfiguration:
+    """A Redis Sentinel topology parsed from a redis+sentinel:// URL.
+
+    ``connection_kwargs`` applies to the data-node (master) connections and
+    ``sentinel_kwargs`` to the connections to the Sentinel daemons themselves;
+    both hold redis-py-native keys (``username``, ``password``, ``ssl``) so a
+    caller can splat them directly.
+    """
+
+    sentinels: list[tuple[str, int]]
+    service_name: str
+    db: int
+    connection_kwargs: dict[str, Any]
+    sentinel_kwargs: dict[str, Any]
+
+
+def parse_sentinel_url(url: str) -> SentinelConfiguration:
+    """Parse a redis+sentinel:// or rediss+sentinel:// URL.
+
+    The grammar follows the redis-sentinel-url convention:
+
+        redis+sentinel://[user:pass@]host[:port][,host2[:port2],...]/service_name[/db]
+
+    The userinfo applies to the data-node (master) connections; the
+    ``sentinel_username`` and ``sentinel_password`` query parameters configure
+    authentication to the Sentinel daemons separately. A ``rediss`` prefix
+    turns on TLS for both the data nodes and the Sentinel daemons.
+
+    Raises:
+        ValueError: for a missing host, malformed port, missing service name,
+            or malformed database index
+    """
+    parsed = urlparse(url)
+
+    # urlparse only exposes the segment before the first comma through
+    # .hostname/.port, so the multi-host netloc is split by hand.
+    hostpart = parsed.netloc.rpartition("@")[2]
+    sentinels: list[tuple[str, int]] = []
+    for member in hostpart.split(","):
+        member = member.strip()
+        if not member:
+            continue
+        if member.startswith("["):
+            # Bracketed IPv6 member, e.g. [::1] or [::1]:26380
+            host, _, rest = member[1:].partition("]")
+            port_text = rest.removeprefix(":")
+        else:
+            host, separator, port_text = member.rpartition(":")
+            if not separator:
+                host, port_text = member, ""
+        if not host:
+            raise ValueError(f"Missing host in sentinel member {member!r}")
+        try:
+            port = int(port_text) if port_text else DEFAULT_SENTINEL_PORT
+        except ValueError:
+            raise ValueError(
+                f"Invalid port {port_text!r} in sentinel member {member!r}"
+            ) from None
+        sentinels.append((host, port))
+    if not sentinels:
+        raise ValueError("A sentinel URL requires at least one sentinel host")
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if not segments:
+        raise ValueError(
+            "A sentinel URL requires a service name, "
+            "e.g. redis+sentinel://localhost:26379/mymaster"
+        )
+    service_name = segments[0]
+    db = 0
+    if len(segments) > 1:
+        try:
+            db = int(segments[1])
+        except ValueError:
+            raise ValueError(
+                f"Invalid database index {segments[1]!r} in sentinel URL"
+            ) from None
+
+    tls = parsed.scheme == "rediss+sentinel"
+
+    connection_kwargs: dict[str, Any] = {}
+    if parsed.username:
+        connection_kwargs["username"] = unquote(parsed.username)
+    if parsed.password:
+        connection_kwargs["password"] = unquote(parsed.password)
+    if tls:
+        connection_kwargs["ssl"] = True
+
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    sentinel_kwargs: dict[str, Any] = {}
+    sentinel_username = query.get("sentinel_username", [""])[0]
+    sentinel_password = query.get("sentinel_password", [""])[0]
+    if sentinel_username:
+        sentinel_kwargs["username"] = sentinel_username
+    if sentinel_password:
+        sentinel_kwargs["password"] = sentinel_password
+    if tls:
+        sentinel_kwargs["ssl"] = True
+
+    return SentinelConfiguration(
+        sentinels=sentinels,
+        service_name=service_name,
+        db=db,
+        connection_kwargs=connection_kwargs,
+        sentinel_kwargs=sentinel_kwargs,
+    )
+
+
+class OwnedSentinelConnectionPool(SentinelConnectionPool):
+    """A SentinelConnectionPool that owns its Sentinel manager.
+
+    redis-py's Sentinel manager keeps one Redis client per Sentinel daemon and
+    has no aclose() of its own, so closing the pool also closes those clients.
+
+    The class-level annotations refine attributes that redis-py assigns in
+    untyped __init__ code, so callers get typed access.
+    """
+
+    service_name: str
+    is_master: bool
+    connection_kwargs: dict[str, Any]
+    sentinel_manager: Sentinel
+
+    @property
+    def sentinel_clients(self) -> Sequence[Redis]:
+        """The Redis clients connected to the Sentinel daemons."""
+        return cast(
+            "Sequence[Redis]",
+            self.sentinel_manager.sentinels,  # pyright: ignore[reportUnknownMemberType]
+        )
+
+    async def aclose(self) -> None:
+        await super().aclose()
+        for sentinel_client in self.sentinel_clients:
+            await close_resource(sentinel_client, "sentinel client")
+
+
 class RedisConnection:
-    """Manages Redis connections for both standalone and cluster modes.
+    """Manages Redis connections for standalone, Sentinel, and cluster modes.
 
     This class encapsulates the lifecycle management of Redis connections,
-    hiding whether the underlying connection is to a standalone Redis server
-    or a Redis Cluster. It provides a unified interface for getting Redis
-    clients, pub/sub connections, and publishing messages.
+    hiding whether the underlying connection is to a standalone Redis server,
+    a Sentinel-monitored master, or a Redis Cluster. It provides a unified
+    interface for getting Redis clients, pub/sub connections, and publishing
+    messages.
 
     Example:
         async with RedisConnection("redis://localhost:6379/0") as connection:
@@ -636,7 +782,8 @@ class RedisConnection:
         """Initialize a Redis connection manager.
 
         Args:
-            url: Redis URL (redis://, rediss://, redis+cluster://, or memory://)
+            url: Redis URL (redis://, rediss://, redis+sentinel://,
+                redis+cluster://, or memory://)
         """
         self.url = url
         self._parsed = urlparse(url)
@@ -701,6 +848,11 @@ class RedisConnection:
     def is_cluster(self) -> bool:
         """Check if this connection is to a Redis Cluster."""
         return self._parsed.scheme in ("redis+cluster", "rediss+cluster")
+
+    @property
+    def is_sentinel(self) -> bool:
+        """Check if this connection discovers its master through Redis Sentinel."""
+        return self._parsed.scheme in ("redis+sentinel", "rediss+sentinel")
 
     @property
     def is_memory(self) -> bool:
@@ -793,8 +945,9 @@ class RedisConnection:
     ) -> ConnectionPool:
         """Create a Redis connection pool from the URL.
 
-        This is only for real Redis connections (redis://, rediss://).
-        Memory backend uses BurnerRedis directly, not connection pools.
+        This is only for real Redis connections (redis://, rediss://, and the
+        +sentinel variants).  Memory backend uses BurnerRedis directly, not
+        connection pools.
 
         Args:
             decode_responses: If True, decode Redis responses from bytes to strings
@@ -802,10 +955,36 @@ class RedisConnection:
         Returns:
             A ConnectionPool ready for use with Redis clients
         """
+        if self.is_sentinel:
+            return self._sentinel_connection_pool(decode_responses=decode_responses)
         return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
             self.url,
             decode_responses=decode_responses,
             socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
+        )
+
+    def _sentinel_connection_pool(self, decode_responses: bool) -> ConnectionPool:
+        """Create a connection pool that resolves the master through Sentinel.
+
+        The pool asks the listed Sentinel daemons for the current master and
+        follows failover automatically, so the rest of the standalone code
+        path (client, pub/sub, publish, result storage) works unchanged.
+
+        Args:
+            decode_responses: If True, decode Redis responses from bytes to strings
+
+        Returns:
+            A ConnectionPool ready for use with Redis clients
+        """
+        config = parse_sentinel_url(self.url)
+        sentinel = Sentinel(config.sentinels, sentinel_kwargs=config.sentinel_kwargs)
+        return OwnedSentinelConnectionPool(
+            config.service_name,
+            sentinel,
+            db=config.db,
+            decode_responses=decode_responses,
+            socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
+            **config.connection_kwargs,
         )
 
     async def _get_or_create_memory_client(self) -> MemoryRedisClient:

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -613,6 +613,27 @@ def get_memory_server(url: str) -> MemoryRedisClient | None:
 DEFAULT_SENTINEL_PORT = 26379
 
 
+def _parse_connection_url(url: str) -> ParseResult:
+    """urlparse that tolerates multi-host netlocs with bracketed IPv6 members.
+
+    Recent CPython releases reject netlocs like ``s1:26379,[::1]:26379`` with
+    ValueError("Invalid IPv6 URL") because data precedes a bracket, so the
+    netloc is carved off by hand, the rest of the URL is parsed with a
+    placeholder host, and the real netloc is restored on the result.
+    """
+    scheme, separator, remainder = url.partition("://")
+    if not separator:
+        return urlparse(url)
+    end = len(remainder)
+    for terminator in "/?#":
+        index = remainder.find(terminator)
+        if index != -1:
+            end = min(end, index)
+    netloc, tail = remainder[:end], remainder[end:]
+    parsed = urlparse(f"{scheme}://netloc-placeholder{tail}")
+    return parsed._replace(netloc=netloc)
+
+
 @dataclass(frozen=True)
 class SentinelConfiguration:
     """A Redis Sentinel topology parsed from a redis+sentinel:// URL.
@@ -652,7 +673,7 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
         ValueError: for a missing host, malformed port, missing service name,
             malformed database index, or malformed connection option
     """
-    parsed = urlparse(url)
+    parsed = _parse_connection_url(url)
 
     # urlparse only exposes the segment before the first comma through
     # .hostname/.port, so the multi-host netloc is split by hand.
@@ -805,7 +826,7 @@ class RedisConnection:
                 redis+cluster://, or memory://)
         """
         self.url = url
-        self._parsed = urlparse(url)
+        self._parsed = _parse_connection_url(url)
         self._connection_pool = None
         self._cluster_client = None
         self._node_pool = None

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -6,6 +6,9 @@ the burner-redis backend used for memory:// URLs.
 This module is designed to be the single point of cluster-awareness, so that
 other modules can remain simple. When Redis Cluster support is added, only
 this module will need to change.
+
+Redis Sentinel support lives in the companion ``_redis_sentinel.py`` module;
+this module only detects the ``redis+sentinel://`` scheme and dispatches there.
 """
 
 from __future__ import annotations
@@ -14,7 +17,6 @@ import asyncio
 import importlib
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from threading import Lock as _ThreadLock
 from types import TracebackType
@@ -34,13 +36,12 @@ from typing import (
     overload,
     runtime_checkable,
 )
-from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import PubSub
 from redis.asyncio.cluster import RedisCluster
-from redis.asyncio.connection import Connection, SSLConnection, parse_url
-from redis.asyncio.sentinel import Sentinel, SentinelConnectionPool
+from redis.asyncio.connection import Connection, SSLConnection
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -608,189 +609,6 @@ def get_memory_server(url: str) -> MemoryRedisClient | None:
     return entry[1]
 
 
-# Redis Sentinel daemons listen on 26379 by default, so sentinel members
-# without an explicit port assume that rather than the data-node port 6379.
-DEFAULT_SENTINEL_PORT = 26379
-
-
-def _parse_connection_url(url: str) -> ParseResult:
-    """urlparse that tolerates multi-host netlocs with bracketed IPv6 members.
-
-    Recent CPython releases reject netlocs like ``s1:26379,[::1]:26379`` with
-    ValueError("Invalid IPv6 URL") because data precedes a bracket, so the
-    netloc is carved off by hand, the rest of the URL is parsed with a
-    placeholder host, and the real netloc is restored on the result.
-    """
-    scheme, separator, remainder = url.partition("://")
-    if not separator:
-        return urlparse(url)
-    end = len(remainder)
-    for terminator in "/?#":
-        index = remainder.find(terminator)
-        if index != -1:
-            end = min(end, index)
-    netloc, tail = remainder[:end], remainder[end:]
-    parsed = urlparse(f"{scheme}://netloc-placeholder{tail}")
-    return parsed._replace(netloc=netloc)
-
-
-@dataclass(frozen=True)
-class SentinelConfiguration:
-    """A Redis Sentinel topology parsed from a redis+sentinel:// URL.
-
-    ``connection_kwargs`` applies to the data-node (master) connections and
-    ``sentinel_kwargs`` to the connections to the Sentinel daemons themselves;
-    both hold redis-py-native keys (``username``, ``password``, ``ssl``, plus
-    any standard connection options from the URL query string) so a caller can
-    splat them directly.
-    """
-
-    sentinels: list[tuple[str, int]]
-    service_name: str
-    db: int
-    connection_kwargs: dict[str, Any]
-    sentinel_kwargs: dict[str, Any]
-
-
-def parse_sentinel_url(url: str) -> SentinelConfiguration:
-    """Parse a redis+sentinel:// or rediss+sentinel:// URL.
-
-    The grammar follows the redis-sentinel-url convention:
-
-        redis+sentinel://[user:pass@]host[:port][,host2[:port2],...]/service_name[/db]
-
-    The userinfo applies to the data-node (master) connections; the
-    ``sentinel_username`` and ``sentinel_password`` query parameters configure
-    authentication to the Sentinel daemons separately. A ``rediss`` prefix
-    turns on TLS for both the data nodes and the Sentinel daemons.
-
-    All other query parameters are standard redis-py connection options
-    (``max_connections``, ``socket_timeout``, ``health_check_interval``, ...)
-    and apply to the data-node connections with exactly the same parsing as a
-    standalone ``redis://`` URL.
-
-    Raises:
-        ValueError: for a missing host, malformed port, missing service name,
-            malformed database index, or malformed connection option
-    """
-    parsed = _parse_connection_url(url)
-
-    # urlparse only exposes the segment before the first comma through
-    # .hostname/.port, so the multi-host netloc is split by hand.
-    hostpart = parsed.netloc.rpartition("@")[2]
-    sentinels: list[tuple[str, int]] = []
-    for member in hostpart.split(","):
-        member = member.strip()
-        if not member:
-            continue
-        if member.startswith("["):
-            # Bracketed IPv6 member, e.g. [::1] or [::1]:26380
-            host, _, rest = member[1:].partition("]")
-            port_text = rest.removeprefix(":")
-        else:
-            host, separator, port_text = member.rpartition(":")
-            if not separator:
-                host, port_text = member, ""
-        if not host:
-            raise ValueError(f"Missing host in sentinel member {member!r}")
-        try:
-            port = int(port_text) if port_text else DEFAULT_SENTINEL_PORT
-        except ValueError:
-            raise ValueError(
-                f"Invalid port {port_text!r} in sentinel member {member!r}"
-            ) from None
-        sentinels.append((host, port))
-    if not sentinels:
-        raise ValueError("A sentinel URL requires at least one sentinel host")
-
-    segments = [segment for segment in parsed.path.split("/") if segment]
-    if not segments:
-        raise ValueError(
-            "A sentinel URL requires a service name, "
-            "e.g. redis+sentinel://localhost:26379/mymaster"
-        )
-    service_name = segments[0]
-    path_db = 0
-    if len(segments) > 1:
-        try:
-            path_db = int(segments[1])
-        except ValueError:
-            raise ValueError(
-                f"Invalid database index {segments[1]!r} in sentinel URL"
-            ) from None
-
-    tls = parsed.scheme == "rediss+sentinel"
-
-    query = parse_qs(parsed.query, keep_blank_values=True)
-    sentinel_kwargs: dict[str, Any] = {}
-    sentinel_username = query.pop("sentinel_username", [""])[0]
-    sentinel_password = query.pop("sentinel_password", [""])[0]
-    if sentinel_username:
-        sentinel_kwargs["username"] = sentinel_username
-    if sentinel_password:
-        sentinel_kwargs["password"] = sentinel_password
-    if tls:
-        sentinel_kwargs["ssl"] = True
-
-    # The remaining query parameters are standard redis-py connection options
-    # (max_connections, socket_timeout, health_check_interval, ...).  Funnel
-    # them through redis-py's parse_url on a synthetic standalone URL so they
-    # get exactly the same type conversion and validation as redis:// URLs.
-    connection_kwargs: dict[str, Any] = {}
-    if query:
-        remaining_query = urlencode(
-            [(name, value) for name, values in query.items() for value in values]
-        )
-        connection_kwargs.update(parse_url(f"redis:///?{remaining_query}"))
-
-    # Mirror redis-py's precedence: a db query parameter wins over the path,
-    # and userinfo credentials win over username/password query parameters.
-    db = connection_kwargs.pop("db", path_db)
-    if parsed.username:
-        connection_kwargs["username"] = unquote(parsed.username)
-    if parsed.password:
-        connection_kwargs["password"] = unquote(parsed.password)
-    if tls:
-        connection_kwargs["ssl"] = True
-
-    return SentinelConfiguration(
-        sentinels=sentinels,
-        service_name=service_name,
-        db=db,
-        connection_kwargs=connection_kwargs,
-        sentinel_kwargs=sentinel_kwargs,
-    )
-
-
-class OwnedSentinelConnectionPool(SentinelConnectionPool):
-    """A SentinelConnectionPool that owns its Sentinel manager.
-
-    redis-py's Sentinel manager keeps one Redis client per Sentinel daemon and
-    has no aclose() of its own, so closing the pool also closes those clients.
-
-    The class-level annotations refine attributes that redis-py assigns in
-    untyped __init__ code, so callers get typed access.
-    """
-
-    service_name: str
-    is_master: bool
-    connection_kwargs: dict[str, Any]
-    sentinel_manager: Sentinel
-
-    @property
-    def sentinel_clients(self) -> Sequence[Redis]:
-        """The Redis clients connected to the Sentinel daemons."""
-        return cast(
-            "Sequence[Redis]",
-            self.sentinel_manager.sentinels,  # pyright: ignore[reportUnknownMemberType]
-        )
-
-    async def aclose(self) -> None:
-        await super().aclose()
-        for sentinel_client in self.sentinel_clients:
-            await close_resource(sentinel_client, "sentinel client")
-
-
 class RedisConnection:
     """Manages Redis connections for standalone, Sentinel, and cluster modes.
 
@@ -825,8 +643,15 @@ class RedisConnection:
             url: Redis URL (redis://, rediss://, redis+sentinel://,
                 redis+cluster://, or memory://)
         """
+        from ._redis_sentinel import is_sentinel_url, urlparse_multihost
+
         self.url = url
-        self._parsed = _parse_connection_url(url)
+        # Sentinel URLs list several daemons in the netloc, which urlparse can't
+        # handle when a bracketed IPv6 member follows another; carve those by
+        # hand and leave standalone, cluster, and memory URLs to urlparse.
+        self._parsed = (
+            urlparse_multihost(url) if is_sentinel_url(url) else urlparse(url)
+        )
         self._connection_pool = None
         self._cluster_client = None
         self._node_pool = None
@@ -996,37 +821,18 @@ class RedisConnection:
             A ConnectionPool ready for use with Redis clients
         """
         if self.is_sentinel:
-            return self._sentinel_connection_pool(decode_responses=decode_responses)
+            from ._redis_sentinel import sentinel_connection_pool
+
+            return sentinel_connection_pool(
+                self.url,
+                decode_responses=decode_responses,
+                socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
+            )
         return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
             self.url,
             decode_responses=decode_responses,
             socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
         )
-
-    def _sentinel_connection_pool(self, decode_responses: bool) -> ConnectionPool:
-        """Create a connection pool that resolves the master through Sentinel.
-
-        The pool asks the listed Sentinel daemons for the current master and
-        follows failover automatically, so the rest of the standalone code
-        path (client, pub/sub, publish, result storage) works unchanged.
-
-        Args:
-            decode_responses: If True, decode Redis responses from bytes to strings
-
-        Returns:
-            A ConnectionPool ready for use with Redis clients
-        """
-        config = parse_sentinel_url(self.url)
-        sentinel = Sentinel(config.sentinels, sentinel_kwargs=config.sentinel_kwargs)
-        # URL query options override the defaults, just as ConnectionPool.from_url
-        # lets a socket_timeout in a standalone URL take precedence.
-        pool_kwargs: dict[str, Any] = {
-            "db": config.db,
-            "decode_responses": decode_responses,
-            "socket_timeout": BLOCKING_READ_SOCKET_TIMEOUT,
-            **config.connection_kwargs,
-        }
-        return OwnedSentinelConnectionPool(config.service_name, sentinel, **pool_kwargs)
 
     async def _get_or_create_memory_client(self) -> MemoryRedisClient:
         """Get or create a BurnerRedis instance for a memory:// URL."""

--- a/src/docket/_redis_sentinel.py
+++ b/src/docket/_redis_sentinel.py
@@ -1,0 +1,273 @@
+"""Redis Sentinel support for docket's ``redis+sentinel://`` URLs.
+
+This module is the single point of Sentinel-awareness: URL parsing, the parsed
+configuration, the connection pool that resolves the master through the Sentinel
+daemons, and the tight TCP keepalive defaults that let a silently-dead master be
+noticed promptly.  ``_redis.py`` only detects the scheme and dispatches here.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from dataclasses import dataclass
+from typing import Any, Sequence, cast
+from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urlparse
+
+from redis.asyncio import ConnectionPool, Redis
+from redis.asyncio.connection import parse_url
+from redis.asyncio.sentinel import Sentinel, SentinelConnectionPool
+
+from ._redis import close_resource
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# Redis Sentinel daemons listen on 26379 by default, so sentinel members
+# without an explicit port assume that rather than the data-node port 6379.
+DEFAULT_SENTINEL_PORT = 26379
+
+SENTINEL_SCHEMES = ("redis+sentinel", "rediss+sentinel")
+
+
+# docket disables the client read timeout (see BLOCKING_READ_SOCKET_TIMEOUT in
+# _redis.py) because of its long, unbounded blocking reads.  That means a master
+# that dies *silently* — a network partition or frozen hypervisor that never
+# sends a FIN/RST — would leave a blocked XREADGROUP waiting on the OS-default
+# TCP keepalive (~2 hours on Linux) while Sentinel completes failover in seconds.
+# We build the Sentinel pool ourselves, so we pin tight keepalive probes here: a
+# dead peer is noticed in roughly TCP_KEEPIDLE + TCP_KEEPCNT * TCP_KEEPINTVL
+# seconds.  The probes only fire on an otherwise-idle socket and a healthy peer
+# answers them, so they don't disturb a legitimately long blocking read — which
+# is exactly why disabling the read timeout is safe.  These match redis-py 8.0's
+# own defaults; pinning them keeps the behaviour identical on the older redis-py
+# releases docket supports (redis>=5), where connections default to no keepalive.
+_SENTINEL_KEEPALIVE_TIMERS: tuple[tuple[str, int], ...] = (
+    ("TCP_KEEPIDLE", 30),
+    ("TCP_KEEPINTVL", 5),
+    ("TCP_KEEPCNT", 3),
+)
+SENTINEL_SOCKET_KEEPALIVE_OPTIONS: dict[int, int] = {
+    int(getattr(socket, name)): value
+    for name, value in _SENTINEL_KEEPALIVE_TIMERS
+    if hasattr(socket, name)
+}
+
+
+def is_sentinel_url(url: str) -> bool:
+    """Whether ``url`` is a redis+sentinel:// or rediss+sentinel:// URL.
+
+    A plain string-prefix check so the rest of ``_redis.py`` can leave standalone,
+    cluster, and memory URLs to ``urlparse`` and only carve the netloc by hand for
+    the multi-host sentinel case.
+    """
+    return url.partition("://")[0] in SENTINEL_SCHEMES
+
+
+def urlparse_multihost(url: str) -> ParseResult:
+    """urlparse a sentinel URL while preserving its multi-host netloc.
+
+    A sentinel URL lists several daemons in its netloc, e.g.
+    ``s1:26379,[::1]:26379``.  ``urlparse`` raises ``ValueError("Invalid IPv6
+    URL")`` for any netloc where data precedes a ``[`` bracket — true on every
+    currently-supported CPython release — so the netloc is carved off by hand,
+    the rest of the URL is parsed with a placeholder host, and the real netloc is
+    restored on the result.
+    """
+    scheme, _, remainder = url.partition("://")
+    end = len(remainder)
+    for terminator in "/?#":
+        index = remainder.find(terminator)
+        if index != -1:
+            end = min(end, index)
+    netloc, tail = remainder[:end], remainder[end:]
+    parsed = urlparse(f"{scheme}://netloc-placeholder{tail}")
+    return parsed._replace(netloc=netloc)
+
+
+@dataclass(frozen=True)
+class SentinelConfiguration:
+    """A Redis Sentinel topology parsed from a redis+sentinel:// URL.
+
+    ``connection_kwargs`` applies to the data-node (master) connections and
+    ``sentinel_kwargs`` to the connections to the Sentinel daemons themselves;
+    both hold redis-py-native keys (``username``, ``password``, ``ssl``, plus
+    any standard connection options from the URL query string) so a caller can
+    splat them directly.
+    """
+
+    sentinels: list[tuple[str, int]]
+    service_name: str
+    db: int
+    connection_kwargs: dict[str, Any]
+    sentinel_kwargs: dict[str, Any]
+
+
+def parse_sentinel_url(url: str) -> SentinelConfiguration:
+    """Parse a redis+sentinel:// or rediss+sentinel:// URL.
+
+    The grammar follows the redis-sentinel-url convention:
+
+        redis+sentinel://[user:pass@]host[:port][,host2[:port2],...]/service_name[/db]
+
+    The database comes from the path and the data-node (master) credentials from
+    the URL userinfo; the ``sentinel_username`` and ``sentinel_password`` query
+    parameters configure authentication to the Sentinel daemons separately. A
+    ``rediss`` prefix turns on TLS for both the data nodes and the Sentinel
+    daemons.
+
+    All other query parameters are standard redis-py connection options
+    (``max_connections``, ``socket_timeout``, ``health_check_interval``, ...)
+    and apply to the data-node connections with exactly the same parsing as a
+    standalone ``redis://`` URL.
+
+    Raises:
+        ValueError: for a missing host, malformed port, missing service name,
+            malformed database index, or malformed connection option
+    """
+    parsed = urlparse_multihost(url)
+
+    # urlparse only exposes the segment before the first comma through
+    # .hostname/.port, so the multi-host netloc is split by hand and each member
+    # parsed on its own; urlparse handles ports, default ports, bracketed IPv6,
+    # and port validation per member.
+    hostpart = parsed.netloc.rpartition("@")[2]
+    sentinels: list[tuple[str, int]] = []
+    for member in hostpart.split(","):
+        member = member.strip()
+        if not member:
+            continue
+        member_url = urlparse(f"//{member}")
+        host = member_url.hostname
+        if not host:
+            raise ValueError(f"Missing host in sentinel member {member!r}")
+        try:
+            port = member_url.port
+        except ValueError:
+            raise ValueError(f"Invalid port in sentinel member {member!r}") from None
+        sentinels.append((host, port if port is not None else DEFAULT_SENTINEL_PORT))
+    if not sentinels:
+        raise ValueError("A sentinel URL requires at least one sentinel host")
+
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if not segments:
+        raise ValueError(
+            "A sentinel URL requires a service name, "
+            "e.g. redis+sentinel://localhost:26379/mymaster"
+        )
+    service_name = segments[0]
+    db = 0
+    if len(segments) > 1:
+        try:
+            db = int(segments[1])
+        except ValueError:
+            raise ValueError(
+                f"Invalid database index {segments[1]!r} in sentinel URL"
+            ) from None
+
+    tls = parsed.scheme == "rediss+sentinel"
+
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    sentinel_kwargs: dict[str, Any] = {}
+    sentinel_username = query.pop("sentinel_username", [""])[0]
+    sentinel_password = query.pop("sentinel_password", [""])[0]
+    if sentinel_username:
+        sentinel_kwargs["username"] = sentinel_username
+    if sentinel_password:
+        sentinel_kwargs["password"] = sentinel_password
+    if tls:
+        sentinel_kwargs["ssl"] = True
+
+    # The remaining query parameters are standard redis-py connection options
+    # (max_connections, socket_timeout, health_check_interval, ...).  Funnel
+    # them through redis-py's parse_url on a synthetic standalone URL so they get
+    # exactly the same type conversion and validation as redis:// URLs.
+    connection_kwargs: dict[str, Any] = {}
+    if query:
+        remaining_query = urlencode(
+            [(name, value) for name, values in query.items() for value in values]
+        )
+        funneled: dict[str, Any] = parse_url(f"redis:///?{remaining_query}")
+        # The query string carries only typed pool options; the database comes
+        # from the path and credentials from the userinfo, so we don't let
+        # parse_url turn a stray ?db=/?username=/?password= into another source.
+        for governed in ("db", "username", "password"):
+            funneled.pop(governed, None)
+        connection_kwargs.update(funneled)
+
+    if parsed.username:
+        connection_kwargs["username"] = unquote(parsed.username)
+    if parsed.password:
+        connection_kwargs["password"] = unquote(parsed.password)
+    if tls:
+        connection_kwargs["ssl"] = True
+
+    return SentinelConfiguration(
+        sentinels=sentinels,
+        service_name=service_name,
+        db=db,
+        connection_kwargs=connection_kwargs,
+        sentinel_kwargs=sentinel_kwargs,
+    )
+
+
+class OwnedSentinelConnectionPool(SentinelConnectionPool):
+    """A SentinelConnectionPool that owns its Sentinel manager.
+
+    redis-py's Sentinel manager keeps one Redis client per Sentinel daemon and
+    has no aclose() of its own, so closing the pool also closes those clients.
+
+    The class-level annotations refine attributes that redis-py assigns in
+    untyped __init__ code, so callers get typed access.
+    """
+
+    service_name: str
+    is_master: bool
+    connection_kwargs: dict[str, Any]
+    sentinel_manager: Sentinel
+
+    @property
+    def sentinel_clients(self) -> Sequence[Redis]:
+        """The Redis clients connected to the Sentinel daemons."""
+        return cast(
+            "Sequence[Redis]",
+            self.sentinel_manager.sentinels,  # pyright: ignore[reportUnknownMemberType]
+        )
+
+    async def aclose(self) -> None:
+        await super().aclose()
+        for sentinel_client in self.sentinel_clients:
+            await close_resource(sentinel_client, "sentinel client")
+
+
+def sentinel_connection_pool(
+    url: str, *, decode_responses: bool, socket_timeout: float | None
+) -> ConnectionPool:
+    """Create a connection pool that resolves the master through Sentinel.
+
+    The pool asks the listed Sentinel daemons for the current master and follows
+    failover automatically, so the rest of the standalone code path (client,
+    pub/sub, publish, result storage) works unchanged.  ``socket_timeout`` is
+    docket's blocking-read timeout, applied to the data-node connections.
+
+    Args:
+        url: The redis+sentinel:// or rediss+sentinel:// URL.
+        decode_responses: If True, decode Redis responses from bytes to strings.
+        socket_timeout: The read timeout for data-node connections.
+
+    Returns:
+        A ConnectionPool ready for use with Redis clients.
+    """
+    config = parse_sentinel_url(url)
+    sentinel = Sentinel(config.sentinels, sentinel_kwargs=config.sentinel_kwargs)
+    # Defaults first so URL query options override them, just as
+    # ConnectionPool.from_url lets a socket_timeout in a standalone URL win.
+    pool_kwargs: dict[str, Any] = {
+        "db": config.db,
+        "decode_responses": decode_responses,
+        "socket_timeout": socket_timeout,
+        "socket_keepalive": True,
+        "socket_keepalive_options": SENTINEL_SOCKET_KEEPALIVE_OPTIONS,
+        **config.connection_kwargs,
+    }
+    return OwnedSentinelConnectionPool(config.service_name, sentinel, **pool_kwargs)

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -164,6 +164,8 @@ class Docket(DocketSnapshotMixin):
                 - "redis://user:password@localhost:6379/0"
                 - "redis://user:password@localhost:6379/0?ssl=true"
                 - "rediss://localhost:6379/0"
+                - "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0"
+                  (Redis Sentinel master discovery)
                 - "unix:///path/to/redis.sock"
                 - "memory://" (in-memory backend for testing)
             heartbeat_interval: How often workers send heartbeat messages to the docket.

--- a/tests/test_sentinel_urls.py
+++ b/tests/test_sentinel_urls.py
@@ -92,6 +92,42 @@ def test_parse_sentinel_url_skips_empty_members():
     ]
 
 
+def test_parse_sentinel_url_passes_through_pool_options():
+    """Standard redis-py options in the query string apply to the data nodes,
+    with the same type conversion as a standalone redis:// URL."""
+    config = parse_sentinel_url(
+        "redis+sentinel://sentinel-a/mymaster"
+        "?max_connections=50&socket_timeout=7.5&health_check_interval=30"
+    )
+    assert config.connection_kwargs == {
+        "max_connections": 50,
+        "socket_timeout": 7.5,
+        "health_check_interval": 30,
+    }
+    assert config.sentinel_kwargs == {}
+
+
+def test_parse_sentinel_url_db_query_parameter_wins_over_path():
+    """Like redis-py's parse_url, a db query parameter beats the path db."""
+    config = parse_sentinel_url("redis+sentinel://sentinel-a/mymaster/2?db=5")
+    assert config.db == 5
+    assert "db" not in config.connection_kwargs
+
+
+def test_parse_sentinel_url_userinfo_wins_over_query_credentials():
+    """Like redis-py's parse_url, URL userinfo beats credential query params."""
+    config = parse_sentinel_url(
+        "redis+sentinel://user:pass@sentinel-a/mymaster?username=qu&password=qp"
+    )
+    assert config.connection_kwargs["username"] == "user"
+    assert config.connection_kwargs["password"] == "pass"
+
+
+def test_parse_sentinel_url_rejects_invalid_option_value():
+    with pytest.raises(ValueError, match="Invalid value for 'max_connections'"):
+        parse_sentinel_url("redis+sentinel://sentinel-a/mymaster?max_connections=lots")
+
+
 def test_parse_sentinel_url_rejects_missing_host():
     with pytest.raises(ValueError, match="Missing host"):
         parse_sentinel_url("redis+sentinel://:26379/mymaster")
@@ -151,6 +187,19 @@ async def test_sentinel_pool_close_also_closes_sentinel_clients():
         await pool.aclose()
 
     assert closed == expected
+
+
+async def test_sentinel_pool_honors_url_pool_options():
+    """URL query options reach the pool, overriding docket's defaults the way
+    ConnectionPool.from_url lets a standalone URL's socket_timeout win."""
+    connection = RedisConnection(
+        "redis+sentinel://sentinel-a/mymaster?max_connections=50&socket_timeout=7.5"
+    )
+    pool = await connection._connection_pool_from_url()  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(pool, OwnedSentinelConnectionPool)
+    assert pool.max_connections == 50
+    assert pool.connection_kwargs["socket_timeout"] == 7.5
+    await pool.aclose()
 
 
 async def test_result_storage_pool_decodes_responses_for_sentinel():

--- a/tests/test_sentinel_urls.py
+++ b/tests/test_sentinel_urls.py
@@ -78,9 +78,30 @@ def test_parse_sentinel_url_tls():
 
 
 def test_parse_sentinel_url_ipv6_member():
-    """Bracketed IPv6 members parse with and without an explicit port."""
-    config = parse_sentinel_url("redis+sentinel://[::1]:26380,[fe80::2]/mymaster")
-    assert config.sentinels == [("::1", 26380), ("fe80::2", DEFAULT_SENTINEL_PORT)]
+    """Bracketed IPv6 members parse with and without an explicit port, in any
+    position — recent CPython urlsplit rejects netlocs with data before a
+    bracket, so the netloc never goes through urlsplit verbatim."""
+    config = parse_sentinel_url("redis+sentinel://s1,[::1]:26380,[fe80::2]/mymaster")
+    assert config.sentinels == [
+        ("s1", DEFAULT_SENTINEL_PORT),
+        ("::1", 26380),
+        ("fe80::2", DEFAULT_SENTINEL_PORT),
+    ]
+
+
+def test_redis_connection_accepts_ipv6_member_after_hostname():
+    """RedisConnection construction itself must tolerate IPv6 members that
+    follow another member in the netloc."""
+    connection = RedisConnection("redis+sentinel://s1:26379,[::1]:26380/mymaster")
+    assert connection.is_sentinel
+
+
+def test_redis_connection_tolerates_scheme_less_url():
+    """A URL without :// falls back to plain urlparse."""
+    connection = RedisConnection("localhost:6379")
+    assert not connection.is_sentinel
+    assert not connection.is_cluster
+    assert not connection.is_memory
 
 
 def test_parse_sentinel_url_skips_empty_members():

--- a/tests/test_sentinel_urls.py
+++ b/tests/test_sentinel_urls.py
@@ -11,10 +11,11 @@ import pytest
 from redis.asyncio import Redis
 
 from docket import Docket
-from docket._redis import (
+from docket._redis import RedisConnection
+from docket._redis_sentinel import (
     DEFAULT_SENTINEL_PORT,
+    SENTINEL_SOCKET_KEEPALIVE_OPTIONS,
     OwnedSentinelConnectionPool,
-    RedisConnection,
     parse_sentinel_url,
 )
 
@@ -79,8 +80,8 @@ def test_parse_sentinel_url_tls():
 
 def test_parse_sentinel_url_ipv6_member():
     """Bracketed IPv6 members parse with and without an explicit port, in any
-    position — recent CPython urlsplit rejects netlocs with data before a
-    bracket, so the netloc never goes through urlsplit verbatim."""
+    position — every currently-supported CPython rejects netlocs with data
+    before a bracket, so the netloc never goes through urlsplit verbatim."""
     config = parse_sentinel_url("redis+sentinel://s1,[::1]:26380,[fe80::2]/mymaster")
     assert config.sentinels == [
         ("s1", DEFAULT_SENTINEL_PORT),
@@ -128,15 +129,17 @@ def test_parse_sentinel_url_passes_through_pool_options():
     assert config.sentinel_kwargs == {}
 
 
-def test_parse_sentinel_url_db_query_parameter_wins_over_path():
-    """Like redis-py's parse_url, a db query parameter beats the path db."""
+def test_parse_sentinel_url_db_comes_from_path_only():
+    """The database is taken from the path; a stray ?db= is not an alternate
+    source, and credentials stay sourced from the URL userinfo."""
     config = parse_sentinel_url("redis+sentinel://sentinel-a/mymaster/2?db=5")
-    assert config.db == 5
+    assert config.db == 2
     assert "db" not in config.connection_kwargs
 
 
-def test_parse_sentinel_url_userinfo_wins_over_query_credentials():
-    """Like redis-py's parse_url, URL userinfo beats credential query params."""
+def test_parse_sentinel_url_credentials_come_from_userinfo_only():
+    """Master credentials come from the URL userinfo; stray ?username=/?password=
+    query parameters are not honored as an alternate source."""
     config = parse_sentinel_url(
         "redis+sentinel://user:pass@sentinel-a/mymaster?username=qu&password=qp"
     )
@@ -220,6 +223,36 @@ async def test_sentinel_pool_honors_url_pool_options():
     assert isinstance(pool, OwnedSentinelConnectionPool)
     assert pool.max_connections == 50
     assert pool.connection_kwargs["socket_timeout"] == 7.5
+    await pool.aclose()
+
+
+async def test_sentinel_pool_defaults_tight_keepalive():
+    """docket disables the read timeout, so the Sentinel pool must default tight
+    TCP keepalive to notice a silently-dead master rather than waiting on the
+    OS-default keepalive (hours), which Sentinel outpaces by failing over in
+    seconds."""
+    connection = RedisConnection(SENTINEL_URL)
+    pool = await connection._connection_pool_from_url()  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(pool, OwnedSentinelConnectionPool)
+    assert pool.connection_kwargs["socket_keepalive"] is True
+    assert (
+        pool.connection_kwargs["socket_keepalive_options"]
+        == SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+    )
+    # The probe timers are populated from the platform's TCP keepalive constants.
+    assert SENTINEL_SOCKET_KEEPALIVE_OPTIONS
+    await pool.aclose()
+
+
+async def test_sentinel_pool_keepalive_is_overridable_from_url():
+    """A socket_keepalive in the URL still wins over docket's default, the way
+    any URL pool option overrides the defaults."""
+    connection = RedisConnection(
+        "redis+sentinel://sentinel-a/mymaster?socket_keepalive=false"
+    )
+    pool = await connection._connection_pool_from_url()  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(pool, OwnedSentinelConnectionPool)
+    assert pool.connection_kwargs["socket_keepalive"] is False
     await pool.aclose()
 
 

--- a/tests/test_sentinel_urls.py
+++ b/tests/test_sentinel_urls.py
@@ -1,0 +1,170 @@
+"""Tests for Redis Sentinel URL handling.
+
+These exercise URL parsing and connection pool construction only; building a
+Sentinel-backed connection pool is lazy and does not connect, so no live
+Sentinel topology is required.
+"""
+
+from unittest import mock
+
+import pytest
+from redis.asyncio import Redis
+
+from docket import Docket
+from docket._redis import (
+    DEFAULT_SENTINEL_PORT,
+    OwnedSentinelConnectionPool,
+    RedisConnection,
+    parse_sentinel_url,
+)
+
+SENTINEL_URL = "redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/1"
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("redis://localhost:6379/0", False),
+        ("rediss://localhost:6379/0", False),
+        ("memory://", False),
+        ("redis+cluster://localhost:6379/0", False),
+        ("rediss+cluster://localhost:6379/0", False),
+        ("redis+sentinel://localhost:26379/mymaster", True),
+        ("rediss+sentinel://localhost:26379/mymaster", True),
+        ("redis+sentinel://user:pass@localhost:26379/mymaster/0", True),
+    ],
+)
+def test_is_sentinel_url(url: str, expected: bool):
+    """RedisConnection.is_sentinel should correctly identify sentinel URLs."""
+    connection = RedisConnection(url)
+    assert connection.is_sentinel == expected
+
+
+def test_sentinel_url_is_neither_cluster_nor_memory():
+    """Sentinel URLs should not be routed down the cluster or memory paths."""
+    connection = RedisConnection(SENTINEL_URL)
+    assert not connection.is_cluster
+    assert not connection.is_memory
+
+
+def test_parse_sentinel_url_minimal():
+    """A single member without a port assumes the Sentinel default port."""
+    config = parse_sentinel_url("redis+sentinel://sentinel-a/mymaster")
+    assert config.sentinels == [("sentinel-a", DEFAULT_SENTINEL_PORT)]
+    assert config.service_name == "mymaster"
+    assert config.db == 0
+    assert config.connection_kwargs == {}
+    assert config.sentinel_kwargs == {}
+
+
+def test_parse_sentinel_url_full():
+    """Members, db, master auth, and sentinel auth all parse out of the URL."""
+    config = parse_sentinel_url(
+        "redis+sentinel://user:s%40crit@sentinel-a:26379,sentinel-b:26380/mymaster/3"
+        "?sentinel_username=watcher&sentinel_password=tower"
+    )
+    assert config.sentinels == [("sentinel-a", 26379), ("sentinel-b", 26380)]
+    assert config.service_name == "mymaster"
+    assert config.db == 3
+    assert config.connection_kwargs == {"username": "user", "password": "s@crit"}
+    assert config.sentinel_kwargs == {"username": "watcher", "password": "tower"}
+
+
+def test_parse_sentinel_url_tls():
+    """A rediss prefix turns on TLS for data nodes and Sentinels alike."""
+    config = parse_sentinel_url("rediss+sentinel://sentinel-a:26379/mymaster")
+    assert config.connection_kwargs == {"ssl": True}
+    assert config.sentinel_kwargs == {"ssl": True}
+
+
+def test_parse_sentinel_url_ipv6_member():
+    """Bracketed IPv6 members parse with and without an explicit port."""
+    config = parse_sentinel_url("redis+sentinel://[::1]:26380,[fe80::2]/mymaster")
+    assert config.sentinels == [("::1", 26380), ("fe80::2", DEFAULT_SENTINEL_PORT)]
+
+
+def test_parse_sentinel_url_skips_empty_members():
+    """Stray commas in the member list are ignored."""
+    config = parse_sentinel_url("redis+sentinel://sentinel-a,,sentinel-b,/mymaster")
+    assert config.sentinels == [
+        ("sentinel-a", DEFAULT_SENTINEL_PORT),
+        ("sentinel-b", DEFAULT_SENTINEL_PORT),
+    ]
+
+
+def test_parse_sentinel_url_rejects_missing_host():
+    with pytest.raises(ValueError, match="Missing host"):
+        parse_sentinel_url("redis+sentinel://:26379/mymaster")
+
+
+def test_parse_sentinel_url_rejects_invalid_port():
+    with pytest.raises(ValueError, match="Invalid port"):
+        parse_sentinel_url("redis+sentinel://sentinel-a:notaport/mymaster")
+
+
+def test_parse_sentinel_url_rejects_empty_member_list():
+    with pytest.raises(ValueError, match="at least one sentinel host"):
+        parse_sentinel_url("redis+sentinel:///mymaster")
+
+
+def test_parse_sentinel_url_rejects_missing_service_name():
+    with pytest.raises(ValueError, match="requires a service name"):
+        parse_sentinel_url("redis+sentinel://sentinel-a:26379")
+
+
+def test_parse_sentinel_url_rejects_invalid_db():
+    with pytest.raises(ValueError, match="Invalid database index"):
+        parse_sentinel_url("redis+sentinel://sentinel-a:26379/mymaster/notadb")
+
+
+async def test_redis_connection_builds_sentinel_pool():
+    """Entering a sentinel RedisConnection builds a Sentinel-backed pool."""
+    async with RedisConnection(SENTINEL_URL) as connection:
+        assert connection.is_connected
+        pool = connection._connection_pool  # pyright: ignore[reportPrivateUsage]
+        assert isinstance(pool, OwnedSentinelConnectionPool)
+        assert pool.service_name == "mymaster"
+        assert pool.is_master
+        assert pool.connection_kwargs["db"] == 1
+        assert len(pool.sentinel_clients) == 2
+
+        async with connection.client() as r:
+            assert isinstance(r, Redis)
+            assert r.connection_pool is pool
+
+    assert not connection.is_connected
+
+
+async def test_sentinel_pool_close_also_closes_sentinel_clients():
+    """Closing the owned pool closes the Sentinel manager's daemon clients."""
+    connection = RedisConnection(SENTINEL_URL)
+    pool = await connection._connection_pool_from_url()  # pyright: ignore[reportPrivateUsage]
+    assert isinstance(pool, OwnedSentinelConnectionPool)
+    expected = list(pool.sentinel_clients)
+
+    closed: list[Redis] = []
+
+    async def tracking_aclose(self: Redis) -> None:
+        closed.append(self)
+
+    with mock.patch.object(Redis, "aclose", tracking_aclose):
+        await pool.aclose()
+
+    assert closed == expected
+
+
+async def test_result_storage_pool_decodes_responses_for_sentinel():
+    """The result store's decoded pool keeps decode_responses for sentinel URLs."""
+    connection = RedisConnection(SENTINEL_URL)
+    pool = await connection._connection_pool_from_url(  # pyright: ignore[reportPrivateUsage]
+        decode_responses=True
+    )
+    assert isinstance(pool, OwnedSentinelConnectionPool)
+    assert pool.connection_kwargs["decode_responses"] is True
+    await pool.aclose()
+
+
+def test_prefix_is_not_hash_tagged_for_sentinel():
+    """Sentinel mode talks to a single logical master, so no hash tags."""
+    docket = Docket(name="my-docket", url=SENTINEL_URL)
+    assert docket.prefix == "my-docket"


### PR DESCRIPTION
Docket currently speaks standalone, cluster, and memory URLs, but not Redis
Sentinel — pointing it at a Sentinel-managed deployment requires a fixed
proxy or VIP in front of the master. This PR teaches `RedisConnection` the
`redis+sentinel://` and `rediss+sentinel://` schemes so Docket discovers the
current master through the Sentinel daemons and follows failover
automatically.

A sentinel URL lists the Sentinel daemons (ports default to 26379) and names
the monitored master group:

    redis+sentinel://[user:pass@]host[:port][,host2[:port2],...]/service_name[/db]

`parse_sentinel_url()` validates the member list, service name, and database
index, splitting master credentials (URL userinfo) from Sentinel daemon
credentials (`sentinel_username` / `sentinel_password` query parameters); a
`rediss` prefix turns on TLS for both.

The connection reuses the standalone code path end to end:
`_connection_pool_from_url()` returns an `OwnedSentinelConnectionPool` — a
`SentinelConnectionPool` that resolves the master through the Sentinel
manager and closes the manager's per-daemon clients on `aclose()`, since
redis-py's `Sentinel` has no close of its own. Because it's an ordinary
`ConnectionPool` to callers, `client()`, `pubsub()`, `publish()`, and the
result store work unchanged, and no hash-tagged prefixes are needed —
Sentinel is a single logical master.

Building the pool is lazy, so the new tests cover URL parsing and pool
construction without a live Sentinel topology. I also smoke-tested end to
end against a real master + sentinel in Docker: `docket.add()` +
`Worker.run_until_finished()` through
`redis+sentinel://localhost:26379/mymaster/0` schedules and executes
correctly.

Validation:

- `uv run prek run --all-files` passes (ruff, pyright strict, codespell,
  loq — limits bumped for the two files that grew).
- Full `pytest` suite: 884 passed. The remaining coverage misses in my
  environment are identical to main's (branches only the CI backend matrix
  reaches); all new sentinel code is covered.

A natural follow-up, mirroring how cluster support landed, would be a
sentinel leg in the CI backend matrix (master + replica + sentinel
containers) to exercise real failover — happy to take a crack at that if
this direction looks right.

For context on the motivation: Prefect's server uses Docket via
`PREFECT_SERVER_DOCKET_URL`, and we're adding Redis Sentinel support across
prefect-redis (staged on top of PrefectHQ/prefect#22211) — Docket is the one
remaining server↔Redis path that can't resolve a Sentinel URL, which blocks
fully HA self-hosted deployments behind Sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)