### PR TITLE
Pace redelivery and stream bookkeeping for a large pending list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Rich dependency injection supporting:
 ### Redis Data Model
 
 - **Streams**: `{docket}:stream` (ready tasks), `{docket}:strikes` (commands)
+- **Strings**: `{docket}:redelivery-sweep` (the fleet's redelivery sweep lease)
 - **Sorted Sets**: `{docket}:queue` (scheduled tasks), `{docket}:workers` (heartbeats)
 - **Hashes**: `{docket}:{key}` (parked task data)
 - **Sets**: `{docket}:worker-tasks:{worker}` (worker capabilities)

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1394
+max_lines = 1389
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
@@ -22,7 +22,7 @@ max_lines = 1336
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 1098
+max_lines = 1106
 
 [[rules]]
 path = "src/docket/_redis.py"

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -1,0 +1,170 @@
+"""How a worker takes messages off the stream, keeps them, and finds lost ones.
+
+A worker keeps a message by renewing its lease: XCLAIM with ``idle=0`` resets
+the message's idle clock, so the sweep below does not take it away while the
+task is still running.  Renewal names every message the worker holds, so it
+goes out in chunks of ``LEASE_RENEWAL_BATCH`` ids, and it asks for JUSTID.
+Redis answers a plain XCLAIM with the whole body of every message, and it
+blocks while it builds that reply for a worker that discards it.
+
+A worker finds messages that another worker abandoned by sweeping its consumer
+group's pending list with XAUTOCLAIM.  Redis reads up to ten times ``count``
+entries of that list per call, so a scan on every pass of the worker loop pins
+a busy Redis at 100% CPU once the pending list grows long.  The sweep is
+periodic and bounded instead.
+
+Each call claims at most ``REDELIVERY_SCAN_BATCH`` entries and starts where the
+last call stopped.  A sweep that always restarted at ``0-0`` would never read
+the entries past its first window, so those could never be redelivered.  Redis
+returns the cursor ``0-0`` at the end of the pending list, which means the
+sweep is done.
+
+The first sweep runs on the worker's first pass, so a worker that replaces a
+dead one picks up its messages as soon as the lease below lets it.  While a
+sweep is in progress the worker scans on every pass, so the sweep finishes
+quickly.  The next sweep then starts a quarter of the redelivery timeout later,
+the cadence lease renewal uses, jittered between 75% and 125% of that.  Without the jitter, a fleet of
+workers that started together would scan the pending list in lockstep, and
+every worker's scan would reach Redis at the same moment.  An abandoned message
+therefore waits at most a jittered quarter of the timeout longer than the
+timeout itself.
+
+One sweep costs Redis a pass over the whole pending list, so the cost of
+sweeping must not grow with the number of workers.  The fleet runs one sweep
+per interval instead of one per worker: before a worker starts a sweep it takes
+a lease with ``SET {docket}:redelivery-sweep <worker> NX PX <interval>``, and
+only the worker that takes the lease sweeps.  A worker that does not take it
+waits for its own next timer.  Nobody renews or deletes the lease.  It expires
+on its own, and that expiry is what paces the fleet.
+
+A worker also caps how many new messages one XREADGROUP may return.  Redis
+serializes every message it returns before it answers, and it blocks while it
+does that, so a worker with tens of thousands of free slots would ask for tens
+of thousands of messages at once.  ``DELIVERY_BATCH`` caps that ask.  The
+worker loop reads again right away while it still has free slots, so the worker
+fills up just as fast; only the time Redis spends on one call drops.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from datetime import timedelta
+from typing import Sequence
+
+from ._redis import RedisClient, RedisMessageID, RedisMessages
+
+logger = logging.getLogger(__name__)
+
+# Most message ids one XCLAIM call may name.
+LEASE_RENEWAL_BATCH = 5000
+
+# Most entries one XAUTOCLAIM call may claim, and so a tenth of the entries
+# Redis will read for it.
+REDELIVERY_SCAN_BATCH = 1000
+
+# Most messages one XREADGROUP call may return.
+DELIVERY_BATCH = 5000
+
+# The cursor Redis returns at the end of the pending list, and the one that
+# starts a fresh sweep.
+SWEEP_START = "0-0"
+
+# The narrowest and widest wait between sweeps, as a fraction of the interval.
+JITTER = (0.75, 1.25)
+
+
+async def renew_leases(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    group_name: str,
+    consumer_name: str,
+    message_ids: Sequence[RedisMessageID],
+) -> None:
+    """Reset the idle time of the messages one worker holds.
+
+    A chunk that Redis refuses is logged and passed over, so the rest of the
+    worker's messages still get their leases renewed on this pass.
+    """
+    for start in range(0, len(message_ids), LEASE_RENEWAL_BATCH):
+        try:
+            await redis.xclaim(
+                name=stream_key,
+                groupname=group_name,
+                consumername=consumer_name,
+                min_idle_time=0,
+                message_ids=message_ids[start : start + LEASE_RENEWAL_BATCH],
+                idle=0,
+                justid=True,
+            )
+        except Exception:
+            logger.warning("Failed to renew leases", exc_info=True)
+
+
+class RedeliverySweep:
+    """Where a worker's scan for abandoned messages is, and when it resumes."""
+
+    def __init__(self, timeout: timedelta, *, lease_key: str, worker_name: str) -> None:
+        self.min_idle_time = int(timeout.total_seconds() * 1000)
+        self.interval = timeout.total_seconds() / 4
+        self.lease_key = lease_key
+        self.lease_milliseconds = max(1, int(self.interval * 1000))
+        self.worker_name = worker_name
+        self.cursor = SWEEP_START
+        self.next_sweep = time.monotonic()
+
+    async def due(self, redis: RedisClient) -> bool:
+        """May this worker scan the pending list on this pass?
+
+        A sweep that is already under way carries on without asking again.  A
+        new sweep waits for this worker's timer, and then for the fleet-wide
+        lease.  A worker that does not take the lease waits for its own next
+        timer.
+        """
+        if self.cursor != SWEEP_START:
+            return True
+        if time.monotonic() < self.next_sweep:
+            return False
+        took_lease = await redis.set(
+            self.lease_key,
+            self.worker_name,
+            nx=True,
+            px=self.lease_milliseconds,
+        )
+        if not took_lease:
+            self._rest()
+        return bool(took_lease)
+
+    async def claim(
+        self,
+        redis: RedisClient,
+        *,
+        stream_key: str,
+        group_name: str,
+        count: int,
+    ) -> RedisMessages:
+        """Claim the next batch of abandoned messages and move the cursor."""
+        cursor, claimed, *_ = await redis.xautoclaim(
+            name=stream_key,
+            groupname=group_name,
+            consumername=self.worker_name,
+            min_idle_time=self.min_idle_time,
+            start_id=self.cursor,
+            count=min(count, REDELIVERY_SCAN_BATCH),
+        )
+        self.advance(cursor)
+        return claimed
+
+    def advance(self, cursor: bytes | str) -> None:
+        """Record where the claim that Redis just answered stopped."""
+        self.cursor = cursor.decode() if isinstance(cursor, bytes) else cursor
+        if self.cursor == SWEEP_START:
+            self._rest()
+
+    def _rest(self) -> None:
+        """Hold off the next sweep for a jittered interval."""
+        low, high = JITTER
+        wait = random.uniform(self.interval * low, self.interval * high)
+        self.next_sweep = time.monotonic() + wait

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -905,6 +905,14 @@ class Docket(DocketSnapshotMixin):
         return self.key(f"cancel:{task_key}")
 
     @property
+    def redelivery_sweep_key(self) -> str:
+        """Return the Redis key for the fleet's redelivery sweep lease.
+
+        See _redelivery for why only one worker per interval sweeps.
+        """
+        return self.key("redelivery-sweep")
+
+    @property
     def results_collection(self) -> str:
         """Return the collection name for result storage."""
         return self.key("results")

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -36,6 +36,7 @@ from opentelemetry.trace import Status, StatusCode, Tracer
 
 from ._cancellation import CANCEL_MSG_CLEANUP, _wait_for_event, cancel_task
 from ._lua import Arg, Key, redis_script
+from ._redelivery import DELIVERY_BATCH, RedeliverySweep, renew_leases
 from ._redis import RedisClient
 from ._telemetry import suppress_instrumentation
 from redis.asyncio import Redis
@@ -619,18 +620,21 @@ class Worker:
                 queue_len = results[1]
                 return stream_len > 0 or queue_len > 0
 
+        # See _redelivery for why this scan is periodic, bounded, and leased.
+        sweep = RedeliverySweep(
+            self.redelivery_timeout,
+            lease_key=self.docket.redelivery_sweep_key,
+            worker_name=self.name,
+        )
+
         async def get_redeliveries(redis: Redis) -> RedisReadGroupResponse:
             logger.debug("Getting redeliveries", extra=log_context)
             try:
                 with self._maybe_suppress_instrumentation():
-                    _, redeliveries, *_ = await redis.xautoclaim(
-                        name=self.docket.stream_key,
-                        groupname=self.docket.worker_group_name,
-                        consumername=self.name,
-                        min_idle_time=int(
-                            self.redelivery_timeout.total_seconds() * 1000
-                        ),
-                        start_id="0-0",
+                    redeliveries = await sweep.claim(
+                        cast(RedisClient, redis),
+                        stream_key=self.docket.stream_key,
+                        group_name=self.docket.worker_group_name,
                         count=available_slots,
                     )
             except ResponseError as e:
@@ -649,7 +653,7 @@ class Worker:
                         consumername=self.name,
                         streams={self.docket.stream_key: ">"},
                         block=int(self.minimum_check_interval.total_seconds() * 1000),
-                        count=available_slots,
+                        count=min(available_slots, DELIVERY_BATCH),
                     )
             except ResponseError as e:
                 if "NOGROUP" in str(e):
@@ -783,7 +787,10 @@ class Worker:
                             )
                             continue
                         try:
-                            for source in [get_redeliveries, get_new_deliveries]:
+                            sources = [get_new_deliveries]
+                            if await sweep.due(cast(RedisClient, redis)):
+                                sources.insert(0, get_redeliveries)
+                            for source in sources:
                                 for stream_key, messages in await source(redis):
                                     is_redelivery = stream_key == b"__redelivery__"
                                     for message_id, message in messages:
@@ -883,8 +890,8 @@ class Worker:
     ) -> None:
         """Periodically renew leases on stream messages.
 
-        Calls XCLAIM with idle=0 to reset the message's idle time, preventing
-        XAUTOCLAIM from reclaiming it while we're still processing.
+        See _redelivery for how a renewal keeps XAUTOCLAIM from reclaiming a
+        message that this worker is still processing.
         """
         session = self._processing_session
         if session is None:
@@ -901,18 +908,14 @@ class Worker:
             if not message_ids:
                 continue
 
-            try:
-                with self._maybe_suppress_instrumentation():
-                    await redis.xclaim(
-                        name=self.docket.stream_key,
-                        groupname=self.docket.worker_group_name,
-                        consumername=self.name,
-                        min_idle_time=0,
-                        message_ids=message_ids,
-                        idle=0,
-                    )
-            except Exception:
-                logger.warning("Failed to renew leases", exc_info=True)
+            with self._maybe_suppress_instrumentation():
+                await renew_leases(
+                    cast(RedisClient, redis),
+                    stream_key=self.docket.stream_key,
+                    group_name=self.docket.worker_group_name,
+                    consumer_name=self.name,
+                    message_ids=message_ids,
+                )
 
     async def _reseed_automatic_perpetual_tasks_loop(self) -> None:
         """Periodically re-sow automatic perpetuals so a chain severed after

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,12 +383,15 @@ async def key_leak_checker(docket: Docket) -> AsyncGenerator[KeyCountChecker, No
         scheduling_resolution=timedelta(milliseconds=5),
     ) as temp_worker:
         await temp_worker.run_until_finished()
-        # Clean up heartbeat data to avoid polluting tests that check worker counts
+        # Clean up heartbeat data to avoid polluting tests that check worker
+        # counts, and release the redelivery sweep lease this worker took, so
+        # the test's own worker can sweep on its first pass.
         async with docket.redis() as r:
             await r.zrem(docket.workers_set, temp_worker.name)
             for task_name in docket.tasks:
                 await r.zrem(docket.task_workers_set(task_name), temp_worker.name)
             await r.delete(docket.worker_tasks_set(temp_worker.name))
+            await r.delete(docket.redelivery_sweep_key)
 
     await checker.capture_baseline()
 

--- a/tests/test_lease_renewal.py
+++ b/tests/test_lease_renewal.py
@@ -1,0 +1,85 @@
+"""Tests for the XCLAIM calls that renew a worker's leases.
+
+A worker holds one message per running task, and one XCLAIM naming every
+held id makes Redis serialize every message back to a worker that discards
+the reply.  These tests cover how those calls are split and what they ask
+for.
+"""
+
+from typing import Any, cast
+
+import pytest
+from redis.exceptions import ConnectionError
+
+from docket import Docket
+from docket._redelivery import LEASE_RENEWAL_BATCH, renew_leases
+from docket._redis import RedisClient
+
+
+class RecordingXclaim:
+    """Delegates to a real client and records the XCLAIM calls it makes."""
+
+    def __init__(self, wrapped: Any, fail_first: bool = False) -> None:
+        self._wrapped = wrapped
+        self._fail_first = fail_first
+        self.calls: list[dict[str, Any]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    async def xclaim(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if self._fail_first and len(self.calls) == 1:
+            raise ConnectionError("Simulated Redis error")
+        return await self._wrapped.xclaim(**kwargs)
+
+
+async def renewable_message_ids(docket: Docket, count: int) -> list[bytes]:
+    """Message ids for a group that exists, so XCLAIM answers them."""
+    await docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+    return [f"{number}-0".encode() for number in range(1, count + 1)]
+
+
+async def test_lease_renewal_claims_in_chunks_and_asks_only_for_ids(docket: Docket):
+    """Renewal splits the ids across XCLAIM calls, and each call uses JUSTID.
+
+    One XCLAIM naming every held id blocks Redis while it serializes every
+    message back to a worker that throws the reply away.
+    """
+    message_ids = await renewable_message_ids(docket, LEASE_RENEWAL_BATCH + 1)
+
+    async with docket.redis() as redis:
+        recording = RecordingXclaim(redis)
+        await renew_leases(
+            cast(RedisClient, recording),
+            stream_key=docket.stream_key,
+            group_name=docket.worker_group_name,
+            consumer_name="worker-a",
+            message_ids=message_ids,
+        )
+
+    assert [len(call["message_ids"]) for call in recording.calls] == [
+        LEASE_RENEWAL_BATCH,
+        1,
+    ]
+    assert all(call["justid"] for call in recording.calls)
+
+
+async def test_lease_renewal_claims_the_rest_after_a_chunk_fails(
+    docket: Docket, caplog: pytest.LogCaptureFixture
+):
+    """A chunk that fails leaves the other chunks of that pass renewed."""
+    message_ids = await renewable_message_ids(docket, LEASE_RENEWAL_BATCH + 1)
+
+    async with docket.redis() as redis:
+        recording = RecordingXclaim(redis, fail_first=True)
+        await renew_leases(
+            cast(RedisClient, recording),
+            stream_key=docket.stream_key,
+            group_name=docket.worker_group_name,
+            consumer_name="worker-a",
+            message_ids=message_ids,
+        )
+
+    assert len(recording.calls) == 2
+    assert "Failed to renew leases" in caplog.text

--- a/tests/test_redelivery_sweep.py
+++ b/tests/test_redelivery_sweep.py
@@ -1,0 +1,270 @@
+"""Tests for how a worker takes messages off the stream.
+
+The worker claims abandoned entries with XAUTOCLAIM. It sweeps the consumer
+group's pending list in bounded batches on a timer, and it takes a fleet-wide
+lease before each sweep, so these tests cover how far a sweep reaches, how
+often one starts, and which worker runs it.  They also cover the cap on how
+many new messages one XREADGROUP may return.
+"""
+
+import asyncio
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, AsyncGenerator, Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from docket import Docket, Worker
+from docket._redelivery import DELIVERY_BATCH, SWEEP_START, RedeliverySweep
+from docket._redis import RedisClient
+
+
+@dataclass
+class StreamCalls:
+    """The stream reads a worker made during a test."""
+
+    claim_starts: list[str] = field(default_factory=list[str])
+    claim_consumers: list[str] = field(default_factory=list[str])
+    read_counts: list[int] = field(default_factory=list[int])
+    reads: int = 0
+
+
+@pytest.fixture
+def stream_calls() -> Generator[StreamCalls, None, None]:
+    """Record XAUTOCLAIM and XREADGROUP calls on every backend.
+
+    The recorder wraps the client the worker actually uses, so it works on
+    standalone, cluster, and memory alike.
+    """
+    calls = StreamCalls()
+
+    class Recording:
+        def __init__(self, wrapped: Any) -> None:
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._wrapped, name)
+
+        async def xautoclaim(self, *args: Any, **kwargs: Any) -> Any:
+            calls.claim_starts.append(str(kwargs["start_id"]))
+            calls.claim_consumers.append(str(kwargs["consumername"]))
+            return await self._wrapped.xautoclaim(*args, **kwargs)
+
+        async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+            calls.reads += 1
+            calls.read_counts.append(int(kwargs["count"]))
+            return await self._wrapped.xreadgroup(*args, **kwargs)
+
+    original_redis = Docket.redis
+
+    @asynccontextmanager
+    async def recording_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as client:
+            yield Recording(client)  # type: ignore[arg-type]
+
+    with patch.object(Docket, "redis", recording_redis):
+        yield calls
+
+
+async def abandon_every_stream_entry(docket: Docket) -> None:
+    """Deliver every stream entry to a worker that never acks it."""
+    await docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+    async with docket.redis() as redis:
+        await redis.xreadgroup(
+            groupname=docket.worker_group_name,
+            consumername="worker-that-died",
+            streams={docket.stream_key: ">"},
+            count=1000,
+        )
+
+
+async def test_sweep_reaches_entries_past_the_first_batch(
+    docket: Docket, stream_calls: StreamCalls
+):
+    """Every abandoned entry is redelivered, not only the first batch of them.
+
+    One worker slot bounds each claim to a single entry, so the worker only
+    reaches the third entry if it resumes the sweep from the cursor of the
+    last claim.
+    """
+    executed: list[int] = []
+
+    async def the_task(number: int) -> None:
+        executed.append(number)
+
+    for number in range(3):
+        await docket.add(the_task, key=f"task-{number}")(number=number)
+
+    await abandon_every_stream_entry(docket)
+
+    await asyncio.sleep(0.25)  # longer than the redelivery timeout
+
+    async with Worker(
+        docket,
+        concurrency=1,
+        redelivery_timeout=timedelta(milliseconds=200),
+        minimum_check_interval=timedelta(milliseconds=10),
+        scheduling_resolution=timedelta(milliseconds=10),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert sorted(executed) == [0, 1, 2]
+
+    # A three-entry pending list is small enough that a scan from the
+    # beginning also reaches the last entry, so only the start of each claim
+    # shows that the sweep resumed instead of starting over.
+    assert [start for start in stream_calls.claim_starts if start != "0-0"]
+
+
+async def test_sweep_rests_between_passes(docket: Docket, stream_calls: StreamCalls):
+    """A finished sweep does not start again on the next pass of the loop."""
+
+    async def slow_task() -> None:
+        await asyncio.sleep(0.5)
+
+    await docket.add(slow_task)()
+
+    # Create the consumer group up front, so the worker's first claim does not
+    # retry past a NOGROUP error and count as a second sweep.
+    await docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+
+    async with Worker(
+        docket,
+        redelivery_timeout=timedelta(seconds=30),
+        minimum_check_interval=timedelta(milliseconds=10),
+        scheduling_resolution=timedelta(milliseconds=10),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert stream_calls.reads > 5, "the loop should have made many passes"
+    assert stream_calls.claim_starts == ["0-0"], "one sweep, on the first pass"
+
+
+def test_the_next_sweep_waits_a_jittered_interval():
+    """A finished sweep schedules the next one 75% to 125% of the interval out.
+
+    Twenty workers that start together would sweep the pending list at the
+    same moment without the jitter.
+    """
+    sweep = RedeliverySweep(
+        timedelta(seconds=40), lease_key="sweep-lease", worker_name="worker-one"
+    )
+
+    with patch("docket._redelivery.random.uniform", return_value=12.5) as uniform:
+        sweep.advance(SWEEP_START)
+
+    uniform.assert_called_once_with(7.5, 12.5)
+    assert sweep.next_sweep - time.monotonic() == pytest.approx(12.5, abs=0.5)
+
+
+async def test_only_the_lease_holder_sweeps(docket: Docket, stream_calls: StreamCalls):
+    """Two workers in one interval run one sweep between them, not two.
+
+    A sweep costs Redis a pass over the whole pending list, so a fleet that
+    swept once per worker would multiply that cost by the size of the fleet.
+    """
+
+    async def slow_task() -> None:
+        await asyncio.sleep(0.2)
+
+    await docket.add(slow_task)()
+
+    # Create the consumer group up front, so neither worker's first claim
+    # retries past a NOGROUP error and counts as a second sweep.
+    await docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+
+    def replacement(name: str) -> Worker:
+        return Worker(
+            docket,
+            name=name,
+            redelivery_timeout=timedelta(seconds=30),
+            minimum_check_interval=timedelta(milliseconds=10),
+            scheduling_resolution=timedelta(milliseconds=10),
+        )
+
+    async with replacement("worker-one") as one, replacement("worker-two") as two:
+        await asyncio.gather(one.run_until_finished(), two.run_until_finished())
+
+    assert len(stream_calls.claim_consumers) == 1
+    assert stream_calls.claim_consumers[0] in {"worker-one", "worker-two"}
+
+
+async def test_a_worker_that_loses_the_lease_sweeps_once_it_expires(docket: Docket):
+    """A worker that replaces a dead one still picks up its abandoned message.
+
+    The dead worker's lease outlives it.  Nobody deletes that lease, so the
+    replacement worker waits for it to expire and then takes it.
+    """
+    executed: list[str] = []
+
+    async def the_task() -> None:
+        executed.append("ran")
+
+    await docket.add(the_task)()
+    await abandon_every_stream_entry(docket)
+
+    async with docket.redis() as redis:
+        await redis.set(docket.redelivery_sweep_key, "the-dead-worker", px=400)
+
+    await asyncio.sleep(0.25)  # longer than the redelivery timeout
+
+    async with Worker(
+        docket,
+        redelivery_timeout=timedelta(milliseconds=200),
+        minimum_check_interval=timedelta(milliseconds=10),
+        scheduling_resolution=timedelta(milliseconds=10),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert executed == ["ran"]
+
+
+async def test_a_read_asks_for_no_more_than_the_delivery_batch(
+    docket: Docket, stream_calls: StreamCalls, the_task: AsyncMock
+):
+    """A worker with more free slots than the batch still asks for the batch.
+
+    Redis serializes every message it returns before it answers, and it blocks
+    while it does that, so one huge read stalls every other client.
+    """
+    await docket.add(the_task)()
+
+    async with Worker(
+        docket,
+        concurrency=DELIVERY_BATCH * 2,
+        minimum_check_interval=timedelta(milliseconds=10),
+        scheduling_resolution=timedelta(milliseconds=10),
+    ) as worker:
+        await worker.run_until_finished()
+
+    the_task.assert_called_once()
+    assert stream_calls.read_counts
+    assert max(stream_calls.read_counts) == DELIVERY_BATCH
+
+
+async def test_a_capped_read_still_drains_a_larger_backlog(
+    docket: Docket, stream_calls: StreamCalls
+):
+    """A backlog bigger than one batch still drains, one batch per read."""
+    executed: list[int] = []
+
+    async def the_task(number: int) -> None:
+        executed.append(number)
+
+    for number in range(6):
+        await docket.add(the_task, key=f"task-{number}")(number=number)
+
+    with patch("docket.worker.DELIVERY_BATCH", 2):
+        async with Worker(
+            docket,
+            concurrency=10,
+            minimum_check_interval=timedelta(milliseconds=10),
+            scheduling_resolution=timedelta(milliseconds=10),
+        ) as worker:
+            await worker.run_until_finished()
+
+    assert sorted(executed) == [0, 1, 2, 3, 4, 5]
+    assert max(stream_calls.read_counts) == 2


### PR DESCRIPTION
On a stream with a million-entry pending list, a worker's stream bookkeeping stops scaling. One XAUTOCLAIM with count=1000 costs 37 ms because Redis scans ten times count entries, so sweeping the whole pending list on every pass pins a busy Redis at 100% CPU. A fresh XREADGROUP for tens of thousands of free slots blocks Redis for hundreds of milliseconds while it serializes every message. Lease renewal with a plain XCLAIM of tens of thousands of ids ships the full body of every message back to a worker that throws the reply away.

A new `_redelivery` module holds the pacing. The sweep runs on a timer of a quarter of the redelivery timeout, jittered between 75% and 125% so a fleet that started together does not sweep in lockstep, and it keeps the cursor the last XAUTOCLAIM returned so entries past the first window are still reached. A fleet-wide lease, `SET {docket}:redelivery-sweep NX PX`, lets one worker sweep per interval, so the cost of a sweep does not grow with the number of workers. The delivery read is capped at `DELIVERY_BATCH` and lease renewal goes out in chunks with JUSTID, so no one command blocks Redis long; the loop reads again while slots remain, so throughput is unchanged.

## Compatibility

- A new Redis key `{docket}:redelivery-sweep` appears. It is harmless to old workers, which ignore it. During a mixed-version window old workers still sweep unthrottled, so the fleet-pacing benefit is full only once all workers are new.
- Redelivery timing changes: an abandoned message can now wait up to the redelivery timeout plus one jittered interval before a worker picks it up.
- No change to task payloads or the stream and queue schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)