### PR TITLE
Adopt uncalled-for 0.4.0: CallArgument references and Depends bindings

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -5,7 +5,8 @@ Docket includes a dependency injection system that provides access to context, c
 As of version 0.18.0, Docket's dependency injection is built on the
 [`uncalled-for`](https://github.com/chrisguidry/uncalled-for) package
 ([PyPI](https://pypi.org/project/uncalled-for/)), which provides the core
-resolution engine, `Depends`, `Shared`, and `Dependency` base class.  Docket
+resolution engine, `Depends`, `Shared`, `CallArgument`, and the `Dependency`
+base class.  Docket
 layers on task-specific context (`CurrentDocket`, `CurrentWorker`, etc.) and
 behavioral dependencies (`Retry`, `Perpetual`, `Timeout`, etc.).
 
@@ -132,6 +133,80 @@ async def flexible_task(
     await process_data(data, resolved_config)
 ```
 
+### CallArgument
+
+`CallArgument` declares that a dependency function's parameter takes its value
+from a parameter of the task itself. It comes from
+[`uncalled-for`](https://github.com/chrisguidry/uncalled-for) and is
+re-exported from `docket`. The bare form takes the name of the parameter it is
+declared on:
+
+```python
+from docket import CallArgument, Depends
+
+async def load_user(user_id: int = CallArgument()) -> User:
+    return await fetch_user(user_id)
+
+async def send_welcome_email(
+    user_id: int,
+    user: User = Depends(load_user),
+) -> None:
+    await send_email(user.email, "Welcome!")
+```
+
+`CallArgument("name")` names a different parameter of the task:
+
+```python
+async def load_recipient(user_id: int = CallArgument("recipient_id")) -> User:
+    return await fetch_user(user_id)
+
+async def send_invoice(
+    recipient_id: int,
+    invoice_id: int,
+    recipient: User = Depends(load_recipient),
+) -> None:
+    ...
+```
+
+The reference sees the same value the task receives for that parameter,
+wherever it comes from. An argument the caller passed always wins. A parameter
+backed by another dependency resolves once, and the task and every reference
+share that one value. A plain signature default like `count: int = 5` is
+returned as-is:
+
+```python
+def default_region() -> str:
+    return "us-east-1"
+
+async def get_bucket(region: str = CallArgument()) -> Bucket:
+    return await connect_bucket(region)
+
+async def archive_report(
+    report_id: int,
+    region: str = Depends(default_region),
+    bucket: Bucket = Depends(get_bucket),
+) -> None:
+    ...
+```
+
+When the caller passes `region="eu-west-1"`, `default_region` is never called,
+and both the task and `get_bucket` see the caller's value. Otherwise
+`default_region` runs once and supplies both.
+
+`CallArgument(optional=True)` yields `None` when the task has no parameter
+with that name. References that form a cycle fail the task with a
+`CycleError` (also re-exported from `docket`) naming the path, such as
+`a -> b -> a`. `optional=True` does not suppress a cycle.
+
+#### TaskArgument and CallArgument
+
+`TaskArgument` is built on `CallArgument`, and the two differ in what they
+can see. `TaskArgument` sees only the
+arguments the caller supplied at the task's call site: for anything else,
+including a parameter backed by a dependency, it raises (or yields `None` with
+`optional=True`). `CallArgument` also sees values produced by sibling
+dependencies on the task's signature and plain signature defaults.
+
 ## Using Functions as Dependencies
 
 ### Depends
@@ -254,7 +329,57 @@ async def important_task(
     logger.info("Important task completed")
 ```
 
-### Shared
+#### Keyword Bindings
+
+`Depends` accepts keyword bindings, so you can wire arguments into a
+dependency function from the place that declares it, without changing the
+function itself. This is the other position for `CallArgument`:
+
+```python
+from docket import CallArgument, Depends
+
+async def load_user(user_id: int) -> User:
+    return await fetch_user(user_id)
+
+async def send_invoice(
+    user_id: int,
+    invoice_id: int,
+    user: User = Depends(load_user, user_id=CallArgument("user_id")),
+) -> None:
+    ...
+```
+
+A binding that is itself a dependency, such as `CallArgument(...)` or another
+`Depends(...)`, resolves first and the function receives its value. Any other
+value passes through as it is:
+
+```python
+async def fetch_report(source: str, timeout: int = 30) -> Report:
+    ...
+
+async def nightly_summary(
+    report: Report = Depends(fetch_report, source="warehouse", timeout=5),
+) -> None:
+    ...
+```
+
+A binding replaces the default of the function's own parameter, which is then
+never resolved. Here `Depends(get_replica)` never runs, because the binding
+supplies `db` directly:
+
+```python
+async def get_orders(db: Database = Depends(get_replica)) -> list[Order]:
+    return await db.fetch_orders()
+
+async def reconcile(
+    orders: list[Order] = Depends(get_orders, db=Depends(get_primary)),
+) -> None:
+    ...
+```
+
+Caching still applies per task execution, keyed by the function and its
+bindings. Two `Depends(same_function)` declarations with the same bindings
+share one result; declarations with different bindings each get their own.
 
 While `Depends` resolves a fresh instance for each task, `Shared` resolves once at worker startup and provides the same instance to all tasks for the worker's lifetime. This is useful for expensive resources like connection pools, loaded configuration, or shared clients.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "typer>=0.15.1",
     "typing_extensions>=4.12.0",
     "tzdata>=2025.2; sys_platform == 'win32'",
-    "uncalled-for>=0.3.2",
+    "uncalled-for>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/docket/__init__.py
+++ b/src/docket/__init__.py
@@ -11,9 +11,11 @@ __version__ = version("pydocket")
 from .agenda import Agenda
 from .annotations import Logged
 from .dependencies import (
+    CallArgument,
     ConcurrencyLimit,
     Cooldown,
     Cron,
+    CycleError,
     Debounce,
     RateLimit,
     CurrentDocket,
@@ -45,9 +47,11 @@ from . import testing
 __all__ = [
     "__version__",
     "Agenda",
+    "CallArgument",
     "ConcurrencyLimit",
     "Cooldown",
     "Cron",
+    "CycleError",
     "Debounce",
     "RateLimit",
     "CurrentDocket",

--- a/src/docket/dependencies/__init__.py
+++ b/src/docket/dependencies/__init__.py
@@ -43,6 +43,8 @@ from ._functional import (
 from ._perpetual import Perpetual
 from ._progress import Progress
 from uncalled_for import (
+    CallArgument,
+    CycleError,
     FailedDependency,
     get_annotation_dependencies,
     validate_dependencies,
@@ -75,6 +77,8 @@ __all__ = [
     "TaskKey",
     "TaskLogger",
     # Functional dependencies
+    "CallArgument",
+    "CycleError",
     "Depends",
     "DependencyFunction",
     "Shared",

--- a/src/docket/dependencies/_contextual.py
+++ b/src/docket/dependencies/_contextual.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from uncalled_for import current_frame
+from uncalled_for.frames import _CallArgument  # pyright: ignore[reportPrivateUsage]
+
 from ._base import Dependency, current_docket, current_execution, current_worker
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -89,29 +92,32 @@ def TaskKey() -> str:
     return cast(str, _TaskKey())
 
 
-class _TaskArgument(Dependency[Any]):
-    parameter: str | None
-    optional: bool
+class _TaskArgument(_CallArgument):
+    """A `CallArgument` limited to arguments the caller supplied.
 
-    def __init__(self, parameter: str | None = None, optional: bool = False) -> None:
-        self.parameter = parameter
-        self.optional = optional
+    `provided_only=True` keeps `TaskArgument` from resolving sibling
+    dependencies or falling back to signature defaults, so `optional=True`
+    yields None for a parameter that is only backed by a dependency.
+    """
 
     async def __aenter__(self) -> Any:
         assert self.parameter is not None
-        execution = current_execution.get()
         try:
-            return execution.get_argument(self.parameter)
-        except KeyError:
+            return await current_frame().resolve(self.parameter, provided_only=True)
+        except LookupError:
             if self.optional:
                 return None
-            raise
+            raise KeyError(self.parameter) from None
 
 
 def TaskArgument(parameter: str | None = None, optional: bool = False) -> Any:
     """A dependency to access a argument of the currently executing task.  This is
     often useful in dependency functions so they can access the arguments of the
     task they are injected into.
+
+    `TaskArgument` sees only the arguments the caller supplied. Use
+    `CallArgument` to also see values that sibling dependencies produce and
+    plain signature defaults.
 
     Example:
 

--- a/src/docket/dependencies/_functional.py
+++ b/src/docket/dependencies/_functional.py
@@ -19,10 +19,8 @@ from uncalled_for.functional import _Depends as _UncalledForDepends
 # uncalled-for's get_dependency_parameters uses internally.
 from uncalled_for.introspection import (
     _parameter_cache as _parameter_cache,
-    get_dependency_parameters,
+    get_dependency_parameters as get_dependency_parameters,
 )
-
-from ._contextual import _TaskArgument
 
 R = TypeVar("R")
 
@@ -30,34 +28,22 @@ DependencyFunction = DependencyFactory
 
 
 class _Depends(_UncalledForDepends[R]):
-    """Docket's call-scoped dependency with TaskArgument inference."""
-
-    async def _resolve_parameters(
-        self,
-        function: Callable[..., Any],
-    ) -> dict[str, Any]:
-        stack = self.stack.get()
-        arguments: dict[str, Any] = {}
-        parameters = get_dependency_parameters(function)
-
-        for parameter, dependency in parameters.items():
-            if isinstance(dependency, _TaskArgument) and not dependency.parameter:
-                dependency.parameter = parameter
-
-            arguments[parameter] = await stack.enter_async_context(dependency)
-
-        return arguments
+    """Docket's call-scoped dependency, resolved fresh for each task."""
 
 
 @overload
-def Depends(dependency: Callable[..., AbstractAsyncContextManager[R]]) -> R: ...
+def Depends(
+    dependency: Callable[..., AbstractAsyncContextManager[R]], **bindings: Any
+) -> R: ...
 @overload
-def Depends(dependency: Callable[..., AbstractContextManager[R]]) -> R: ...
+def Depends(
+    dependency: Callable[..., AbstractContextManager[R]], **bindings: Any
+) -> R: ...
 @overload
-def Depends(dependency: Callable[..., Awaitable[R]]) -> R: ...
+def Depends(dependency: Callable[..., Awaitable[R]], **bindings: Any) -> R: ...
 @overload
-def Depends(dependency: Callable[..., R]) -> R: ...
-def Depends(dependency: DependencyFactory[R]) -> R:
+def Depends(dependency: Callable[..., R], **bindings: Any) -> R: ...
+def Depends(dependency: DependencyFactory[R], **bindings: Any) -> R:
     """Include a user-defined function as a dependency.  Dependencies may be:
     - Synchronous functions returning a value
     - Asynchronous functions returning a value (awaitable)
@@ -66,6 +52,14 @@ def Depends(dependency: DependencyFactory[R]) -> R:
 
     If a dependency returns a context manager, it will be entered and exited around
     the task, giving an opportunity to control the lifetime of a resource.
+
+    Keyword `bindings` supply arguments to the dependency function from the
+    place that declares it. A `Dependency` value, such as `CallArgument()` or
+    another `Depends(...)`, resolves first and the function receives its value.
+    Any other value passes through as it is. A binding replaces the default of
+    the function's own parameter, which is then never resolved. Two
+    dependencies on the same function share one cached result only when their
+    bindings match.
 
     **Important**: Synchronous dependencies should NOT include blocking I/O operations
     (file access, network calls, database queries, etc.). Use async dependencies for
@@ -117,4 +111,4 @@ def Depends(dependency: DependencyFactory[R]) -> R:
         await db.execute("UPDATE users SET ...", params)
     ```
     """
-    return cast(R, _Depends(dependency))
+    return cast(R, _Depends(dependency, **bindings))

--- a/src/docket/dependencies/_resolution.py
+++ b/src/docket/dependencies/_resolution.py
@@ -188,7 +188,8 @@ async def resolved_dependencies(
         async with AsyncExitStack() as stack:
             stack_token = _Depends.stack.set(stack)
             try:
-                with frame_scope(execution.function, _provided_arguments(execution)):
+                provided = _provided_arguments(execution)
+                with frame_scope(execution.function, provided) as frame:
                     arguments: dict[str, Any] = {}
 
                     for name, dependency in worker.dependencies.items():
@@ -202,9 +203,14 @@ async def resolved_dependencies(
 
                     parameters = get_dependency_parameters(execution.function)
                     for parameter, dependency in parameters.items():
-                        kwargs = execution.kwargs
-                        if parameter in kwargs:
-                            arguments[parameter] = kwargs[parameter]
+                        if parameter in execution.kwargs:
+                            arguments[parameter] = execution.kwargs[parameter]
+                            continue
+
+                        # A positionally-supplied argument reaches the function
+                        # through *args, so resolving the dependency here would
+                        # collide with it at call time.
+                        if parameter in provided:
                             continue
 
                         # At the top-level task function call, a bare TaskArgument
@@ -219,10 +225,11 @@ async def resolved_dependencies(
                             )
                             continue
 
+                        # The frame memoizes each parameter, so a CallArgument
+                        # reference to a sibling shares this resolution instead
+                        # of entering the dependency a second time.
                         try:
-                            arguments[parameter] = await stack.enter_async_context(
-                                dependency
-                            )
+                            arguments[parameter] = await frame.resolve(parameter)
                         except Exception as error:
                             arguments[parameter] = FailedDependency(parameter, error)
 

--- a/src/docket/dependencies/_resolution.py
+++ b/src/docket/dependencies/_resolution.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, TypeVar
 
 from uncalled_for import (
     FailedDependency,
+    frame_scope,
     get_annotation_dependencies,
+    get_signature,
 )
 
 from ._base import (
@@ -159,6 +161,20 @@ def detect_single_conflicts(
     return conflicts
 
 
+def _provided_arguments(execution: Execution) -> dict[str, Any]:
+    """Map the caller's positional and keyword arguments to parameter names.
+
+    When the arguments do not bind to the signature, fall back to the keyword
+    arguments alone; calling the task will fail later with the same TypeError.
+    """
+    signature = get_signature(execution.function)
+    try:
+        bound = signature.bind(*execution.args, **execution.kwargs)
+    except TypeError:
+        return dict(execution.kwargs)
+    return dict(bound.arguments)
+
+
 @asynccontextmanager
 async def resolved_dependencies(
     worker: Worker, execution: Execution
@@ -172,63 +188,67 @@ async def resolved_dependencies(
         async with AsyncExitStack() as stack:
             stack_token = _Depends.stack.set(stack)
             try:
-                arguments: dict[str, Any] = {}
+                with frame_scope(execution.function, _provided_arguments(execution)):
+                    arguments: dict[str, Any] = {}
 
-                for name, dependency in worker.dependencies.items():
-                    slot = f"__worker_dep__{name}"
-                    try:
-                        arguments[slot] = await stack.enter_async_context(dependency)
-                    except Exception as error:
-                        arguments[slot] = FailedDependency(name, error)
-
-                parameters = get_dependency_parameters(execution.function)
-                for parameter, dependency in parameters.items():
-                    kwargs = execution.kwargs
-                    if parameter in kwargs:
-                        arguments[parameter] = kwargs[parameter]
-                        continue
-
-                    # At the top-level task function call, a bare TaskArgument without
-                    # a parameter name doesn't make sense, so mark it as failed.
-                    if (
-                        isinstance(dependency, _TaskArgument)
-                        and not dependency.parameter
-                    ):
-                        arguments[parameter] = FailedDependency(
-                            parameter, ValueError("No parameter name specified")
-                        )
-                        continue
-
-                    try:
-                        arguments[parameter] = await stack.enter_async_context(
-                            dependency
-                        )
-                    except Exception as error:
-                        arguments[parameter] = FailedDependency(parameter, error)
-
-                annotations = get_annotation_dependencies(execution.function)
-                for parameter_name, dependencies in annotations.items():
-                    argument_value = execution.kwargs.get(
-                        parameter_name, arguments.get(parameter_name)
-                    )
-                    for dependency in dependencies:
-                        bound = dependency.bind_to_parameter(
-                            parameter_name, argument_value
-                        )
+                    for name, dependency in worker.dependencies.items():
+                        slot = f"__worker_dep__{name}"
                         try:
-                            await stack.enter_async_context(bound)
-                        except Exception as error:
-                            arguments[parameter_name] = FailedDependency(
-                                parameter_name, error
+                            arguments[slot] = await stack.enter_async_context(
+                                dependency
                             )
+                        except Exception as error:
+                            arguments[slot] = FailedDependency(name, error)
 
-                arguments.update(
-                    worker.validate_task_dependencies(
-                        execution.function, arguments, annotations
+                    parameters = get_dependency_parameters(execution.function)
+                    for parameter, dependency in parameters.items():
+                        kwargs = execution.kwargs
+                        if parameter in kwargs:
+                            arguments[parameter] = kwargs[parameter]
+                            continue
+
+                        # At the top-level task function call, a bare TaskArgument
+                        # without a parameter name doesn't make sense, so mark it
+                        # as failed.
+                        if (
+                            isinstance(dependency, _TaskArgument)
+                            and not dependency.parameter
+                        ):
+                            arguments[parameter] = FailedDependency(
+                                parameter, ValueError("No parameter name specified")
+                            )
+                            continue
+
+                        try:
+                            arguments[parameter] = await stack.enter_async_context(
+                                dependency
+                            )
+                        except Exception as error:
+                            arguments[parameter] = FailedDependency(parameter, error)
+
+                    annotations = get_annotation_dependencies(execution.function)
+                    for parameter_name, dependencies in annotations.items():
+                        argument_value = execution.kwargs.get(
+                            parameter_name, arguments.get(parameter_name)
+                        )
+                        for dependency in dependencies:
+                            bound = dependency.bind_to_parameter(
+                                parameter_name, argument_value
+                            )
+                            try:
+                                await stack.enter_async_context(bound)
+                            except Exception as error:
+                                arguments[parameter_name] = FailedDependency(
+                                    parameter_name, error
+                                )
+
+                    arguments.update(
+                        worker.validate_task_dependencies(
+                            execution.function, arguments, annotations
+                        )
                     )
-                )
 
-                yield arguments
+                    yield arguments
             finally:
                 _Depends.stack.reset(stack_token)
     finally:

--- a/tests/fundamentals/test_call_arguments.py
+++ b/tests/fundamentals/test_call_arguments.py
@@ -1,0 +1,310 @@
+"""Tests for CallArgument references and Depends keyword bindings."""
+
+import logging
+from uuid import uuid4
+
+import pytest
+
+from docket import CallArgument, Depends, Docket, TaskArgument, Worker
+
+
+async def test_bare_call_argument_on_a_dependency_factory(
+    docket: Docket, worker: Worker
+):
+    """A bare CallArgument takes the name of the parameter it is declared on"""
+
+    called = 0
+
+    async def load_user(user_id: str = CallArgument()) -> str:
+        return f"user-{user_id}"
+
+    async def dependent_task(
+        user_id: str,
+        user: str = Depends(load_user),
+    ) -> None:
+        assert user == f"user-{user_id}"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(user_id="abc123")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_named_call_argument_on_a_dependency_factory(
+    docket: Docket, worker: Worker
+):
+    """CallArgument("name") reads a differently-named task parameter"""
+
+    called = 0
+
+    async def load_recipient(user_id: str = CallArgument("recipient_id")) -> str:
+        return f"user-{user_id}"
+
+    async def dependent_task(
+        recipient_id: str,
+        recipient: str = Depends(load_recipient),
+    ) -> None:
+        assert recipient == f"user-{recipient_id}"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(recipient_id="abc123")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_call_argument_reads_a_dependency_backed_parameter(
+    docket: Docket, worker: Worker
+):
+    """A CallArgument can read a task parameter backed by another dependency"""
+
+    called = 0
+    tokens_made = 0
+
+    async def make_token() -> str:
+        nonlocal tokens_made
+        tokens_made += 1
+        return f"token-{uuid4()}"
+
+    async def audit(token: str = CallArgument()) -> str:
+        return token
+
+    async def dependent_task(
+        token: str = Depends(make_token),
+        audited: str = Depends(audit),
+    ) -> None:
+        assert audited == token
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)()
+
+    await worker.run_until_finished()
+
+    assert called == 1
+    assert tokens_made == 1
+
+
+async def test_caller_argument_wins_over_a_dependency_backed_parameter(
+    docket: Docket, worker: Worker
+):
+    """A caller-supplied argument wins and the dependency is never resolved"""
+
+    called = 0
+
+    async def make_token() -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def audit(token: str = CallArgument()) -> str:
+        return token
+
+    async def dependent_task(
+        token: str = Depends(make_token),
+        audited: str = Depends(audit),
+    ) -> None:
+        assert token == "from-the-caller"
+        assert audited == "from-the-caller"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(token="from-the-caller")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_bare_call_argument_in_a_depends_binding(docket: Docket, worker: Worker):
+    """A bare CallArgument binding resolves the parameter it is bound to"""
+
+    called = 0
+
+    async def load_user(user_id: str) -> str:
+        return f"user-{user_id}"
+
+    async def dependent_task(
+        user_id: str,
+        user: str = Depends(load_user, user_id=CallArgument()),
+    ) -> None:
+        assert user == f"user-{user_id}"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(user_id="abc123")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_named_call_argument_in_a_depends_binding(docket: Docket, worker: Worker):
+    """A named CallArgument binding wires a task parameter to a factory parameter"""
+
+    called = 0
+
+    async def load_user(user_id: str) -> str:
+        return f"user-{user_id}"
+
+    async def dependent_task(
+        owner: str,
+        user: str = Depends(load_user, user_id=CallArgument("owner")),
+    ) -> None:
+        assert user == f"user-{owner}"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(owner="abc123")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_plain_value_bindings_pass_through(docket: Docket, worker: Worker):
+    """A plain value binding passes through to the factory as it is"""
+
+    called = 0
+
+    async def fetch_report(source: str, timeout: int = 30) -> str:
+        return f"{source}:{timeout}"
+
+    async def dependent_task(
+        report: str = Depends(fetch_report, source="warehouse", timeout=5),
+    ) -> None:
+        assert report == "warehouse:5"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)()
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_binding_replaces_a_factory_depends_default(
+    docket: Docket, worker: Worker
+):
+    """A binding replaces the factory's own Depends default, which never runs"""
+
+    called = 0
+
+    async def get_replica() -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def get_primary() -> str:
+        return "primary"
+
+    async def get_orders(db: str = Depends(get_replica)) -> str:
+        return f"orders-from-{db}"
+
+    async def dependent_task(
+        orders: str = Depends(get_orders, db=Depends(get_primary)),
+    ) -> None:
+        assert orders == "orders-from-primary"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)()
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_optional_call_argument_yields_none_when_missing(
+    docket: Docket, worker: Worker
+):
+    """CallArgument(optional=True) yields None for a missing parameter"""
+
+    called = 0
+
+    async def load_config(name: str | None = CallArgument(optional=True)) -> str:
+        return name or "defaults"
+
+    async def dependent_task(
+        data: str,
+        config: str = Depends(load_config),
+    ) -> None:
+        assert data == "payload"
+        assert config == "defaults"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(data="payload")
+
+    await worker.run_until_finished()
+
+    assert called == 1
+
+
+async def test_circular_call_arguments_fail_the_task(
+    docket: Docket, worker: Worker, caplog: pytest.LogCaptureFixture
+):
+    """CallArgument references that form a cycle fail the task with CycleError"""
+
+    async def needs_b(b: str = CallArgument("b")) -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def needs_a(a: str = CallArgument("a")) -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def dependent_task(
+        a: str = Depends(needs_b),
+        b: str = Depends(needs_a),
+    ) -> None:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    await docket.add(dependent_task)()
+
+    with caplog.at_level(logging.ERROR):
+        await worker.run_until_finished()
+
+    assert "Failed to resolve dependencies" in caplog.text
+    assert "CycleError" in caplog.text
+    assert "Circular argument reference" in caplog.text
+
+
+async def test_task_argument_works_alongside_call_argument(
+    docket: Docket, worker: Worker
+):
+    """TaskArgument and CallArgument can serve the same task together"""
+
+    called = 0
+
+    async def greeting(name: str = TaskArgument()) -> str:
+        return f"Hello, {name}!"
+
+    async def load_user(name: str = CallArgument()) -> str:
+        return f"user-{name}"
+
+    async def dependent_task(
+        name: str,
+        greet: str = Depends(greeting),
+        user: str = Depends(load_user),
+    ) -> None:
+        assert greet == "Hello, alice!"
+        assert user == "user-alice"
+
+        nonlocal called
+        called += 1
+
+    await docket.add(dependent_task)(name="alice")
+
+    await worker.run_until_finished()
+
+    assert called == 1

--- a/tests/fundamentals/test_call_arguments.py
+++ b/tests/fundamentals/test_call_arguments.py
@@ -1,9 +1,6 @@
 """Tests for CallArgument references and Depends keyword bindings."""
 
-import logging
 from uuid import uuid4
-
-import pytest
 
 from docket import CallArgument, Depends, Docket, TaskArgument, Worker
 
@@ -250,33 +247,6 @@ async def test_optional_call_argument_yields_none_when_missing(
     await worker.run_until_finished()
 
     assert called == 1
-
-
-async def test_circular_call_arguments_fail_the_task(
-    docket: Docket, worker: Worker, caplog: pytest.LogCaptureFixture
-):
-    """CallArgument references that form a cycle fail the task with CycleError"""
-
-    async def needs_b(b: str = CallArgument("b")) -> str:
-        raise NotImplementedError("This should not be called")  # pragma: no cover
-
-    async def needs_a(a: str = CallArgument("a")) -> str:
-        raise NotImplementedError("This should not be called")  # pragma: no cover
-
-    async def dependent_task(
-        a: str = Depends(needs_b),
-        b: str = Depends(needs_a),
-    ) -> None:
-        raise NotImplementedError("This should not be called")  # pragma: no cover
-
-    await docket.add(dependent_task)()
-
-    with caplog.at_level(logging.ERROR):
-        await worker.run_until_finished()
-
-    assert "Failed to resolve dependencies" in caplog.text
-    assert "CycleError" in caplog.text
-    assert "Circular argument reference" in caplog.text
 
 
 async def test_task_argument_works_alongside_call_argument(

--- a/tests/test_call_arguments.py
+++ b/tests/test_call_arguments.py
@@ -44,12 +44,8 @@ async def test_positional_argument_overrides_a_dependency_backed_parameter(
 ):
     """A positionally-supplied argument wins over the parameter's dependency"""
 
-    factory_calls = 0
-
     async def default_region() -> str:
-        nonlocal factory_calls
-        factory_calls += 1
-        return "us-east-1"  # pragma: no cover
+        raise NotImplementedError("This should not be called")  # pragma: no cover
 
     received: list[str] = []
 
@@ -61,7 +57,6 @@ async def test_positional_argument_overrides_a_dependency_backed_parameter(
     await worker.run_until_finished()
 
     assert received == ["eu-west-1"]
-    assert factory_calls == 0
 
 
 async def test_referenced_sibling_dependency_is_entered_once(

--- a/tests/test_call_arguments.py
+++ b/tests/test_call_arguments.py
@@ -1,0 +1,98 @@
+"""Edge-case tests for CallArgument references and Depends bindings.
+
+The happy-path tests live in tests/fundamentals/test_call_arguments.py.
+"""
+
+import logging
+from typing import cast
+
+import pytest
+
+from docket import Docket, Worker
+from docket.dependencies import CallArgument, Dependency, Depends
+
+
+async def test_circular_call_arguments_fail_the_task(
+    docket: Docket, worker: Worker, caplog: pytest.LogCaptureFixture
+):
+    """CallArgument references that form a cycle fail the task with CycleError"""
+
+    async def needs_b(b: str = CallArgument("b")) -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def needs_a(a: str = CallArgument("a")) -> str:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    async def dependent_task(
+        a: str = Depends(needs_b),
+        b: str = Depends(needs_a),
+    ) -> None:
+        raise NotImplementedError("This should not be called")  # pragma: no cover
+
+    await docket.add(dependent_task)()
+
+    with caplog.at_level(logging.ERROR):
+        await worker.run_until_finished()
+
+    assert "Failed to resolve dependencies" in caplog.text
+    assert "CycleError" in caplog.text
+    assert "Circular argument reference" in caplog.text
+
+
+async def test_positional_argument_overrides_a_dependency_backed_parameter(
+    docket: Docket, worker: Worker
+):
+    """A positionally-supplied argument wins over the parameter's dependency"""
+
+    factory_calls = 0
+
+    async def default_region() -> str:
+        nonlocal factory_calls
+        factory_calls += 1
+        return "us-east-1"  # pragma: no cover
+
+    received: list[str] = []
+
+    async def dependent_task(region: str = Depends(default_region)) -> None:
+        received.append(region)
+
+    await docket.add(dependent_task)("eu-west-1")
+
+    await worker.run_until_finished()
+
+    assert received == ["eu-west-1"]
+    assert factory_calls == 0
+
+
+async def test_referenced_sibling_dependency_is_entered_once(
+    docket: Docket, worker: Worker
+):
+    """A CallArgument reference shares the sibling's resolution, never repeats it"""
+
+    class Counting(Dependency[str]):
+        def __init__(self) -> None:
+            self.enters = 0
+
+        async def __aenter__(self) -> str:
+            self.enters += 1
+            return f"value-{self.enters}"
+
+    counting = Counting()
+
+    async def consume(token: str = CallArgument()) -> str:
+        return f"used {token}"
+
+    received: list[tuple[str, str]] = []
+
+    async def dependent_task(
+        token: str = cast(str, counting),
+        consumer: str = Depends(consume),
+    ) -> None:
+        received.append((token, consumer))
+
+    await docket.add(dependent_task)()
+
+    await worker.run_until_finished()
+
+    assert received == [("value-1", "used value-1")]
+    assert counting.enters == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1404,7 +1404,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.15.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2025.2" },
-    { name = "uncalled-for", specifier = ">=0.3.2" },
+    { name = "uncalled-for", specifier = ">=0.4.0" },
 ]
 provides-extras = ["metrics"]
 
@@ -1947,11 +1947,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopt uncalled-for 0.4.0: CallArgument references and Depends bindings

uncalled-for 0.4.0 adds a call-scoped resolution frame with explicit
argument references (https://github.com/chrisguidry/uncalled-for/pull/12).
Docket now enters frame_scope() around dependency resolution and
re-exports CallArgument and CycleError. Depends() accepts keyword
bindings that supply factory arguments at the composition site.

TaskArgument is rebuilt on the same frame with provided_only=True,
which preserves its exact behavior: it sees only caller-supplied
arguments, and optional=True still yields None over a dependency-backed
parameter. The mutation-based name inference in _Depends is gone; the
for_parameter hook binds bare references without touching shared
instances. All existing TaskArgument tests pass unmodified.

The docs describe CallArgument and bindings with task examples, since
uncalled-for has no docs site of its own.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)