### PR TITLE
Share ssl_* options with the Sentinel daemon connections on TLS URLs

### DIFF
--- a/src/docket/_redis_sentinel.py
+++ b/src/docket/_redis_sentinel.py
@@ -119,7 +119,9 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
     All other query parameters are standard redis-py connection options
     (``max_connections``, ``socket_timeout``, ``health_check_interval``, ...)
     and apply to the data-node connections with exactly the same parsing as a
-    standalone ``redis://`` URL.
+    standalone ``redis://`` URL. On the ``rediss+sentinel`` scheme the ``ssl_*``
+    options additionally apply to the connections to the Sentinel daemons, so a
+    single private CA (``?ssl_ca_certs=...``) covers the whole topology.
 
     Raises:
         ValueError: for a missing host, malformed port, missing service name,
@@ -194,6 +196,19 @@ def parse_sentinel_url(url: str) -> SentinelConfiguration:
         for governed in ("db", "username", "password"):
             funneled.pop(governed, None)
         connection_kwargs.update(funneled)
+        if tls:
+            # The Sentinel daemons share the data nodes' TLS profile: without
+            # this, a private CA passed as ?ssl_ca_certs= (or ?ssl_cert_reqs=none
+            # for unverified setups) would apply to the master connections only,
+            # and every connection to a Sentinel daemon would fail certificate
+            # verification during discovery.
+            sentinel_kwargs.update(
+                {
+                    name: value
+                    for name, value in funneled.items()
+                    if name.startswith("ssl_")
+                }
+            )
 
     if parsed.username:
         connection_kwargs["username"] = unquote(parsed.username)

--- a/tests/test_sentinel_urls.py
+++ b/tests/test_sentinel_urls.py
@@ -129,6 +129,37 @@ def test_parse_sentinel_url_passes_through_pool_options():
     assert config.sentinel_kwargs == {}
 
 
+def test_parse_sentinel_url_tls_shares_ssl_options_with_sentinels():
+    """On the rediss+sentinel scheme the ssl_* options apply to the Sentinel
+    daemon connections too, so one private CA verifies the whole topology
+    (discovery would otherwise fail certificate verification)."""
+    config = parse_sentinel_url(
+        "rediss+sentinel://sentinel-a/mymaster"
+        "?ssl_ca_certs=/etc/redis/ca.pem&ssl_check_hostname=false&socket_timeout=5"
+    )
+    assert config.connection_kwargs == {
+        "ssl": True,
+        "ssl_ca_certs": "/etc/redis/ca.pem",
+        "ssl_check_hostname": False,
+        "socket_timeout": 5.0,
+    }
+    assert config.sentinel_kwargs == {
+        "ssl": True,
+        "ssl_ca_certs": "/etc/redis/ca.pem",
+        "ssl_check_hostname": False,
+    }
+
+
+def test_parse_sentinel_url_plaintext_sentinels_get_no_ssl_options():
+    """Without TLS the daemons stay plaintext: ssl_* options pass through to
+    the data-node kwargs only, like any other redis-py option."""
+    config = parse_sentinel_url(
+        "redis+sentinel://sentinel-a/mymaster?ssl_ca_certs=/etc/redis/ca.pem"
+    )
+    assert config.connection_kwargs == {"ssl_ca_certs": "/etc/redis/ca.pem"}
+    assert config.sentinel_kwargs == {}
+
+
 def test_parse_sentinel_url_db_comes_from_path_only():
     """The database is taken from the path; a stray ?db= is not an alternate
     source, and credentials stay sourced from the URL userinfo."""


### PR DESCRIPTION
This PR shares the funneled `ssl_*` connection options with the Sentinel daemon connections on `rediss+sentinel://` URLs, so a single private CA covers the whole topology.

## Problem

`parse_sentinel_url` funnels the remaining query parameters through redis-py's `parse_url` and applies them to the **data-node** connections only; `sentinel_kwargs` carries just `sentinel_username`/`sentinel_password` and the scheme-derived `ssl=True`. That means on a TLS topology with a private or self-signed CA:

- `?ssl_ca_certs=/etc/redis/ca.pem` configures the master connections, but every connection to a Sentinel daemon still verifies against the system trust store with `ssl_cert_reqs="required"`;
- discovery fails for all daemons and master resolution raises `MasterNotFoundError` before a data connection is ever attempted — there is no way to make a private-CA `rediss+sentinel://` URL work at all (the same applies to `?ssl_cert_reqs=none` for deliberately unverified setups).

Reproduced against a real TLS Sentinel topology in Docker (master + 2 replicas + 3 Sentinels on TLS-only ports, `tls-replication yes`, self-signed CA): every variant failed with `MasterNotFoundError`, with the daemon connection reprs showing `ssl_ca_certs=None, ssl_cert_reqs=required`.

## Fix

When the scheme is `rediss+sentinel`, the daemon connections now reuse the URL's funneled `ssl_*` options (`ssl_ca_certs`, `ssl_cert_reqs`, `ssl_check_hostname`, ...). Plaintext `redis+sentinel://` URLs are unaffected — `ssl_*` options keep applying to the data nodes only, like any other redis-py option.

With the fix, the same Docker topology passes end to end: CA-verified discovery and reads/writes, the `?ssl_cert_reqs=none&ssl_check_hostname=false` unverified variant, rejection when the CA is omitted (negative control), and a master SIGKILL failover under TLS (~3s, client follows the promotion).

## Notes

- `prefect-redis`, whose Sentinel parser deliberately mirrors this module, hit exactly this in review testing and applied the same fix in PrefectHQ/prefect#22377 — this PR keeps the two convergent.
- Tests cover both the TLS sharing and the plaintext non-sharing case; `pytest tests/test_sentinel_urls.py` (34 passed) and `prek run` (ruff, pyright, loq) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
