### PR TITLE
Reconnect when a blocking read loses Redis mid-loop

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1260
+max_lines = 1281
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -706,6 +706,7 @@ class Worker:
                 if not execution._acked:
                     await execution.mark_as_failed(error=None)
 
+        disconnect: ConnectionError | None = None
         try:
             async with AsyncExitStack() as dependency_stack:
                 # Each Dependency class used by a registered task may declare
@@ -752,23 +753,43 @@ class Worker:
                             )
                             continue
 
-                        for source in [get_redeliveries, get_new_deliveries]:
-                            for stream_key, messages in await source(redis):
-                                is_redelivery = stream_key == b"__redelivery__"
-                                for message_id, message in messages:
-                                    if not message:  # pragma: no cover
-                                        continue
+                        try:
+                            for source in [get_redeliveries, get_new_deliveries]:
+                                for stream_key, messages in await source(redis):
+                                    is_redelivery = stream_key == b"__redelivery__"
+                                    for message_id, message in messages:
+                                        if not message:  # pragma: no cover
+                                            continue
 
-                                    await start_task(message_id, message, is_redelivery)
+                                        await start_task(
+                                            message_id, message, is_redelivery
+                                        )
 
-                            if available_slots <= 0:
-                                break
+                                if available_slots <= 0:
+                                    break
 
-                        if not forever and not active_tasks:
-                            has_work = await check_for_work()
+                            if not forever and not active_tasks:
+                                has_work = await check_for_work()
+                        except ConnectionError as error:
+                            # The worker's own polling read lost its connection --
+                            # a failover or a server restart drops a blocked
+                            # XREADGROUP this way.  Stop the loop and let _run
+                            # reconnect; in-flight tasks still drain in the finally
+                            # below.  A ConnectionError raised by a task body
+                            # surfaces through process_completed_tasks instead,
+                            # which stays outside this guard so it keeps its
+                            # die-and-redeliver behavior.
+                            disconnect = error
+                            break
 
                     # Signal internal tasks to stop before exiting TaskGroup
                     self._worker_stopping.set()
+
+            # A disconnection in the poll loop above leaves the TaskGroup intact
+            # (no exception escaped it), so re-raise it here as a bare
+            # ConnectionError for _run to catch and reconnect on.
+            if disconnect is not None:
+                raise disconnect
 
         except asyncio.CancelledError:
             if active_tasks:  # pragma: no cover

--- a/tests/worker/test_core.py
+++ b/tests/worker/test_core.py
@@ -76,34 +76,6 @@ async def test_two_workers_split_work(docket: Docket):
         assert call_counts[worker2] > 20
 
 
-async def test_worker_reconnects_when_connection_is_lost(
-    docket: Docket, the_task: AsyncMock
-):
-    """The worker should reconnect when the connection is lost"""
-    worker = Worker(docket, reconnection_delay=timedelta(milliseconds=100))
-
-    # Mock the _worker_loop method to fail once then succeed
-    original_worker_loop = worker._worker_loop  # type: ignore[protected-access]
-    call_count = 0
-
-    async def mock_worker_loop(redis: RedisClient, forever: bool = False):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise ConnectionError("Simulated connection error")
-        return await original_worker_loop(redis, forever=forever)  # type: ignore[arg-type]
-
-    worker._worker_loop = mock_worker_loop  # type: ignore[protected-access]
-
-    await docket.add(the_task)()
-
-    async with worker:
-        await worker.run_until_finished()
-
-        assert call_count == 2
-        the_task.assert_called_once()
-
-
 async def test_worker_respects_concurrency_limit(docket: Docket, worker: Worker):
     """Worker should not exceed its configured concurrency limit"""
 

--- a/tests/worker/test_reconnection.py
+++ b/tests/worker/test_reconnection.py
@@ -1,0 +1,85 @@
+"""Tests for how the worker survives losing its Redis connection."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from docket._redis import RedisClient
+from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
+from redis.exceptions import ConnectionError
+
+from docket import Docket, Worker
+
+
+async def test_worker_reconnects_when_connection_is_lost(
+    docket: Docket, the_task: AsyncMock
+):
+    """The worker should reconnect when the connection is lost"""
+    worker = Worker(docket, reconnection_delay=timedelta(milliseconds=100))
+
+    # Mock the _worker_loop method to fail once then succeed
+    original_worker_loop = worker._worker_loop  # type: ignore[protected-access]
+    call_count = 0
+
+    async def mock_worker_loop(redis: RedisClient, forever: bool = False):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("Simulated connection error")
+        return await original_worker_loop(redis, forever=forever)  # type: ignore[arg-type]
+
+    worker._worker_loop = mock_worker_loop  # type: ignore[protected-access]
+
+    await docket.add(the_task)()
+
+    async with worker:
+        await worker.run_until_finished()
+
+        assert call_count == 2
+        the_task.assert_called_once()
+
+
+async def test_worker_reconnects_when_main_loop_read_disconnects(
+    docket: Docket, the_task: AsyncMock
+):
+    """A ConnectionError raised by the worker's own blocking read should
+    reconnect, not kill the worker.
+
+    The main poll loop runs inside a TaskGroup, which re-raises a body
+    exception wrapped in an ExceptionGroup. A failover (or a plain server
+    restart) drops a blocked XREADGROUP with a ConnectionError; the worker must
+    treat that as a disconnection and reconnect rather than dying with an
+    unhandled ExceptionGroup."""
+    xreadgroup_calls = 0
+    original_redis = Redis.xreadgroup
+    original_cluster = RedisCluster.xreadgroup
+
+    async def flaky_redis_xreadgroup(self: Redis, *args: object, **kwargs: object):
+        nonlocal xreadgroup_calls
+        xreadgroup_calls += 1
+        if xreadgroup_calls == 1:
+            raise ConnectionError("Simulated failover mid-XREADGROUP")
+        return await original_redis(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    async def flaky_cluster_xreadgroup(  # pragma: no cover
+        self: RedisCluster, *args: object, **kwargs: object
+    ):
+        nonlocal xreadgroup_calls
+        xreadgroup_calls += 1
+        if xreadgroup_calls == 1:
+            raise ConnectionError("Simulated failover mid-XREADGROUP")
+        return await original_cluster(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    await docket.add(the_task)()
+
+    with (
+        patch.object(Redis, "xreadgroup", flaky_redis_xreadgroup),
+        patch.object(RedisCluster, "xreadgroup", flaky_cluster_xreadgroup),
+    ):
+        async with Worker(
+            docket, reconnection_delay=timedelta(milliseconds=50)
+        ) as worker:
+            await worker.run_until_finished()
+
+    the_task.assert_called_once()
+    assert xreadgroup_calls >= 2

--- a/tests/worker/test_reconnection.py
+++ b/tests/worker/test_reconnection.py
@@ -1,11 +1,11 @@
 """Tests for how the worker survives losing its Redis connection."""
 
+from contextlib import asynccontextmanager
 from datetime import timedelta
+from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 from docket._redis import RedisClient
-from redis.asyncio import Redis
-from redis.asyncio.cluster import RedisCluster
 from redis.exceptions import ConnectionError
 
 from docket import Docket, Worker
@@ -49,37 +49,42 @@ async def test_worker_reconnects_when_main_loop_read_disconnects(
     exception wrapped in an ExceptionGroup. A failover (or a plain server
     restart) drops a blocked XREADGROUP with a ConnectionError; the worker must
     treat that as a disconnection and reconnect rather than dying with an
-    unhandled ExceptionGroup."""
-    xreadgroup_calls = 0
-    original_redis = Redis.xreadgroup
-    original_cluster = RedisCluster.xreadgroup
+    unhandled ExceptionGroup.
 
-    async def flaky_redis_xreadgroup(self: Redis, *args: object, **kwargs: object):
-        nonlocal xreadgroup_calls
-        xreadgroup_calls += 1
-        if xreadgroup_calls == 1:
-            raise ConnectionError("Simulated failover mid-XREADGROUP")
-        return await original_redis(self, *args, **kwargs)  # type: ignore[arg-type]
+    The fault is injected by wrapping the client the worker actually uses, so
+    this exercises the real reconnect path on every backend -- standalone,
+    cluster, and memory alike."""
+    reads = {"count": 0}
 
-    async def flaky_cluster_xreadgroup(  # pragma: no cover
-        self: RedisCluster, *args: object, **kwargs: object
-    ):
-        nonlocal xreadgroup_calls
-        xreadgroup_calls += 1
-        if xreadgroup_calls == 1:
-            raise ConnectionError("Simulated failover mid-XREADGROUP")
-        return await original_cluster(self, *args, **kwargs)  # type: ignore[arg-type]
+    class FailFirstRead:
+        """Delegates to a real client but raises on its first xreadgroup."""
+
+        def __init__(self, wrapped: Any):
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._wrapped, name)
+
+        async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+            reads["count"] += 1
+            if reads["count"] == 1:
+                raise ConnectionError("Simulated server loss mid-XREADGROUP")
+            return await self._wrapped.xreadgroup(*args, **kwargs)
+
+    original_redis = Docket.redis
+
+    @asynccontextmanager
+    async def flaky_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as r:
+            yield FailFirstRead(r)  # type: ignore[arg-type]
 
     await docket.add(the_task)()
 
-    with (
-        patch.object(Redis, "xreadgroup", flaky_redis_xreadgroup),
-        patch.object(RedisCluster, "xreadgroup", flaky_cluster_xreadgroup),
-    ):
+    with patch.object(Docket, "redis", flaky_redis):
         async with Worker(
             docket, reconnection_delay=timedelta(milliseconds=50)
         ) as worker:
             await worker.run_until_finished()
 
     the_task.assert_called_once()
-    assert xreadgroup_calls >= 2
+    assert reads["count"] >= 2


### PR DESCRIPTION
Worker._run reconnects on a bare ConnectionError, but the main poll loop runs inside a TaskGroup, which re-raises a body exception wrapped in an ExceptionGroup on every supported Python. So when the worker's own blocking read (XREADGROUP / XAUTOCLAIM) lost the server mid-loop — a Sentinel failover, or just a server restart — the bare handler never matched and the worker died with `ExceptionGroup(...[ConnectionError])`. This isn't Sentinel-specific; it reproduces on a plain `redis://` URL too.

Guard only the worker's own polling reads: on a ConnectionError, stop the loop and re-raise it bare once the TaskGroup has unwound, so `_run`'s existing handler reconnects. A ConnectionError raised by a task body still surfaces through `process_completed_tasks`, which stays outside the guard and keeps its die-and-redeliver behavior (the contract in `test_perpetual_reliability.py`).

Moves the reconnection tests into their own `tests/worker/test_reconnection.py` to keep `test_core.py` under the file-size limit.

This completes the failover story for the Redis Sentinel support added in #431 — the worker now follows a failover the way the production docs already describe, and on a plain `redis://` server restart too.

<details>
<summary>Session context</summary>

Started by reviewing the updated #431 (Redis Sentinel support); the contributor had addressed all earlier review feedback and that PR was merged to main. While reviewing it I'd noted a pre-existing failover gap in docket itself, which this PR fixes.

Key points worked through:
- Root cause is the TaskGroup wrapping mid-loop exceptions in an ExceptionGroup, which the bare `except ConnectionError` in `_run` doesn't match.
- The tricky constraint: a ConnectionError from a *task body* (via `process_completed_tasks` → `await task`) must keep killing the worker so redelivery recovers the chain (pinned by `test_perpetual_reliability.py`). A blanket `ExceptionGroup` split at `_run` would have broken that, so the guard is scoped to only the worker's own polling reads.
- Confirmed all three child tasks (scheduler, lease renewal, cancellation listener) already swallow their own ConnectionError, so the poll loop was the only unhandled source.
- Decision (with maintainer): reconnect for both `run_forever` and `run_until_finished`, consistent with the existing bare-ConnectionError path.
- TDD: wrote a failing repro (`xreadgroup` raising once), confirmed the ExceptionGroup death, then implemented.
- loq: bumped only `worker.py`'s existing baseline; decomposed the test file instead of baselining it.

Full suite green (894 passed); coverage misses are the same pre-existing backend-matrix partials as on main; `prek` fully clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)