### PR TITLE
Re-seed automatic perpetuals so a severed chain heals without a restart

### DIFF
--- a/docs/task-behaviors.md
+++ b/docs/task-behaviors.md
@@ -50,6 +50,8 @@ docket.register(background_cleanup)
 # The task key will be the function name: "background_cleanup"
 ```
 
+Workers keep automatic tasks scheduled throughout their lifetime, not just at startup. If an automatic task's schedule is ever lost — for example, an old worker draining during a rolling deploy consumes one execution before it has the task registered — a running worker re-establishes it on its next check, so it keeps running without a restart.
+
 ### Self-Canceling Tasks
 
 Perpetual tasks can stop themselves when their work is done:

--- a/docs/task-behaviors.md
+++ b/docs/task-behaviors.md
@@ -50,7 +50,7 @@ docket.register(background_cleanup)
 # The task key will be the function name: "background_cleanup"
 ```
 
-Workers keep automatic tasks scheduled throughout their lifetime, not just at startup. If an automatic task's schedule is ever lost — for example, an old worker draining during a rolling deploy consumes one execution before it has the task registered — a running worker re-establishes it on its next check, so it keeps running without a restart.
+Workers don't only schedule automatic tasks at startup. They keep them scheduled the whole time they're running, so if one ever falls off the schedule a worker quietly puts it back. This matters most during a rolling deploy, where an older worker that doesn't know about a newly-added task can pick up one of its runs and drop it. Without this, the task would sit stranded until the next restart.
 
 ### Self-Canceling Tasks
 

--- a/docs/task-behaviors.md
+++ b/docs/task-behaviors.md
@@ -52,6 +52,8 @@ docket.register(background_cleanup)
 
 Workers don't only schedule automatic tasks at startup. They keep them scheduled the whole time they're running, so if one ever falls off the schedule a worker quietly puts it back. This matters most during a rolling deploy, where an older worker that doesn't know about a newly-added task can pick up one of its runs and drop it. Without this, the task would sit stranded until the next restart.
 
+Because a running worker keeps putting automatic tasks back, cancelling one only pauses it until the next reseed. To stop an automatic task for good, strike it with `docket.strike("task_name")`.
+
 ### Self-Canceling Tasks
 
 Perpetual tasks can stop themselves when their work is done:

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1317
+max_lines = 1336
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1281
+max_lines = 1317
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/dependencies/_perpetual.py
+++ b/src/docket/dependencies/_perpetual.py
@@ -62,6 +62,9 @@ class Perpetual(CompletionHandler["Perpetual"]):
                 startup and continually through the worker's lifespan.  This ensures
                 that the task will always be scheduled despite crashes and other
                 adverse conditions.  Automatic tasks must not require any arguments.
+                Because a running worker keeps re-establishing them, cancelling an
+                automatic task only pauses it until the next reseed; use
+                `Docket.strike` to stop one durably.
         """
         self.every = every
         self.automatic = automatic

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -99,6 +99,7 @@ ADMISSION_BLOCKED_RETRY_DELAY = timedelta(milliseconds=100)
 # Lock timeout for coordinating automatic perpetual task scheduling at startup.
 # If a worker crashes while holding this lock, it expires after this many seconds.
 AUTOMATIC_PERPETUAL_LOCK_TIMEOUT_SECONDS = 10
+AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS = 60
 
 # Minimum TTL in seconds for Redis keys to avoid immediate expiration when
 # redelivery_timeout is very small (e.g., in tests with 200ms timeouts).
@@ -730,6 +731,10 @@ class Worker:
 
                     if self.schedule_automatic_tasks:
                         await self._schedule_all_automatic_perpetual_tasks()
+                        infra.create_task(
+                            self._reseed_automatic_perpetual_tasks_loop(),
+                            name=f"{self.docket.name} - automatic perpetual reseed",
+                        )
 
                     infra.create_task(
                         self._scheduler_loop(redis),
@@ -889,6 +894,37 @@ class Worker:
                     )
             except Exception:
                 logger.warning("Failed to renew leases", exc_info=True)
+
+    async def _reseed_automatic_perpetual_tasks_loop(self) -> None:
+        """Periodically re-sow automatic perpetuals so a chain severed after
+        startup is recovered without a full restart.
+
+        A perpetual reschedules itself from its own completion handler, but an
+        execution consumed through the unknown-task fallback (e.g. by an old
+        worker mid-deploy that hasn't registered the task yet) completes without
+        that handler, leaving nothing scheduled.  Re-seeding heals it: a
+        ``docket.add`` under the deterministic key dedups against a live
+        perpetual and only takes effect once the chain has actually been lost.
+        """
+        log_context = self._log_context()
+
+        while not self._worker_stopping.is_set():  # pragma: no branch
+            try:
+                await asyncio.wait_for(
+                    self._worker_stopping.wait(),
+                    timeout=AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS,
+                )
+                return  # Event was set, exit the loop
+            except asyncio.TimeoutError:
+                pass  # Normal timeout, re-seed and continue
+
+            try:
+                await self._schedule_all_automatic_perpetual_tasks()
+            except Exception:  # pragma: no cover
+                logger.exception(
+                    "Error re-seeding automatic perpetual tasks",
+                    extra=log_context,
+                )
 
     async def _schedule_all_automatic_perpetual_tasks(self) -> None:
         # Wait for strikes to be fully loaded before scheduling to avoid

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -945,11 +945,30 @@ class Worker:
 
                         if perpetual is not None and perpetual.automatic:
                             key = task_function.__name__
+                            # Skip tasks that already have a live schedule entry.
+                            # add() would dedup them, but evaluating
+                            # ``initial_when`` first has side effects: a Cron's
+                            # iterator advances on every call, so reseeding a
+                            # healthy cron would drift its schedule into the
+                            # future.  Only touch a task once its chain is gone.
+                            if await self._automatic_perpetual_is_live(redis, key):
+                                continue
                             await self.docket.add(
                                 task_function, when=perpetual.initial_when, key=key
                             )()
             except LockError:  # pragma: no cover
                 return
+
+    async def _automatic_perpetual_is_live(self, redis: RedisClient, key: str) -> bool:
+        """Whether an automatic perpetual already has a live schedule entry.
+
+        Mirrors the dedup in the scheduling script: a task is live when it's
+        parked or queued (``known`` is set) or currently running.
+        """
+        runs_key = self.docket.runs_key(key)
+        if (await redis.hget(runs_key, "known")) is not None:
+            return True
+        return (await redis.hget(runs_key, "state")) == b"running"
 
     async def _delete_known_task(self, redis: Redis, execution: Execution) -> None:
         logger.debug("Deleting known task", extra=self._log_context())

--- a/tests/test_automatic_perpetual_recovery.py
+++ b/tests/test_automatic_perpetual_recovery.py
@@ -1,0 +1,224 @@
+"""Recovery of automatic perpetuals whose self-rescheduling chain is severed.
+
+A rolling deploy that introduces a new ``Perpetual(automatic=True)`` task can
+have its chain silently and permanently broken: an old worker that doesn't yet
+have the task registered consumes one of its executions through the unknown-task
+fallback, which carries no ``Perpetual`` completion handler and so never
+reschedules.  The streaming Lua has already removed the schedule entry, so the
+chain is gone until the whole fleet restarts (see issue #437).
+
+A still-running worker re-sows automatic perpetuals on an interval, which heals
+a severed chain without a restart.  ``docket.add(task, key=name)`` dedups against
+a live perpetual (scheduled, queued, or running), so re-seeding is a no-op while
+the chain is healthy and only takes effect once it has actually been lost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+import pytest
+
+from docket import Docket, Perpetual, Worker
+from tests.conftest import wait_until
+
+
+async def test_running_worker_resows_severed_automatic_perpetual(
+    docket: Docket,
+    worker: Worker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A long-running worker re-sows an automatic perpetual after its chain is
+    severed, without needing a restart."""
+    # Re-seed often so the test doesn't wait the production minute.
+    monkeypatch.setattr(
+        "docket.worker.AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS", 0.05
+    )
+
+    calls = 0
+
+    async def perpetual_task(
+        # A long interval so the chain won't re-run on its own within the test
+        # window -- only a re-seed produces the second execution.
+        perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
+    ):
+        nonlocal calls
+        calls += 1
+
+    docket.register(perpetual_task)
+    runs_key = docket.runs_key("perpetual_task")
+
+    async def next_run_is_parked() -> bool:
+        async with docket.redis() as redis:
+            return await redis.hget(runs_key, "state") == b"scheduled"
+
+    run = asyncio.create_task(worker.run_forever())
+    await wait_until(lambda: calls == 1, description="startup seeding ran the task")
+    # Let the perpetual finish parking its own next run before severing, so the
+    # cancel can't race the self-reschedule and leave the chain intact.
+    await wait_until(next_run_is_parked, description="next run parked")
+
+    # Sever the chain the same way the fallback drop does: no scheduled entry,
+    # nothing in flight.
+    await docket.cancel("perpetual_task")
+
+    await wait_until(lambda: calls == 2, description="re-seeding re-ran the perpetual")
+
+    run.cancel()
+    await asyncio.gather(run, return_exceptions=True)
+
+    # Leave nothing parked 30s out for the leak checker.
+    await docket.cancel("perpetual_task")
+
+
+async def test_fallback_drop_then_reseed_recovers_chain(
+    docket: Docket,
+    caplog: pytest.LogCaptureFixture,
+):
+    """An old worker dropping a new automatic perpetual via the unknown-task
+    fallback severs its chain, and re-seeding restores it."""
+    calls = 0
+
+    async def perpetual_task(
+        perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
+    ):
+        nonlocal calls
+        calls += 1
+
+    docket.register(perpetual_task)
+
+    # The new worker has seeded the perpetual; it becomes due and is streamed.
+    await docket.add(perpetual_task, key="perpetual_task")()
+
+    # An old worker, still draining, doesn't have the task registered and drops
+    # it through the fallback.
+    docket.tasks.pop("perpetual_task")
+    async with Worker(
+        docket,
+        schedule_automatic_tasks=False,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as old_worker:
+        with caplog.at_level(logging.WARNING):
+            await old_worker.run_until_finished()
+
+    assert "Unknown task 'perpetual_task' received - dropping" in caplog.text
+    assert calls == 0
+
+    # The chain is severed: no live schedule entry remains for the perpetual.
+    runs_key = docket.runs_key("perpetual_task")
+    async with docket.redis() as redis:
+        assert await redis.hget(runs_key, "known") is None
+
+    # The surviving new worker (which has the task) re-sows it on its next tick.
+    docket.register(perpetual_task)
+    new_worker = Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    )
+    await new_worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+
+    async with docket.redis() as redis:
+        assert await redis.hget(runs_key, "known") is not None
+
+    async with new_worker:
+        await new_worker.run_at_most({"perpetual_task": 1})
+    assert calls == 1
+
+    await docket.cancel("perpetual_task")
+
+
+async def test_reseed_is_idempotent_for_live_perpetual(
+    docket: Docket,
+    worker: Worker,
+):
+    """Re-seeding a healthy automatic perpetual dedups against the live entry
+    and never injects a duplicate execution."""
+
+    async def perpetual_task(
+        perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
+    ):
+        pass  # pragma: no cover
+
+    docket.register(perpetual_task)
+
+    # First seed establishes a live (queued) entry for the perpetual.
+    await worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+
+    runs_key = docket.runs_key("perpetual_task")
+    async with docket.redis() as redis:
+        assert await redis.hget(runs_key, "known") is not None
+        generation_before = await redis.hget(runs_key, "generation")
+
+    # A second seed of the same live perpetual must dedup, not re-schedule -- the
+    # generation counter only advances when a task is actually (re)scheduled.
+    await worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+
+    async with docket.redis() as redis:
+        generation_after = await redis.hget(runs_key, "generation")
+
+    assert generation_before == generation_after
+
+    await docket.cancel("perpetual_task")
+
+
+async def test_restoring_struck_automatic_perpetual_resumes_without_restart(
+    docket: Docket,
+    worker: Worker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A struck automatic perpetual resumes scheduling after it is restored,
+    without needing a worker restart (issue #377).
+
+    Striking blocks rescheduling and cancels the due execution, which severs a
+    perpetual's self-rescheduling chain.  Before re-seeding existed, restore left
+    the task inert until the worker was restarted; now a running worker re-sows
+    it on its next tick.
+    """
+    monkeypatch.setattr(
+        "docket.worker.AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS", 0.05
+    )
+
+    calls = 0
+
+    async def perpetual_task(
+        perpetual: Perpetual = Perpetual(
+            every=timedelta(milliseconds=50), automatic=True
+        ),
+    ):
+        nonlocal calls
+        calls += 1
+
+    docket.register(perpetual_task)
+    runs_key = docket.runs_key("perpetual_task")
+
+    async def chain_is_dead() -> bool:
+        async with docket.redis() as redis:
+            known = await redis.hget(runs_key, "known")
+            state = await redis.hget(runs_key, "state")
+            return known is None and state != b"running"
+
+    run = asyncio.create_task(worker.run_forever())
+    await wait_until(lambda: calls >= 1, description="perpetual running normally")
+
+    # Suspend it: striking cancels the due execution and blocks rescheduling, so
+    # the chain dies and re-seeding stays a no-op while struck.
+    await docket.strike("perpetual_task")
+    await wait_until(chain_is_dead, description="struck chain severed")
+    calls_while_struck = calls
+
+    # Restoring must resume scheduling on the still-running worker.
+    await docket.restore("perpetual_task")
+    await wait_until(
+        lambda: calls > calls_while_struck,
+        description="restored perpetual resumed without restart",
+    )
+
+    run.cancel()
+    await asyncio.gather(run, return_exceptions=True)
+    await docket.cancel("perpetual_task")
+
+    await docket.cancel("perpetual_task")

--- a/tests/test_automatic_perpetual_recovery.py
+++ b/tests/test_automatic_perpetual_recovery.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
-from docket import Docket, Perpetual, Worker
+from docket import Cron, Docket, Perpetual, Worker
 from tests.conftest import wait_until
 
 
@@ -163,6 +164,42 @@ async def test_reseed_is_idempotent_for_live_perpetual(
     assert generation_before == generation_after
 
     await docket.cancel("perpetual_task")
+
+
+async def test_reseed_does_not_advance_cron_iterator_while_live(
+    docket: Docket,
+    worker: Worker,
+):
+    """Reseeding a healthy automatic cron must not consume its schedule iterator.
+
+    ``Cron.initial_when`` advances the iterator each time it's read, so reseeding
+    a cron that's already scheduled would march its next run further into the
+    future on every tick. Live tasks should be left untouched.
+    """
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    next_time_calls = 0
+
+    def advancing() -> datetime:
+        nonlocal next_time_calls
+        next_time_calls += 1
+        return base + timedelta(hours=next_time_calls)
+
+    async def cron_task(cron: Cron = Cron("0 * * * *", automatic=True)):
+        pass  # pragma: no cover
+
+    docket.register(cron_task)
+
+    with patch.object(Cron, "next_time", side_effect=advancing):
+        # The first seed schedules the cron, consuming one occurrence.
+        await worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+        assert next_time_calls == 1
+
+        # The cron is now live; further reseeds must leave the iterator alone.
+        await worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+        await worker._schedule_all_automatic_perpetual_tasks()  # type: ignore[protected-access]
+        assert next_time_calls == 1
+
+    await docket.cancel("cron_task")
 
 
 async def test_restoring_struck_automatic_perpetual_resumes_without_restart(


### PR DESCRIPTION
A perpetual only reschedules itself from its own completion handler, and automatic perpetuals were seeded just once at worker startup. That leaves a gap: if an execution's chain is broken after startup, no running worker ever re-establishes it, so the task quietly stops until the whole fleet restarts.

Two ways this bites in practice:

- A rolling deploy that introduces a new automatic perpetual can lose it silently. While old and new pods overlap, an old worker that doesn't have the new task registered can consume one of its executions through the unknown-task fallback. The fallback carries no Perpetual handler, so nothing reschedules, and the streaming script has already removed the schedule entry. The only signal is a single "Unknown task ... dropping" warning. (Closes #437)
- Striking an automatic perpetual cancels its due execution and blocks rescheduling, which severs the chain. Restoring it didn't bring it back; the task stayed inert until a worker restart. (Closes #377)

This adds a periodic re-seed loop that re-runs the existing automatic-perpetual seeding on an interval, not just at startup. The seeding is already idempotent: adding under the deterministic per-task key dedups against a live perpetual (scheduled, queued, or running), so re-seeding is a no-op while the chain is healthy and only takes effect once it has actually been lost. This is what the `automatic` docstring already described ("continually through the worker's lifespan"); the implementation just hadn't been doing the continual part.

The interval is a fixed 60s module constant, so a severed chain heals within about a minute. Re-seeding is cheap (a non-blocking lock plus a few dedup'd adds).

Tests cover a running worker re-sowing after its chain is cancelled, the faithful fallback-drop → sever → recovery path, idempotency on a healthy perpetual, and the strike → restore-without-restart case from #377.

<details>
<summary>Session context</summary>

Started from #437. Explored the fallback path (`default_fallback_task` resolves an unknown task to a function with no `Perpetual`/`CompletionHandler`, so `on_complete` never reschedules), the streaming Lua (`DEL`s the hash and `ZREM`s the queue entry at stream time), and automatic seeding (single startup call site). Confirmed the `_schedule` Lua's non-replace branch dedups an `add` against a live perpetual via the `known` field / `state == running`, which makes repeated seeding safe — no-op when alive, re-sow when dead.

Decisions: a module constant for the cadence (no new public `Worker` param) and self-healing re-seed only (no wire-format / fallback changes, which would only help future deploys where this version is the old worker). Mid-way realized this also fixes #377 (struck-then-restored automatic perpetual not resuming) and added a specific regression for it.

Verification: new tests stable across repeated runs; full suite 898 passed; CI's exact core gate (`--ignore=tests/cli --cov-config=.coveragerc-core --cov-fail-under=100`) reaches 100.00% (a plain local `pytest` shows 99.94%, but that measures test files and `tests/cli` under a broader config — the stragglers are cluster-mode branches in untouched files). `prek run --all-files` green. Two false alarms along the way were a venv-recreation race from running `prek` concurrently with the suite (broke CLI subprocess tests) and a test flake where a `cancel` raced the perpetual's own reschedule (fixed by waiting until the next run is parked before severing).
</details>
