### PR TITLE
Tie worker liveness to claim-ready processing

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1352
+max_lines = 1363
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1336
+max_lines = 1352
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1363
+max_lines = 1388
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -108,6 +108,14 @@ MINIMUM_TTL_SECONDS = 1
 TaskKey: TypeAlias = str
 
 
+async def _wait_for_event(event: asyncio.Event, timeout: float) -> bool:
+    try:
+        await asyncio.wait_for(event.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        return False
+    return True
+
+
 class PubSubMessage(TypedDict):
     """Message received from Redis pub/sub pattern subscription."""
 
@@ -519,19 +527,29 @@ class Worker:
 
     async def _run(self, forever: bool = False) -> None:
         self._startup_log()
-
-        while True:
-            try:
-                async with self.docket.redis() as redis:
-                    return await self._worker_loop(redis, forever=forever)
-            except ConnectionError:
-                REDIS_DISRUPTIONS.add(1, self.labels())
-                logger.warning(
-                    "Error connecting to redis, retrying in %s...",
-                    self.reconnection_delay,
-                    exc_info=True,
-                )
-                await asyncio.sleep(self.reconnection_delay.total_seconds())
+        self._worker_stopping.clear()
+        self._worker_done.clear()
+        stopping = self._worker_stopping
+        try:
+            while not stopping.is_set():  # pragma: no branch
+                try:
+                    async with self.docket.redis() as redis:
+                        return await self._worker_loop(redis, forever=forever)
+                except ConnectionError:
+                    if stopping.is_set():
+                        return
+                    REDIS_DISRUPTIONS.add(1, self.labels())
+                    logger.warning(
+                        "Error connecting to redis, retrying in %s...",
+                        self.reconnection_delay,
+                        exc_info=True,
+                    )
+                    if await _wait_for_event(
+                        stopping, self.reconnection_delay.total_seconds()
+                    ):
+                        return
+        finally:
+            self._worker_done.set()
 
     def _dependency_lifecycle_classes(self) -> list[type[Dependency[Any]]]:
         """Discover Dependency subclasses (used by registered tasks or worker
@@ -572,10 +590,10 @@ class Worker:
         return ordered
 
     async def _worker_loop(self, redis: Redis, forever: bool = False):
-        self._worker_stopping.clear()
-        self._worker_done.clear()
-        self._cancellation_ready.clear()  # Reset for reconnection scenarios
-
+        cancellation_ready = self._cancellation_ready
+        cancellation_ready.clear()  # Reset for reconnection scenarios
+        processing_stopping = asyncio.Event()
+        stopping = self._worker_stopping
         active_tasks: dict[asyncio.Task[None], RedisMessageID] = {}
         task_executions: dict[asyncio.Task[None], Execution] = {}
         available_slots = self.concurrency
@@ -710,43 +728,47 @@ class Worker:
                 async with TaskGroup() as infra:
                     # Start cancellation listener and wait for it to be ready
                     infra.create_task(
-                        self._cancellation_listener(),
+                        self._cancellation_listener(
+                            processing_stopping, cancellation_ready
+                        ),
                         name=f"{self.docket.name} - cancellation listener",
                     )
-                    await self._cancellation_ready.wait()
-
+                    while not cancellation_ready.is_set() and not stopping.is_set():
+                        await _wait_for_event(cancellation_ready, 0.1)
+                    if stopping.is_set():
+                        processing_stopping.set()
+                        return
                     if self.schedule_automatic_tasks:
                         await self._schedule_all_automatic_perpetual_tasks()
                         infra.create_task(
-                            self._reseed_automatic_perpetual_tasks_loop(),
+                            self._reseed_automatic_perpetual_tasks_loop(
+                                processing_stopping
+                            ),
                             name=f"{self.docket.name} - automatic perpetual reseed",
                         )
-
                     infra.create_task(
-                        self._scheduler_loop(redis),
+                        self._scheduler_loop(redis, processing_stopping),
                         name=f"{self.docket.name} - scheduler",
                     )
                     infra.create_task(
-                        self._renew_leases(redis, active_tasks),
+                        self._renew_leases(redis, active_tasks, processing_stopping),
                         name=f"{self.docket.name} - lease renewal",
                     )
                     self._heartbeat_task = asyncio.create_task(
-                        self._heartbeat(), name=f"{self.docket.name} - heartbeat"
+                        self._heartbeat(processing_stopping),
+                        name=f"{self.docket.name} - heartbeat",
                     )
-
                     has_work: bool = True
-                    stopping = self._worker_stopping.is_set
-                    while (forever or has_work or active_tasks) and not stopping():
+                    while (
+                        forever or has_work or active_tasks
+                    ) and not stopping.is_set():
                         await process_completed_tasks()
-
                         available_slots = self.concurrency - len(active_tasks)
-
                         if available_slots <= 0:
                             await asyncio.sleep(
                                 self.minimum_check_interval.total_seconds()
                             )
                             continue
-
                         try:
                             for source in [get_redeliveries, get_new_deliveries]:
                                 for stream_key, messages in await source(redis):
@@ -776,15 +798,13 @@ class Worker:
                             disconnect = error
                             break
 
-                    # Signal internal tasks to stop before exiting TaskGroup
-                    self._worker_stopping.set()
+                    processing_stopping.set()
 
             # A disconnection in the poll loop above leaves the TaskGroup intact
             # (no exception escaped it), so re-raise it here as a bare
             # ConnectionError for _run to catch and reconnect on.
             if disconnect is not None:
                 raise disconnect
-
         except asyncio.CancelledError:
             if active_tasks:  # pragma: no cover
                 logger.info(
@@ -793,21 +813,18 @@ class Worker:
                     extra=log_context,
                 )
         finally:
-            # Drain any remaining active tasks
+            processing_stopping.set()
+            if self._heartbeat_task is not None:
+                await cancel_task(self._heartbeat_task, CANCEL_MSG_CLEANUP)
+            self._heartbeat_task = None
+            await self._remove_heartbeat()
             if active_tasks:
                 await asyncio.gather(*active_tasks, return_exceptions=True)
                 await process_completed_tasks()
 
-            if self._heartbeat_task is not None:
-                await cancel_task(self._heartbeat_task, CANCEL_MSG_CLEANUP)
-            self._heartbeat_task = None
-            self._worker_done.set()
-
-    async def _scheduler_loop(self, redis: Redis) -> None:
-        """Loop that moves due tasks from the queue to the stream."""
+    async def _scheduler_loop(self, redis: Redis, stop_event: asyncio.Event) -> None:
         log_context = self._log_context()
-
-        while not self._worker_stopping.is_set():  # pragma: no branch
+        while not stop_event.is_set():  # pragma: no branch
             try:
                 logger.debug("Scheduling due tasks", extra=log_context)
                 with self._maybe_suppress_instrumentation():
@@ -835,20 +852,16 @@ class Worker:
                     extra=log_context,
                 )
 
-            # Use interruptible wait so we respond to stopping quickly
-            try:
-                await asyncio.wait_for(
-                    self._worker_stopping.wait(),
-                    timeout=self.scheduling_resolution.total_seconds(),
-                )
-                return  # Event was set, exit the loop
-            except asyncio.TimeoutError:
-                pass  # Normal timeout, continue scheduling
+            if await _wait_for_event(
+                stop_event, self.scheduling_resolution.total_seconds()
+            ):
+                return
 
     async def _renew_leases(
         self,
         redis: Redis,
         active_messages: dict[asyncio.Task[None], RedisMessageID],
+        stop_event: asyncio.Event,
     ) -> None:
         """Periodically renew leases on stream messages.
 
@@ -858,17 +871,9 @@ class Worker:
         # Renew leases 4 times per redelivery_timeout period
         renewal_interval = self.redelivery_timeout.total_seconds() / 4
 
-        while not self._worker_stopping.is_set():  # pragma: no branch
-            # Use interruptible wait so we respond to stopping quickly
-            try:
-                await asyncio.wait_for(
-                    self._worker_stopping.wait(), timeout=renewal_interval
-                )
-                # Event was set, exit the loop
+        while not stop_event.is_set():  # pragma: no branch
+            if await _wait_for_event(stop_event, renewal_interval):
                 return
-            except asyncio.TimeoutError:
-                # Normal timeout, continue with lease renewal
-                pass
 
             message_ids = list(active_messages.values())
             if not message_ids:
@@ -887,7 +892,9 @@ class Worker:
             except Exception:
                 logger.warning("Failed to renew leases", exc_info=True)
 
-    async def _reseed_automatic_perpetual_tasks_loop(self) -> None:
+    async def _reseed_automatic_perpetual_tasks_loop(
+        self, stop_event: asyncio.Event
+    ) -> None:
         """Periodically re-sow automatic perpetuals so a chain severed after
         startup is recovered without a full restart.
 
@@ -900,15 +907,11 @@ class Worker:
         """
         log_context = self._log_context()
 
-        while not self._worker_stopping.is_set():  # pragma: no branch
-            try:
-                await asyncio.wait_for(
-                    self._worker_stopping.wait(),
-                    timeout=AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS,
-                )
-                return  # Event was set, exit the loop
-            except asyncio.TimeoutError:
-                pass  # Normal timeout, re-seed and continue
+        while not stop_event.is_set():  # pragma: no branch
+            if await _wait_for_event(
+                stop_event, AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS
+            ):
+                return
 
             try:
                 await self._schedule_all_automatic_perpetual_tasks()
@@ -1214,8 +1217,23 @@ class Worker:
     def task_workers_set(self, task_name: str) -> str:
         return self.docket.task_workers_set(task_name)
 
-    async def _heartbeat(self) -> None:
-        while not self._worker_stopping.is_set():  # pragma: no branch
+    async def _remove_heartbeat(self) -> None:
+        try:
+            async with self.docket.redis() as r, r.pipeline() as pipeline:
+                pipeline.zrem(self.workers_set, self.name)
+                for task_name in self.docket.tasks:
+                    pipeline.zrem(self.task_workers_set(task_name), self.name)
+                pipeline.delete(self.worker_tasks_set(self.name))
+                await pipeline.execute()
+        except Exception:
+            logger.exception(
+                "Error clearing worker heartbeat",
+                exc_info=True,
+                extra=self._log_context(),
+            )
+
+    async def _heartbeat(self, stop_event: asyncio.Event) -> None:
+        while not stop_event.is_set():  # pragma: no branch
             try:
                 now = datetime.now(timezone.utc).timestamp()
                 maximum_age = (
@@ -1276,50 +1294,49 @@ class Worker:
                     extra=self._log_context(),
                 )
 
-            try:
-                await asyncio.wait_for(
-                    self._worker_stopping.wait(),
-                    timeout=self.docket.heartbeat_interval.total_seconds(),
-                )
+            if await _wait_for_event(
+                stop_event, self.docket.heartbeat_interval.total_seconds()
+            ):
                 return
-            except asyncio.TimeoutError:
-                pass
 
-    async def _cancellation_listener(self) -> None:
-        """Listen for cancellation signals and cancel matching tasks."""
+    async def _cancellation_listener(
+        self,
+        stop_event: asyncio.Event,
+        ready_event: asyncio.Event,
+    ) -> None:
         cancel_pattern = self.docket.key("cancel:*")
         log_context = self._log_context()
-
-        while not self._worker_stopping.is_set():
+        while not stop_event.is_set():
             try:
                 async with self.docket._pubsub() as pubsub:
                     await pubsub.psubscribe(cancel_pattern)
-                    self._cancellation_ready.set()
-                    # Poll for messages, checking _worker_stopping periodically
-                    while not self._worker_stopping.is_set():
+                    ready_event.set()
+                    while not stop_event.is_set():
                         message = await pubsub.get_message(
                             ignore_subscribe_messages=True, timeout=0.1
                         )
                         if message is not None and message["type"] == "pmessage":
                             await self._handle_cancellation(message)
             except ConnectionError:
-                if self._worker_stopping.is_set():
+                if stop_event.is_set():
                     return  # pragma: no cover
                 REDIS_DISRUPTIONS.add(1, self.labels())
                 logger.warning(
                     "Redis connection error in cancellation listener, reconnecting...",
                     extra=log_context,
                 )
-                await asyncio.sleep(1)
+                if await _wait_for_event(stop_event, 1):
+                    return
             except Exception:
-                if self._worker_stopping.is_set():
+                if stop_event.is_set():
                     return  # pragma: no cover
                 logger.exception(
                     "Error in cancellation listener",
                     exc_info=True,
                     extra=log_context,
                 )
-                await asyncio.sleep(1)
+                if await _wait_for_event(stop_event, 1):
+                    return
 
     async def _handle_cancellation(self, message: PubSubMessage) -> None:
         """Handle a cancellation message by cancelling the matching task."""

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -33,7 +33,6 @@ else:
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode, Tracer
 
-from ._cancellation import CANCEL_MSG_CLEANUP, cancel_task
 from ._lua import Arg, Key, redis_script
 from ._redis import RedisClient
 from ._telemetry import suppress_instrumentation
@@ -284,7 +283,6 @@ class Worker:
         self._stack = AsyncExitStack()
         await self._stack.__aenter__()
 
-        # Events for coordinating worker loop shutdown (cleaned up last)
         self._worker_stopping = asyncio.Event()
         self._stack.callback(lambda: delattr(self, "_worker_stopping"))
         self._worker_done = asyncio.Event()
@@ -298,21 +296,14 @@ class Worker:
         self._tasks_by_key: dict[TaskKey, asyncio.Task[None]] = {}
         self._stack.callback(lambda: delattr(self, "_tasks_by_key"))
 
-        self._heartbeat_task = asyncio.create_task(
-            self._heartbeat(), name=f"{self.docket.name} - heartbeat"
-        )
+        self._heartbeat_task: asyncio.Task[None] | None = None
         self._stack.callback(lambda: delattr(self, "_heartbeat_task"))
-        self._stack.push_async_callback(
-            cancel_task, self._heartbeat_task, CANCEL_MSG_CLEANUP
-        )
 
-        # Worker-scoped ContextVars for ambient access to docket/worker
         self._docket_token = current_docket.set(self.docket)
         self._stack.callback(lambda: current_docket.reset(self._docket_token))
         self._worker_token = current_worker.set(self)
         self._stack.callback(lambda: current_worker.reset(self._worker_token))
 
-        # Shared context is set up last, so it's cleaned up first (LIFO)
         self._shared_context = SharedContext()
         self._stack.callback(lambda: delattr(self, "_shared_context"))
         await self._stack.enter_async_context(self._shared_context)
@@ -325,11 +316,9 @@ class Worker:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        # Signal worker loop to stop and wait for it to drain
         self._worker_stopping.set()
         await self._worker_done.wait()
 
-        # Stack handles LIFO cleanup: shared_context first, then heartbeat
         try:
             await self._stack.__aexit__(exc_type, exc_value, traceback)
         finally:
@@ -744,6 +733,9 @@ class Worker:
                         self._renew_leases(redis, active_tasks),
                         name=f"{self.docket.name} - lease renewal",
                     )
+                    self._heartbeat_task = infra.create_task(
+                        self._heartbeat(), name=f"{self.docket.name} - heartbeat"
+                    )
 
                     has_work: bool = True
                     stopping = self._worker_stopping.is_set
@@ -810,6 +802,7 @@ class Worker:
                 await process_completed_tasks()
 
             self._worker_done.set()
+            self._heartbeat_task = None
 
     async def _scheduler_loop(self, redis: Redis) -> None:
         """Loop that moves due tasks from the queue to the stream."""
@@ -1223,7 +1216,7 @@ class Worker:
         return self.docket.task_workers_set(task_name)
 
     async def _heartbeat(self) -> None:
-        while True:
+        while not self._worker_stopping.is_set():  # pragma: no branch
             try:
                 now = datetime.now(timezone.utc).timestamp()
                 maximum_age = (
@@ -1284,7 +1277,14 @@ class Worker:
                     extra=self._log_context(),
                 )
 
-            await asyncio.sleep(self.docket.heartbeat_interval.total_seconds())
+            try:
+                await asyncio.wait_for(
+                    self._worker_stopping.wait(),
+                    timeout=self.docket.heartbeat_interval.total_seconds(),
+                )
+                return
+            except asyncio.TimeoutError:
+                pass
 
     async def _cancellation_listener(self) -> None:
         """Listen for cancellation signals and cancel matching tasks."""

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import time
 from contextlib import AsyncExitStack, contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import (
@@ -123,6 +124,14 @@ class PubSubMessage(TypedDict):
     pattern: bytes
     channel: bytes
     data: bytes | str
+
+
+@dataclass
+class _ProcessingSession:
+    """State scoped to one ready-to-claim Redis processing attempt."""
+
+    stopping: asyncio.Event
+    cancellation_ready: asyncio.Event
 
 
 async def default_fallback_task(
@@ -298,8 +307,6 @@ class Worker:
         self._worker_done = asyncio.Event()
         self._stack.callback(lambda: delattr(self, "_worker_done"))
         self._worker_done.set()  # Initially done (not running)
-        self._cancellation_ready = asyncio.Event()
-        self._stack.callback(lambda: delattr(self, "_cancellation_ready"))
 
         self._execution_counts: dict[str, int] = {}
         self._stack.callback(lambda: delattr(self, "_execution_counts"))
@@ -310,6 +317,8 @@ class Worker:
         # Worker context.  It starts only after that attempt can claim work.
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._stack.callback(lambda: delattr(self, "_heartbeat_task"))
+        self._processing_session: _ProcessingSession | None = None
+        self._stack.callback(lambda: delattr(self, "_processing_session"))
 
         # Worker-scoped ContextVars for ambient access to docket/worker
         self._docket_token = current_docket.set(self.docket)
@@ -597,9 +606,11 @@ class Worker:
         return ordered
 
     async def _worker_loop(self, redis: Redis, forever: bool = False):
-        cancellation_ready = self._cancellation_ready
-        cancellation_ready.clear()  # Reset for reconnection scenarios
-        processing_stopping = asyncio.Event()
+        session = _ProcessingSession(
+            stopping=asyncio.Event(),
+            cancellation_ready=asyncio.Event(),
+        )
+        self._processing_session = session
         stopping = self._worker_stopping
         active_tasks: dict[asyncio.Task[None], RedisMessageID] = {}
         task_executions: dict[asyncio.Task[None], Execution] = {}
@@ -739,34 +750,33 @@ class Worker:
                 async with TaskGroup() as infra:
                     # Start cancellation listener and wait for it to be ready
                     infra.create_task(
-                        self._cancellation_listener(
-                            processing_stopping, cancellation_ready
-                        ),
+                        self._cancellation_listener(),
                         name=f"{self.docket.name} - cancellation listener",
                     )
-                    while not cancellation_ready.is_set() and not stopping.is_set():
-                        await _wait_for_event(cancellation_ready, 0.1)
+                    while (
+                        not session.cancellation_ready.is_set()
+                        and not stopping.is_set()
+                    ):
+                        await _wait_for_event(session.cancellation_ready, 0.1)
                     if stopping.is_set():
-                        processing_stopping.set()
+                        session.stopping.set()
                         return
                     if self.schedule_automatic_tasks:
                         await self._schedule_all_automatic_perpetual_tasks()
                         infra.create_task(
-                            self._reseed_automatic_perpetual_tasks_loop(
-                                processing_stopping
-                            ),
+                            self._reseed_automatic_perpetual_tasks_loop(),
                             name=f"{self.docket.name} - automatic perpetual reseed",
                         )
                     infra.create_task(
-                        self._scheduler_loop(redis, processing_stopping),
+                        self._scheduler_loop(redis),
                         name=f"{self.docket.name} - scheduler",
                     )
                     infra.create_task(
-                        self._renew_leases(redis, active_tasks, processing_stopping),
+                        self._renew_leases(redis, active_tasks),
                         name=f"{self.docket.name} - lease renewal",
                     )
                     self._heartbeat_task = asyncio.create_task(
-                        self._heartbeat(processing_stopping),
+                        self._heartbeat(),
                         name=f"{self.docket.name} - heartbeat",
                     )
                     has_work: bool = True
@@ -809,7 +819,7 @@ class Worker:
                             disconnect = error
                             break
 
-                    processing_stopping.set()
+                    session.stopping.set()
 
             # A disconnection in the poll loop above leaves the TaskGroup intact
             # (no exception escaped it), so re-raise it here as a bare
@@ -824,7 +834,7 @@ class Worker:
                     extra=log_context,
                 )
         finally:
-            processing_stopping.set()
+            session.stopping.set()
             if self._heartbeat_task is not None:
                 await cancel_task(self._heartbeat_task, CANCEL_MSG_CLEANUP)
             self._heartbeat_task = None
@@ -832,10 +842,16 @@ class Worker:
             if active_tasks:
                 await asyncio.gather(*active_tasks, return_exceptions=True)
                 await process_completed_tasks()
+            if self._processing_session is session:
+                self._processing_session = None
 
-    async def _scheduler_loop(self, redis: Redis, stop_event: asyncio.Event) -> None:
+    async def _scheduler_loop(self, redis: Redis) -> None:
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
         log_context = self._log_context()
-        while not stop_event.is_set():  # pragma: no branch
+        while not session.stopping.is_set():  # pragma: no branch
             try:
                 logger.debug("Scheduling due tasks", extra=log_context)
                 with self._maybe_suppress_instrumentation():
@@ -864,7 +880,7 @@ class Worker:
                 )
 
             if await _wait_for_event(
-                stop_event, self.scheduling_resolution.total_seconds()
+                session.stopping, self.scheduling_resolution.total_seconds()
             ):
                 return
 
@@ -872,18 +888,21 @@ class Worker:
         self,
         redis: Redis,
         active_messages: dict[asyncio.Task[None], RedisMessageID],
-        stop_event: asyncio.Event,
     ) -> None:
         """Periodically renew leases on stream messages.
 
         Calls XCLAIM with idle=0 to reset the message's idle time, preventing
         XAUTOCLAIM from reclaiming it while we're still processing.
         """
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
         # Renew leases 4 times per redelivery_timeout period
         renewal_interval = self.redelivery_timeout.total_seconds() / 4
 
-        while not stop_event.is_set():  # pragma: no branch
-            if await _wait_for_event(stop_event, renewal_interval):
+        while not session.stopping.is_set():  # pragma: no branch
+            if await _wait_for_event(session.stopping, renewal_interval):
                 return
 
             message_ids = list(active_messages.values())
@@ -903,9 +922,7 @@ class Worker:
             except Exception:
                 logger.warning("Failed to renew leases", exc_info=True)
 
-    async def _reseed_automatic_perpetual_tasks_loop(
-        self, stop_event: asyncio.Event
-    ) -> None:
+    async def _reseed_automatic_perpetual_tasks_loop(self) -> None:
         """Periodically re-sow automatic perpetuals so a chain severed after
         startup is recovered without a full restart.
 
@@ -916,11 +933,15 @@ class Worker:
         ``docket.add`` under the deterministic key dedups against a live
         perpetual and only takes effect once the chain has actually been lost.
         """
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
         log_context = self._log_context()
 
-        while not stop_event.is_set():  # pragma: no branch
+        while not session.stopping.is_set():  # pragma: no branch
             if await _wait_for_event(
-                stop_event, AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS
+                session.stopping, AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS
             ):
                 return
 
@@ -1243,8 +1264,12 @@ class Worker:
                 extra=self._log_context(),
             )
 
-    async def _heartbeat(self, stop_event: asyncio.Event) -> None:
-        while not stop_event.is_set():  # pragma: no branch
+    async def _heartbeat(self) -> None:
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
+        while not session.stopping.is_set():  # pragma: no branch
             try:
                 now = datetime.now(timezone.utc).timestamp()
                 maximum_age = (
@@ -1306,47 +1331,47 @@ class Worker:
                 )
 
             if await _wait_for_event(
-                stop_event, self.docket.heartbeat_interval.total_seconds()
+                session.stopping, self.docket.heartbeat_interval.total_seconds()
             ):
                 return
 
-    async def _cancellation_listener(
-        self,
-        stop_event: asyncio.Event,
-        ready_event: asyncio.Event,
-    ) -> None:
+    async def _cancellation_listener(self) -> None:
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
         cancel_pattern = self.docket.key("cancel:*")
         log_context = self._log_context()
-        while not stop_event.is_set():
+        while not session.stopping.is_set():
             try:
                 async with self.docket._pubsub() as pubsub:
                     await pubsub.psubscribe(cancel_pattern)
-                    ready_event.set()
-                    while not stop_event.is_set():
+                    session.cancellation_ready.set()
+                    while not session.stopping.is_set():
                         message = await pubsub.get_message(
                             ignore_subscribe_messages=True, timeout=0.1
                         )
                         if message is not None and message["type"] == "pmessage":
                             await self._handle_cancellation(message)
             except ConnectionError:
-                if stop_event.is_set():
+                if session.stopping.is_set():
                     return  # pragma: no cover
                 REDIS_DISRUPTIONS.add(1, self.labels())
                 logger.warning(
                     "Redis connection error in cancellation listener, reconnecting...",
                     extra=log_context,
                 )
-                if await _wait_for_event(stop_event, 1):
+                if await _wait_for_event(session.stopping, 1):
                     return
             except Exception:
-                if stop_event.is_set():
+                if session.stopping.is_set():
                     return  # pragma: no cover
                 logger.exception(
                     "Error in cancellation listener",
                     exc_info=True,
                     extra=log_context,
                 )
-                if await _wait_for_event(stop_event, 1):
+                if await _wait_for_event(session.stopping, 1):
                     return
 
     async def _handle_cancellation(self, message: PubSubMessage) -> None:

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -33,6 +33,7 @@ else:
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode, Tracer
 
+from ._cancellation import CANCEL_MSG_CLEANUP, cancel_task
 from ._lua import Arg, Key, redis_script
 from ._redis import RedisClient
 from ._telemetry import suppress_instrumentation
@@ -699,12 +700,8 @@ class Worker:
         disconnect: ConnectionError | None = None
         try:
             async with AsyncExitStack() as dependency_stack:
-                # Each Dependency class used by a registered task may declare
-                # a ``worker_lifecycle`` classmethod that returns an async
-                # context manager.  We enter all of them around the worker's
-                # main loop so dependency-owned background work (subscribers,
-                # housekeeping tasks, etc.) gets started up and torn down in
-                # lockstep with the worker.  Worker stays dependency-agnostic.
+                # Enter dependency-owned worker lifecycle hooks around the
+                # processing loop while keeping Worker dependency-agnostic.
                 for dep_cls in self._dependency_lifecycle_classes():
                     cm = dep_cls.worker_lifecycle(self.docket, self)
                     if cm is not None:
@@ -733,7 +730,7 @@ class Worker:
                         self._renew_leases(redis, active_tasks),
                         name=f"{self.docket.name} - lease renewal",
                     )
-                    self._heartbeat_task = infra.create_task(
+                    self._heartbeat_task = asyncio.create_task(
                         self._heartbeat(), name=f"{self.docket.name} - heartbeat"
                     )
 
@@ -801,8 +798,10 @@ class Worker:
                 await asyncio.gather(*active_tasks, return_exceptions=True)
                 await process_completed_tasks()
 
-            self._worker_done.set()
+            if self._heartbeat_task is not None:
+                await cancel_task(self._heartbeat_task, CANCEL_MSG_CLEANUP)
             self._heartbeat_task = None
+            self._worker_done.set()
 
     async def _scheduler_loop(self, redis: Redis) -> None:
         """Loop that moves due tasks from the queue to the stream."""

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -292,6 +292,7 @@ class Worker:
         self._stack = AsyncExitStack()
         await self._stack.__aenter__()
 
+        # Events for coordinating worker loop shutdown (cleaned up last)
         self._worker_stopping = asyncio.Event()
         self._stack.callback(lambda: delattr(self, "_worker_stopping"))
         self._worker_done = asyncio.Event()
@@ -305,14 +306,18 @@ class Worker:
         self._tasks_by_key: dict[TaskKey, asyncio.Task[None]] = {}
         self._stack.callback(lambda: delattr(self, "_tasks_by_key"))
 
+        # The heartbeat task is owned by each processing attempt, not the
+        # Worker context.  It starts only after that attempt can claim work.
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._stack.callback(lambda: delattr(self, "_heartbeat_task"))
 
+        # Worker-scoped ContextVars for ambient access to docket/worker
         self._docket_token = current_docket.set(self.docket)
         self._stack.callback(lambda: current_docket.reset(self._docket_token))
         self._worker_token = current_worker.set(self)
         self._stack.callback(lambda: current_worker.reset(self._worker_token))
 
+        # Shared context is set up last, so it's cleaned up first (LIFO)
         self._shared_context = SharedContext()
         self._stack.callback(lambda: delattr(self, "_shared_context"))
         await self._stack.enter_async_context(self._shared_context)
@@ -325,9 +330,11 @@ class Worker:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        # Signal worker loop to stop and wait for it to drain
         self._worker_stopping.set()
         await self._worker_done.wait()
 
+        # Stack handles LIFO cleanup: shared context first, then attributes
         try:
             await self._stack.__aexit__(exc_type, exc_value, traceback)
         finally:
@@ -718,8 +725,12 @@ class Worker:
         disconnect: ConnectionError | None = None
         try:
             async with AsyncExitStack() as dependency_stack:
-                # Enter dependency-owned worker lifecycle hooks around the
-                # processing loop while keeping Worker dependency-agnostic.
+                # Each Dependency class used by a registered task may declare
+                # a ``worker_lifecycle`` classmethod that returns an async
+                # context manager.  We enter all of them around the worker's
+                # main loop so dependency-owned background work (subscribers,
+                # housekeeping tasks, etc.) gets started up and torn down in
+                # lockstep with the worker.  Worker stays dependency-agnostic.
                 for dep_cls in self._dependency_lifecycle_classes():
                     cm = dep_cls.worker_lifecycle(self.docket, self)
                     if cm is not None:

--- a/tests/cli/test_workers.py
+++ b/tests/cli/test_workers.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from contextlib import suppress
 from datetime import timedelta
 
 import pytest
@@ -22,21 +23,34 @@ async def test_list_workers_command(docket: Docket):
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
 
-    async with Worker(docket, name="worker-1"), Worker(docket, name="worker-2"):
-        await asyncio.sleep(heartbeat.total_seconds() * 5)
+    async with (
+        Worker(docket, name="worker-1") as worker_1,
+        Worker(docket, name="worker-2") as worker_2,
+    ):
+        run_1 = asyncio.create_task(worker_1.run_forever())
+        run_2 = asyncio.create_task(worker_2.run_forever())
+        try:
+            await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        result = await run_cli(
-            "workers",
-            "ls",
-            "--url",
-            docket.url,
-            "--docket",
-            docket.name,
-        )
-        assert result.exit_code == 0, result.output
+            result = await run_cli(
+                "workers",
+                "ls",
+                "--url",
+                docket.url,
+                "--docket",
+                docket.name,
+            )
+            assert result.exit_code == 0, result.output
 
-        assert "worker-1" in result.output
-        assert "worker-2" in result.output
+            assert "worker-1" in result.output
+            assert "worker-2" in result.output
+        finally:
+            run_1.cancel()
+            run_2.cancel()
+            with suppress(asyncio.CancelledError):
+                await run_1
+            with suppress(asyncio.CancelledError):
+                await run_2
 
 
 async def test_list_workers_for_task(docket: Docket):
@@ -45,19 +59,32 @@ async def test_list_workers_for_task(docket: Docket):
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
 
-    async with Worker(docket, name="worker-1"), Worker(docket, name="worker-2"):
-        await asyncio.sleep(heartbeat.total_seconds() * 5)
+    async with (
+        Worker(docket, name="worker-1") as worker_1,
+        Worker(docket, name="worker-2") as worker_2,
+    ):
+        run_1 = asyncio.create_task(worker_1.run_forever())
+        run_2 = asyncio.create_task(worker_2.run_forever())
+        try:
+            await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        result = await run_cli(
-            "workers",
-            "for-task",
-            "trace",
-            "--url",
-            docket.url,
-            "--docket",
-            docket.name,
-        )
-        assert result.exit_code == 0, result.output
+            result = await run_cli(
+                "workers",
+                "for-task",
+                "trace",
+                "--url",
+                docket.url,
+                "--docket",
+                docket.name,
+            )
+            assert result.exit_code == 0, result.output
 
-        assert "worker-1" in result.output
-        assert "worker-2" in result.output
+            assert "worker-1" in result.output
+            assert "worker-2" in result.output
+        finally:
+            run_1.cancel()
+            run_2.cancel()
+            with suppress(asyncio.CancelledError):
+                await run_1
+            with suppress(asyncio.CancelledError):
+                await run_2

--- a/tests/instrumentation/test_export.py
+++ b/tests/instrumentation/test_export.py
@@ -5,6 +5,7 @@ import http.client
 import socket
 import sys
 import time
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
@@ -201,20 +202,23 @@ async def test_worker_publishes_depth_gauges(
     QUEUE_DEPTH: Mock,
     SCHEDULE_DEPTH: Mock,
 ):
-    """Should publish depth gauges for due and scheduled tasks."""
-    await docket.add(the_task)()
-    await docket.add(the_task)()
-
+    """Should publish depth gauges from an active worker heartbeat."""
     future = datetime.now(timezone.utc) + timedelta(seconds=60)
     await docket.add(the_task, when=future)()
     await docket.add(the_task, when=future)()
     await docket.add(the_task, when=future)()
 
     docket.heartbeat_interval = timedelta(seconds=0.1)
-    async with Worker(docket):
-        await asyncio.sleep(0.2)  # enough for a heartbeat to be published
+    async with Worker(docket) as worker:
+        run = asyncio.create_task(worker.run_forever())
+        try:
+            await asyncio.sleep(0.2)  # enough for a heartbeat to be published
+        finally:
+            run.cancel()
+            with suppress(asyncio.CancelledError):
+                await run
 
-    QUEUE_DEPTH.assert_called_with(2, docket_labels)
+    QUEUE_DEPTH.assert_called_with(0, docket_labels)
     SCHEDULE_DEPTH.assert_called_with(3, docket_labels)
 
 

--- a/tests/test_docket_registration.py
+++ b/tests/test_docket_registration.py
@@ -1,5 +1,8 @@
 """Tests for Docket task registration."""
 
+import asyncio
+from contextlib import suppress
+
 from docket.docket import Docket
 from docket.worker import Worker
 from tests.conftest import wait_until
@@ -165,17 +168,23 @@ async def test_alias_appears_in_worker_announcements(docket: Docket):
     docket.register(my_task, names=["custom_alias"])
 
     async with Worker(docket) as w:
-        # The worker registers itself as a handler for "custom_alias"
-        # during its first heartbeat, which fires on a timer.  Poll
-        # task_workers() instead of guessing how long the heartbeat takes.
-        async def alias_visible() -> bool:
+        run = asyncio.create_task(w.run_forever())
+        try:
+            # The worker registers itself as a handler for "custom_alias"
+            # during its first heartbeat, which fires on a timer.  Poll
+            # task_workers() instead of guessing how long the heartbeat takes.
+            async def alias_visible() -> bool:
+                workers = await docket.task_workers("custom_alias")
+                return any(worker.name == w.name for worker in workers)
+
+            await wait_until(
+                alias_visible, description="custom_alias to appear in task_workers"
+            )
+
             workers = await docket.task_workers("custom_alias")
-            return any(worker.name == w.name for worker in workers)
-
-        await wait_until(
-            alias_visible, description="custom_alias to appear in task_workers"
-        )
-
-        workers = await docket.task_workers("custom_alias")
-        assert len(workers) == 1
-        assert w.name in {worker.name for worker in workers}
+            assert len(workers) == 1
+            assert w.name in {worker.name for worker in workers}
+        finally:
+            run.cancel()
+            with suppress(asyncio.CancelledError):
+                await run

--- a/tests/worker/test_core.py
+++ b/tests/worker/test_core.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import sys
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from typing import AsyncGenerator
 from unittest.mock import AsyncMock, patch
@@ -197,30 +197,47 @@ async def test_worker_announcements(
     docket.register(another_task)
 
     async with Worker(docket, name="worker-a") as worker_a:
-        await asyncio.sleep(heartbeat.total_seconds() * 5)
-
-        workers = await docket.workers()
-        assert len(workers) == 1
-        assert worker_a.name in {w.name for w in workers}
-
-        async with Worker(docket, name="worker-b") as worker_b:
+        run_a = asyncio.create_task(worker_a.run_forever())
+        try:
             await asyncio.sleep(heartbeat.total_seconds() * 5)
 
             workers = await docket.workers()
-            assert len(workers) == 2
-            assert {w.name for w in workers} == {worker_a.name, worker_b.name}
+            assert len(workers) == 1
+            assert worker_a.name in {w.name for w in workers}
 
-            for worker in workers:
-                # Allow generous timing tolerance - CI can have significant delays
-                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 20)
-                assert worker.tasks == builtin_tasks | {"the_task", "another_task"}
+            async with Worker(docket, name="worker-b") as worker_b:
+                run_b = asyncio.create_task(worker_b.run_forever())
+                try:
+                    await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        await asyncio.sleep(heartbeat.total_seconds() * 10)
+                    workers = await docket.workers()
+                    assert len(workers) == 2
+                    assert {w.name for w in workers} == {worker_a.name, worker_b.name}
 
-        workers = await docket.workers()
-        assert len(workers) == 1
-        assert worker_a.name in {w.name for w in workers}
-        assert worker_b.name not in {w.name for w in workers}
+                    for worker in workers:
+                        # Allow generous timing tolerance - CI can have significant delays
+                        assert worker.last_seen > datetime.now(timezone.utc) - (
+                            heartbeat * 20
+                        )
+                        assert worker.tasks == builtin_tasks | {
+                            "the_task",
+                            "another_task",
+                        }
+                finally:
+                    run_b.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await run_b
+
+            await asyncio.sleep(heartbeat.total_seconds() * 10)
+
+            workers = await docket.workers()
+            assert len(workers) == 1
+            assert worker_a.name in {w.name for w in workers}
+            assert worker_b.name not in {w.name for w in workers}
+        finally:
+            run_a.cancel()
+            with suppress(asyncio.CancelledError):
+                await run_a
 
     await asyncio.sleep(heartbeat.total_seconds() * 10)
 
@@ -242,30 +259,47 @@ async def test_task_announcements(
     docket.register(the_task)
     docket.register(another_task)
     async with Worker(docket, name="worker-a") as worker_a:
-        await asyncio.sleep(heartbeat.total_seconds() * 5)
-
-        workers = await docket.task_workers("the_task")
-        assert len(workers) == 1
-        assert worker_a.name in {w.name for w in workers}
-
-        async with Worker(docket, name="worker-b") as worker_b:
+        run_a = asyncio.create_task(worker_a.run_forever())
+        try:
             await asyncio.sleep(heartbeat.total_seconds() * 5)
 
             workers = await docket.task_workers("the_task")
-            assert len(workers) == 2
-            assert {w.name for w in workers} == {worker_a.name, worker_b.name}
+            assert len(workers) == 1
+            assert worker_a.name in {w.name for w in workers}
 
-            for worker in workers:
-                # Allow generous timing tolerance - CI can have significant delays
-                assert worker.last_seen > datetime.now(timezone.utc) - (heartbeat * 20)
-                assert worker.tasks == builtin_tasks | {"the_task", "another_task"}
+            async with Worker(docket, name="worker-b") as worker_b:
+                run_b = asyncio.create_task(worker_b.run_forever())
+                try:
+                    await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        await asyncio.sleep(heartbeat.total_seconds() * 10)
+                    workers = await docket.task_workers("the_task")
+                    assert len(workers) == 2
+                    assert {w.name for w in workers} == {worker_a.name, worker_b.name}
 
-        workers = await docket.task_workers("the_task")
-        assert len(workers) == 1
-        assert worker_a.name in {w.name for w in workers}
-        assert worker_b.name not in {w.name for w in workers}
+                    for worker in workers:
+                        # Allow generous timing tolerance - CI can have significant delays
+                        assert worker.last_seen > datetime.now(timezone.utc) - (
+                            heartbeat * 20
+                        )
+                        assert worker.tasks == builtin_tasks | {
+                            "the_task",
+                            "another_task",
+                        }
+                finally:
+                    run_b.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await run_b
+
+            await asyncio.sleep(heartbeat.total_seconds() * 10)
+
+            workers = await docket.task_workers("the_task")
+            assert len(workers) == 1
+            assert worker_a.name in {w.name for w in workers}
+            assert worker_b.name not in {w.name for w in workers}
+        finally:
+            run_a.cancel()
+            with suppress(asyncio.CancelledError):
+                await run_a
 
     await asyncio.sleep(heartbeat.total_seconds() * 10)
 
@@ -312,21 +346,27 @@ async def test_worker_recovers_from_redis_errors(
 
     monkeypatch.setattr(docket, "redis", mock_redis)
 
-    async with Worker(docket) as worker:
-        await asyncio.sleep(heartbeat.total_seconds() * 1.5)
+    async with Worker(docket, schedule_automatic_tasks=False) as worker:
+        run = asyncio.create_task(worker.run_forever())
+        try:
+            await asyncio.sleep(heartbeat.total_seconds() * 1.5)
 
-        await asyncio.sleep(heartbeat.total_seconds() * 5)
+            await asyncio.sleep(heartbeat.total_seconds() * 5)
 
-        workers = await docket.workers()
-        assert len(workers) == 1
-        assert worker.name in {w.name for w in workers}
+            workers = await docket.workers()
+            assert len(workers) == 1
+            assert worker.name in {w.name for w in workers}
 
-        # Verify that the last_seen timestamp is after our error
-        worker_info = next(w for w in workers if w.name == worker.name)
-        assert error_time
-        assert worker_info.last_seen > error_time, (
-            "Worker should have sent heartbeats after the Redis error"
-        )
+            # Verify that the last_seen timestamp is after our error
+            worker_info = next(w for w in workers if w.name == worker.name)
+            assert error_time
+            assert worker_info.last_seen > error_time, (
+                "Worker should have sent heartbeats after the Redis error"
+            )
+        finally:
+            run.cancel()
+            with suppress(asyncio.CancelledError):
+                await run
 
 
 async def test_worker_can_be_told_to_skip_automatic_tasks(docket: Docket):

--- a/tests/worker/test_core.py
+++ b/tests/worker/test_core.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timedelta, timezone
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,6 +17,7 @@ from redis.exceptions import ConnectionError
 
 from docket import CurrentWorker, Docket, Worker
 from docket.tasks import standard_tasks
+from tests.conftest import wait_until
 
 
 async def test_worker_acknowledges_messages(
@@ -307,66 +308,99 @@ async def test_task_announcements(
     assert len(workers) == 0
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        ConnectionError("oof"),
-        ValueError("woops"),
-    ],
-)
 async def test_worker_recovers_from_redis_errors(
     docket: Docket,
     the_task: AsyncMock,
-    monkeypatch: pytest.MonkeyPatch,
-    error: Exception,
 ):
-    """Should recover from errors and continue sending heartbeats"""
+    """Should recover from a polling disconnection and resume heartbeats."""
 
     heartbeat = timedelta(milliseconds=20)
     docket.heartbeat_interval = heartbeat
-    docket.missed_heartbeats = 3
-
+    docket.missed_heartbeats = 2
     docket.register(the_task)
+    fail_next_read = asyncio.Event()
+    read_failed = asyncio.Event()
+    error_time: datetime | None = None
 
-    original_redis = docket.redis
-    error_time = None
-    redis_calls = 0
+    class FailNextRead:
+        def __init__(self, wrapped: Any):
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._wrapped, name)
+
+        async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+            nonlocal error_time
+            if fail_next_read.is_set() and not read_failed.is_set():
+                error_time = datetime.now(timezone.utc)
+                read_failed.set()
+                raise ConnectionError("Simulated server loss mid-XREADGROUP")
+            return await self._wrapped.xreadgroup(*args, **kwargs)
+
+    original_redis = Docket.redis
 
     @asynccontextmanager
-    async def mock_redis() -> AsyncGenerator[RedisClient, None]:
-        nonlocal redis_calls, error_time
-        redis_calls += 1
+    async def flaky_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as r:
+            yield FailNextRead(r)  # type: ignore[arg-type]
 
-        if redis_calls == 2:
-            error_time = datetime.now(timezone.utc)
-            raise error
+    async def worker_is_visible(worker_name: str) -> bool:
+        workers = await docket.workers()
+        return any(worker.name == worker_name for worker in workers)
 
-        async with original_redis() as r:
-            yield r
+    async def worker_is_absent(worker_name: str) -> bool:
+        return not await worker_is_visible(worker_name)
 
-    monkeypatch.setattr(docket, "redis", mock_redis)
+    async def worker_info_after_error(worker_name: str) -> bool:
+        workers = await docket.workers()
+        return any(
+            worker.name == worker_name
+            and error_time is not None
+            and worker.last_seen > error_time
+            for worker in workers
+        )
 
-    async with Worker(docket, schedule_automatic_tasks=False) as worker:
-        run = asyncio.create_task(worker.run_forever())
-        try:
-            await asyncio.sleep(heartbeat.total_seconds() * 1.5)
+    with patch.object(Docket, "redis", flaky_redis):
+        async with Worker(
+            docket,
+            reconnection_delay=timedelta(milliseconds=150),
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+            schedule_automatic_tasks=False,
+        ) as worker:
+            run = asyncio.create_task(worker.run_forever())
+            try:
+                await wait_until(
+                    lambda: worker_is_visible(worker.name),
+                    timeout=1.0,
+                    description="initial worker heartbeat",
+                )
 
-            await asyncio.sleep(heartbeat.total_seconds() * 5)
+                fail_next_read.set()
+                await asyncio.wait_for(read_failed.wait(), timeout=2.0)
 
-            workers = await docket.workers()
-            assert len(workers) == 1
-            assert worker.name in {w.name for w in workers}
+                await wait_until(
+                    lambda: worker_is_absent(worker.name),
+                    timeout=1.0,
+                    description="worker to disappear while reconnecting",
+                )
 
-            # Verify that the last_seen timestamp is after our error
-            worker_info = next(w for w in workers if w.name == worker.name)
-            assert error_time
-            assert worker_info.last_seen > error_time, (
-                "Worker should have sent heartbeats after the Redis error"
-            )
-        finally:
-            run.cancel()
-            with suppress(asyncio.CancelledError):
-                await run
+                await wait_until(
+                    lambda: worker_info_after_error(worker.name),
+                    timeout=2.0,
+                    description="worker heartbeat after reconnect",
+                )
+
+                await docket.add(the_task)()
+                await wait_until(
+                    lambda: the_task.await_count == 1,
+                    timeout=2.0,
+                    description="worker to claim work after reconnect",
+                )
+            finally:
+                run.cancel()
+                with suppress(asyncio.CancelledError):
+                    await run
 
 
 async def test_worker_can_be_told_to_skip_automatic_tasks(docket: Docket):

--- a/tests/worker/test_invariants.py
+++ b/tests/worker/test_invariants.py
@@ -105,6 +105,7 @@ async def test_invariant_worker_attributes_deleted_after_exit(docket: Docket):
     assert hasattr(worker, "_worker_done")
     assert hasattr(worker, "_cancellation_ready")
     assert hasattr(worker, "_heartbeat_task")
+    assert worker._heartbeat_task is None  # type: ignore[protected-access]
     assert hasattr(worker, "_shared_context")
 
     await worker.__aexit__(None, None, None)

--- a/tests/worker/test_invariants.py
+++ b/tests/worker/test_invariants.py
@@ -103,9 +103,10 @@ async def test_invariant_worker_attributes_deleted_after_exit(docket: Docket):
     assert hasattr(worker, "_execution_counts")
     assert hasattr(worker, "_worker_stopping")
     assert hasattr(worker, "_worker_done")
-    assert hasattr(worker, "_cancellation_ready")
     assert hasattr(worker, "_heartbeat_task")
     assert worker._heartbeat_task is None  # type: ignore[protected-access]
+    assert hasattr(worker, "_processing_session")
+    assert worker._processing_session is None  # type: ignore[protected-access]
     assert hasattr(worker, "_shared_context")
 
     await worker.__aexit__(None, None, None)
@@ -115,8 +116,8 @@ async def test_invariant_worker_attributes_deleted_after_exit(docket: Docket):
     assert not hasattr(worker, "_execution_counts")
     assert not hasattr(worker, "_worker_stopping")
     assert not hasattr(worker, "_worker_done")
-    assert not hasattr(worker, "_cancellation_ready")
     assert not hasattr(worker, "_heartbeat_task")
+    assert not hasattr(worker, "_processing_session")
     assert not hasattr(worker, "_shared_context")
     assert not hasattr(worker, "_stack")
 

--- a/tests/worker/test_lifecycle.py
+++ b/tests/worker/test_lifecycle.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from redis.exceptions import ConnectionError
 
 from docket import Docket, Worker, testing
+from docket.dependencies import Dependency
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     from asyncio import timeout as async_timeout
@@ -137,6 +138,87 @@ async def test_worker_done_set_after_early_cancellation(docket: Docket):
         await worker.__aexit__(None, None, None)
 
 
+async def test_context_exit_interrupts_reconnection_delay(docket: Docket):
+    reconnecting = asyncio.Event()
+
+    async with Worker(
+        docket,
+        reconnection_delay=timedelta(seconds=30),
+    ) as worker:
+
+        async def failing_loop(redis: Any, forever: bool = False) -> None:
+            reconnecting.set()
+            raise ConnectionError("simulated reconnect")
+
+        with patch.object(worker, "_worker_loop", failing_loop):
+            worker_task = asyncio.create_task(worker.run_forever())
+            await asyncio.wait_for(reconnecting.wait(), timeout=1.0)
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(worker_task, timeout=1.0)
+
+
+async def test_worker_stopped_disconnect_returns_without_retry(docket: Docket):
+    async with Worker(docket) as worker:
+
+        async def stopped_loop(redis: Any, forever: bool = False) -> None:
+            worker._worker_stopping.set()  # pyright: ignore[reportPrivateUsage]
+            raise ConnectionError("simulated stopped reconnect")
+
+        with patch.object(worker, "_worker_loop", stopped_loop):
+            await worker.run_forever()
+
+
+async def test_worker_lifecycle_skips_dependency_without_context(docket: Docket):
+    events: list[str] = []
+
+    class NoLifecycleContext(Dependency[None]):
+        @classmethod
+        def worker_lifecycle(cls, docket: Docket, worker: Worker) -> None:
+            events.append("skipped-context")
+            return None
+
+        async def __aenter__(self) -> None:
+            return None
+
+    class TrackedLifecycleContext(Dependency[None]):
+        @classmethod
+        @asynccontextmanager
+        async def worker_lifecycle(
+            cls, docket: Docket, worker: Worker
+        ) -> AsyncGenerator[None, None]:
+            events.append("enter-context")
+            try:
+                yield
+            finally:
+                events.append("exit-context")
+
+        async def __aenter__(self) -> None:
+            return None
+
+    async def the_task(
+        no_context: None = NoLifecycleContext(),  # type: ignore[assignment]
+        tracked: None = TrackedLifecycleContext(),  # type: ignore[assignment]
+    ) -> None:
+        events.append("task")
+
+    await docket.add(the_task)()
+
+    async with Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert events == [
+        "skipped-context",
+        "enter-context",
+        "task",
+        "exit-context",
+    ]
+
+
 async def test_worker_rapid_start_cancel_cycles(docket: Docket):
     """Verify worker handles rapid start/cancel cycles without hanging."""
     for _ in range(10):  # pragma: no branch
@@ -171,7 +253,10 @@ async def test_worker_cancellation_during_setup_before_scheduler_created(
 
     # Patch _cancellation_listener to block indefinitely on _cancellation_ready
     # This ensures scheduler_task and lease_renewal_task are never created
-    async def slow_listener() -> None:
+    async def slow_listener(
+        stop_event: asyncio.Event,
+        ready_event: asyncio.Event,
+    ) -> None:
         # Don't set _cancellation_ready, just wait forever
         await asyncio.Event().wait()
 
@@ -188,6 +273,27 @@ async def test_worker_cancellation_during_setup_before_scheduler_created(
     # Cleanup
     async with async_timeout(1.0):  # pragma: no branch
         await worker.__aexit__(None, None, None)
+
+
+async def test_context_exit_while_waiting_for_cancellation_readiness(docket: Docket):
+    async def exercise() -> None:
+        async with Worker(
+            docket,
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+        ) as worker:
+
+            async def slow_listener(
+                stop_event: asyncio.Event,
+                ready_event: asyncio.Event,
+            ) -> None:
+                await stop_event.wait()
+
+            with patch.object(worker, "_cancellation_listener", slow_listener):
+                asyncio.create_task(worker.run_forever())
+                await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(exercise(), timeout=1.0)
 
 
 async def test_cancellation_listener_handles_connection_error(docket: Docket):
@@ -231,6 +337,28 @@ async def test_cancellation_listener_handles_connection_error(docket: Docket):
                 await worker_task
 
         assert error_count >= 2
+
+
+async def test_cancellation_listener_stops_during_error_backoff(docket: Docket):
+    async with Worker(docket) as worker:
+        for error in [ConnectionError("redis down"), RuntimeError("listener error")]:
+            stop_event = asyncio.Event()
+            ready_event = asyncio.Event()
+
+            @asynccontextmanager
+            async def failing_pubsub() -> AsyncGenerator[Any, None]:
+                raise error
+                yield  # pragma: no cover
+
+            with patch.object(docket, "_pubsub", failing_pubsub):
+                listener = asyncio.create_task(
+                    worker._cancellation_listener(  # pyright: ignore[reportPrivateUsage]
+                        stop_event, ready_event
+                    )
+                )
+                await asyncio.sleep(0.01)
+                stop_event.set()
+                await asyncio.wait_for(listener, timeout=1.0)
 
 
 async def test_cancellation_listener_handles_generic_exception(docket: Docket):

--- a/tests/worker/test_lifecycle.py
+++ b/tests/worker/test_lifecycle.py
@@ -12,6 +12,7 @@ from redis.exceptions import ConnectionError
 
 from docket import Docket, Worker, testing
 from docket.dependencies import Dependency
+from docket.worker import _ProcessingSession  # pyright: ignore[reportPrivateUsage]
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     from asyncio import timeout as async_timeout
@@ -240,9 +241,10 @@ async def test_worker_rapid_start_cancel_cycles(docket: Docket):
 async def test_worker_cancellation_during_setup_before_scheduler_created(
     docket: Docket,
 ):
-    """Test cancellation during _cancellation_ready.wait() before scheduler/lease tasks exist.
+    """Test cancellation before scheduler/lease tasks are created.
 
-    This hits the None branches in the finally block for scheduler_task and lease_renewal_task.
+    This keeps the processing attempt before its heartbeat, scheduler, and
+    lease-renewal tasks start.
     """
     worker = Worker(
         docket,
@@ -251,18 +253,14 @@ async def test_worker_cancellation_during_setup_before_scheduler_created(
     )
     await worker.__aenter__()
 
-    # Patch _cancellation_listener to block indefinitely on _cancellation_ready
-    # This ensures scheduler_task and lease_renewal_task are never created
-    async def slow_listener(
-        stop_event: asyncio.Event,
-        ready_event: asyncio.Event,
-    ) -> None:
-        # Don't set _cancellation_ready, just wait forever
+    # Patch _cancellation_listener to block indefinitely before readiness.
+    # This ensures scheduler_task and lease_renewal_task are never created.
+    async def slow_listener() -> None:
         await asyncio.Event().wait()
 
     with patch.object(worker, "_cancellation_listener", slow_listener):
         worker_task = asyncio.create_task(worker.run_forever())
-        # Give time for the task to start and reach _cancellation_ready.wait()
+        # Give time for the task to start and wait on cancellation readiness.
         await asyncio.sleep(0.01)
         worker_task.cancel()
 
@@ -283,11 +281,10 @@ async def test_context_exit_while_waiting_for_cancellation_readiness(docket: Doc
             scheduling_resolution=timedelta(milliseconds=5),
         ) as worker:
 
-            async def slow_listener(
-                stop_event: asyncio.Event,
-                ready_event: asyncio.Event,
-            ) -> None:
-                await stop_event.wait()
+            async def slow_listener() -> None:
+                session = worker._processing_session  # pyright: ignore[reportPrivateUsage]
+                assert session is not None
+                await session.stopping.wait()
 
             with patch.object(worker, "_cancellation_listener", slow_listener):
                 asyncio.create_task(worker.run_forever())
@@ -342,8 +339,11 @@ async def test_cancellation_listener_handles_connection_error(docket: Docket):
 async def test_cancellation_listener_stops_during_error_backoff(docket: Docket):
     async with Worker(docket) as worker:
         for error in [ConnectionError("redis down"), RuntimeError("listener error")]:
-            stop_event = asyncio.Event()
-            ready_event = asyncio.Event()
+            session = _ProcessingSession(
+                stopping=asyncio.Event(),
+                cancellation_ready=asyncio.Event(),
+            )
+            worker._processing_session = session  # pyright: ignore[reportPrivateUsage]
 
             @asynccontextmanager
             async def failing_pubsub() -> AsyncGenerator[Any, None]:
@@ -351,14 +351,16 @@ async def test_cancellation_listener_stops_during_error_backoff(docket: Docket):
                 yield  # pragma: no cover
 
             with patch.object(docket, "_pubsub", failing_pubsub):
-                listener = asyncio.create_task(
-                    worker._cancellation_listener(  # pyright: ignore[reportPrivateUsage]
-                        stop_event, ready_event
+                try:
+                    listener = asyncio.create_task(
+                        worker._cancellation_listener()  # pyright: ignore[reportPrivateUsage]
                     )
-                )
-                await asyncio.sleep(0.01)
-                stop_event.set()
-                await asyncio.wait_for(listener, timeout=1.0)
+                    await asyncio.sleep(0.01)
+                    session.stopping.set()
+                    await asyncio.wait_for(listener, timeout=1.0)
+                finally:
+                    session.stopping.set()
+                    worker._processing_session = None  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_cancellation_listener_handles_generic_exception(docket: Docket):

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -1,10 +1,15 @@
 """Tests for worker liveness announcements."""
 
 import asyncio
+from contextlib import asynccontextmanager, suppress
 from datetime import timedelta
+from typing import Any, AsyncGenerator
 from unittest.mock import patch
 
 from docket import Docket, Worker
+from docket._redis import RedisClient
+from redis.exceptions import ConnectionError
+from tests.conftest import wait_until
 
 
 async def test_worker_context_without_processing_loop_is_not_announced(
@@ -49,11 +54,14 @@ async def test_worker_waits_for_cancellation_readiness_before_announcement(
     ) as worker:
         listener_ready = asyncio.Event()
 
-        async def slow_listener() -> None:
+        async def slow_listener(
+            stop_event: asyncio.Event,
+            ready_event: asyncio.Event,
+        ) -> None:
             await asyncio.sleep(heartbeat.total_seconds() * 8)
-            worker._cancellation_ready.set()  # pyright: ignore[reportPrivateUsage]
+            ready_event.set()
             listener_ready.set()
-            await worker._worker_stopping.wait()  # pyright: ignore[reportPrivateUsage]
+            await stop_event.wait()
 
         with patch.object(worker, "_cancellation_listener", slow_listener):
             worker_run = asyncio.create_task(worker.run_until_finished())
@@ -86,7 +94,7 @@ async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket)
             scheduling_resolution=timedelta(milliseconds=5),
         ) as worker:
 
-            async def blocked_heartbeat() -> None:
+            async def blocked_heartbeat(stop_event: asyncio.Event) -> None:
                 heartbeat_started.set()
                 try:
                     await asyncio.Event().wait()
@@ -103,3 +111,136 @@ async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket)
     await asyncio.wait_for(exercise(), timeout=2.0)
 
     assert heartbeat_cancelled.is_set()
+
+
+async def test_worker_draining_after_disconnect_is_not_announced(docket: Docket):
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+    docket.missed_heartbeats = 100
+
+    task_started = asyncio.Event()
+    finish_task = asyncio.Event()
+    fail_next_read = asyncio.Event()
+    read_failed = asyncio.Event()
+    later_task_finished = asyncio.Event()
+
+    async def long_task() -> None:
+        task_started.set()
+        await finish_task.wait()
+
+    async def later_task() -> None:
+        later_task_finished.set()
+
+    class FailNextRead:
+        def __init__(self, wrapped: Any):
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._wrapped, name)
+
+        async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+            if fail_next_read.is_set() and not read_failed.is_set():
+                read_failed.set()
+                raise ConnectionError("Simulated server loss mid-XREADGROUP")
+            return await self._wrapped.xreadgroup(*args, **kwargs)
+
+    original_redis = Docket.redis
+
+    @asynccontextmanager
+    async def flaky_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as redis:
+            yield FailNextRead(redis)  # type: ignore[arg-type]
+
+    async def worker_is_visible(worker_name: str) -> bool:
+        return any(worker.name == worker_name for worker in await docket.workers())
+
+    async def worker_is_absent(worker_name: str) -> bool:
+        return not await worker_is_visible(worker_name)
+
+    await docket.add(long_task)()
+
+    with patch.object(Docket, "redis", flaky_redis):
+        async with Worker(
+            docket,
+            name="draining-worker",
+            concurrency=2,
+            reconnection_delay=timedelta(milliseconds=100),
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+            schedule_automatic_tasks=False,
+        ) as worker:
+            worker_run = asyncio.create_task(worker.run_forever())
+            try:
+                await asyncio.wait_for(task_started.wait(), timeout=2.0)
+                await wait_until(
+                    lambda: worker_is_visible(worker.name),
+                    timeout=1.0,
+                    description="worker to publish initial heartbeat",
+                )
+
+                fail_next_read.set()
+                await asyncio.wait_for(read_failed.wait(), timeout=2.0)
+                await wait_until(
+                    lambda: worker_is_absent(worker.name),
+                    timeout=0.5,
+                    description="draining worker to stop being announced",
+                )
+
+                finish_task.set()
+                await docket.add(later_task)()
+                await wait_until(
+                    later_task_finished.is_set,
+                    timeout=2.0,
+                    description="worker to claim work after reconnect",
+                )
+            finally:
+                worker_run.cancel()
+                with suppress(asyncio.CancelledError):
+                    await worker_run
+
+
+async def test_heartbeat_recovers_from_connection_error(docket: Docket):
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+
+    async def liveness_task() -> None: ...
+
+    docket.register(liveness_task)
+    redis_calls = 0
+    original_redis = Docket.redis
+
+    @asynccontextmanager
+    async def flaky_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        nonlocal redis_calls
+        redis_calls += 1
+        if redis_calls == 1:
+            raise ConnectionError("simulated heartbeat connection error")
+        async with original_redis(self) as redis:
+            yield redis
+
+    async with Worker(docket, name="heartbeat-worker") as worker:
+        stop_event = asyncio.Event()
+        with patch.object(Docket, "redis", flaky_redis):
+            heartbeat_task = asyncio.create_task(
+                worker._heartbeat(stop_event)  # pyright: ignore[reportPrivateUsage]
+            )
+            try:
+                await wait_until(
+                    lambda: redis_calls >= 2,
+                    timeout=1.0,
+                    description="heartbeat retry after connection error",
+                )
+            finally:
+                stop_event.set()
+                await heartbeat_task
+
+
+async def test_remove_heartbeat_suppresses_cleanup_errors(docket: Docket):
+    @asynccontextmanager
+    async def broken_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        raise RuntimeError("simulated cleanup error")
+        yield  # pragma: no cover
+
+    async with Worker(docket) as worker:
+        with patch.object(Docket, "redis", broken_redis):
+            await worker._remove_heartbeat()  # pyright: ignore[reportPrivateUsage]

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -1,0 +1,71 @@
+"""Tests for worker liveness announcements."""
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import patch
+
+from docket import Docket, Worker
+
+
+async def test_worker_context_without_processing_loop_is_not_announced(
+    docket: Docket,
+):
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+    docket.missed_heartbeats = 3
+
+    async def liveness_task() -> None: ...
+
+    docket.register(liveness_task)
+
+    async with Worker(docket, name="idle-worker"):
+        await asyncio.sleep(heartbeat.total_seconds() * 2)
+
+        snapshot = await docket.snapshot()
+
+    assert {worker.name for worker in snapshot.workers} == set()
+
+
+async def test_worker_waits_for_cancellation_readiness_before_announcement(
+    docket: Docket,
+):
+    heartbeat = timedelta(milliseconds=20)
+    docket.heartbeat_interval = heartbeat
+    docket.missed_heartbeats = 3
+
+    task_complete = False
+
+    async def delayed_task() -> None:
+        nonlocal task_complete
+        task_complete = True
+
+    await docket.add(delayed_task)()
+
+    async with Worker(
+        docket,
+        name="not-ready-worker",
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as worker:
+        listener_ready = asyncio.Event()
+
+        async def slow_listener() -> None:
+            await asyncio.sleep(heartbeat.total_seconds() * 8)
+            worker._cancellation_ready.set()  # pyright: ignore[reportPrivateUsage]
+            listener_ready.set()
+            await worker._worker_stopping.wait()  # pyright: ignore[reportPrivateUsage]
+
+        with patch.object(worker, "_cancellation_listener", slow_listener):
+            worker_run = asyncio.create_task(worker.run_until_finished())
+            try:
+                await asyncio.sleep(heartbeat.total_seconds() * 2)
+
+                snapshot = await docket.snapshot()
+                await asyncio.wait_for(listener_ready.wait(), timeout=1)
+                await asyncio.wait_for(worker_run, timeout=5)
+            finally:
+                worker_run.cancel()
+                await asyncio.gather(worker_run, return_exceptions=True)
+
+    assert {worker.name for worker in snapshot.workers} == set()
+    assert task_complete

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -69,3 +69,37 @@ async def test_worker_waits_for_cancellation_readiness_before_announcement(
 
     assert {worker.name for worker in snapshot.workers} == set()
     assert task_complete
+
+
+async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket):
+    heartbeat_started = asyncio.Event()
+    heartbeat_cancelled = asyncio.Event()
+
+    async def liveness_task() -> None: ...
+
+    docket.register(liveness_task)
+
+    async def exercise() -> None:
+        async with Worker(
+            docket,
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+        ) as worker:
+
+            async def blocked_heartbeat() -> None:
+                heartbeat_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    heartbeat_cancelled.set()
+                    raise
+
+            with patch.object(worker, "_heartbeat", blocked_heartbeat):
+                worker_run = asyncio.create_task(worker.run_forever())
+                await heartbeat_started.wait()
+
+        await worker_run
+
+    await asyncio.wait_for(exercise(), timeout=2.0)
+
+    assert heartbeat_cancelled.is_set()

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from docket import Docket, Worker
 from docket._redis import RedisClient
+from docket.worker import _ProcessingSession  # pyright: ignore[reportPrivateUsage]
 from redis.exceptions import ConnectionError
 from tests.conftest import wait_until
 
@@ -54,14 +55,13 @@ async def test_worker_waits_for_cancellation_readiness_before_announcement(
     ) as worker:
         listener_ready = asyncio.Event()
 
-        async def slow_listener(
-            stop_event: asyncio.Event,
-            ready_event: asyncio.Event,
-        ) -> None:
+        async def slow_listener() -> None:
+            session = worker._processing_session  # pyright: ignore[reportPrivateUsage]
+            assert session is not None
             await asyncio.sleep(heartbeat.total_seconds() * 8)
-            ready_event.set()
+            session.cancellation_ready.set()
             listener_ready.set()
-            await stop_event.wait()
+            await session.stopping.wait()
 
         with patch.object(worker, "_cancellation_listener", slow_listener):
             worker_run = asyncio.create_task(worker.run_until_finished())
@@ -94,7 +94,7 @@ async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket)
             scheduling_resolution=timedelta(milliseconds=5),
         ) as worker:
 
-            async def blocked_heartbeat(stop_event: asyncio.Event) -> None:
+            async def blocked_heartbeat() -> None:
                 heartbeat_started.set()
                 try:
                     await asyncio.Event().wait()
@@ -219,10 +219,14 @@ async def test_heartbeat_recovers_from_connection_error(docket: Docket):
             yield redis
 
     async with Worker(docket, name="heartbeat-worker") as worker:
-        stop_event = asyncio.Event()
+        session = _ProcessingSession(
+            stopping=asyncio.Event(),
+            cancellation_ready=asyncio.Event(),
+        )
+        worker._processing_session = session  # pyright: ignore[reportPrivateUsage]
         with patch.object(Docket, "redis", flaky_redis):
             heartbeat_task = asyncio.create_task(
-                worker._heartbeat(stop_event)  # pyright: ignore[reportPrivateUsage]
+                worker._heartbeat()  # pyright: ignore[reportPrivateUsage]
             )
             try:
                 await wait_until(
@@ -231,8 +235,9 @@ async def test_heartbeat_recovers_from_connection_error(docket: Docket):
                     description="heartbeat retry after connection error",
                 )
             finally:
-                stop_event.set()
+                session.stopping.set()
                 await heartbeat_task
+                worker._processing_session = None  # pyright: ignore[reportPrivateUsage]
 
 
 async def test_remove_heartbeat_suppresses_cleanup_errors(docket: Docket):


### PR DESCRIPTION
## Summary
- Fixes the worker liveness invariant exposed by the Redis outage: a worker is advertised only while it is ready to claim and schedule work.
- Moves heartbeat ownership from the `Worker` context lifetime to each active processing attempt, after cancellation listening is ready and processing infrastructure has started.
- Stops advertising the worker during reconnect/drain periods when it cannot claim new work, then advertises again once the next processing attempt is ready.
- Adds regressions for context-only workers, Redis polling recovery, delayed cancellation-listener readiness, and reconnect shutdown behavior.

## Related
- Addresses the Docket side of PrefectHQ/prefect#22212.
