### PR TITLE
Fold pre-claim and pre-schedule reads into the Lua scripts

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1421
+max_lines = 1423
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/_execution_scripts.py
+++ b/src/docket/_execution_scripts.py
@@ -1,0 +1,437 @@
+"""The Lua that moves one task key between lifecycle states.
+
+Every transition in a task's life is one atomic script against the keys for
+a single task: ``_schedule`` puts it on the stream or the queue, ``_claim``
+takes it for a worker, ``_terminal`` records how it finished, and
+``_cancel_task`` takes it back off.  The first three each check the
+``generation`` counter in the runs hash, so a stale attempt can never
+overwrite a newer one.
+
+``Execution`` and ``Docket`` call these; the scripts hold no Python logic of
+their own.
+"""
+
+from typing import Any
+
+from ._lua import Arg, Args, Key, redis_script
+from ._redis import RedisClient
+
+
+@redis_script
+async def _schedule(
+    redis: RedisClient,
+    *,
+    stream_key: Key[str],
+    known_key: Key[str],
+    parked_key: Key[str],
+    queue_key: Key[str],
+    stream_id_key: Key[str],
+    runs_key: Key[str],
+    state_channel: Key[str],
+    task_key: Arg[str],
+    when_timestamp: Arg[float],
+    is_immediate: Arg[bool],
+    replace: Arg[bool],
+    reschedule_message_id: Arg[bytes],
+    expected_generation: Arg[int],
+    worker_group_name: Arg[str],
+    state_payload: Arg[str],
+    message: Args[dict[bytes, bytes]],
+) -> bytes | str:
+    """
+    -- TODO: Remove known_key / parked_key / queue_key / stream_id_key
+    -- handling in v0.14.0 (legacy key locations).
+
+    -- A caller that is rescheduling on behalf of the attempt it just ran
+    -- (Perpetual's on_complete) passes the generation it holds, so the
+    -- supersession check rides along with the schedule instead of costing
+    -- its own HGET.  A newer stored generation means someone else has taken
+    -- the key and this schedule must not touch it.  0 means "no check", both
+    -- for callers that don't have a generation and for messages that predate
+    -- generation tracking.
+    if expected_generation > 0 then
+        local stored = redis.call('HGET', runs_key, 'generation')
+        local stored_generation = 0
+        if stored then
+            stored_generation = tonumber(stored)
+        end
+        if stored_generation > expected_generation then
+            return 'SUPERSEDED'
+        end
+    end
+
+    -- Extract message fields
+    local message = {}
+    local function_name = nil
+    local args_data = nil
+    local kwargs_data = nil
+    local generation_index = nil
+
+    for i = message_start, #ARGV, 2 do
+        local field_name = ARGV[i]
+        local field_value = ARGV[i + 1]
+        message[#message + 1] = field_name
+        message[#message + 1] = field_value
+
+        -- Extract task data fields for runs hash
+        if field_name == 'function' then
+            function_name = field_value
+        elseif field_name == 'args' then
+            args_data = field_value
+        elseif field_name == 'kwargs' then
+            kwargs_data = field_value
+        elseif field_name == 'generation' then
+            generation_index = #message
+        end
+    end
+
+    -- Handle rescheduling from stream: atomically ACK the original message and
+    -- re-route the task.  Prevents both task loss (ACK before reschedule) and
+    -- duplicate execution (reschedule before ACK with slow reschedule causing
+    -- redelivery).  Honors is_immediate so a retry with delay=0 lands in the
+    -- stream right away instead of waiting for the scheduler poll.  Sets
+    -- 'known' so a concurrent docket.add() for the same key dedups against
+    -- this rescheduled task.
+    if reschedule_message_id ~= '' then
+        -- Acknowledge and delete the message from the stream
+        redis.call('XACK', stream_key, worker_group_name, reschedule_message_id)
+        redis.call('XDEL', stream_key, reschedule_message_id)
+
+        -- Increment generation counter
+        local new_gen = redis.call('HINCRBY', runs_key, 'generation', 1)
+        if generation_index then
+            message[generation_index] = tostring(new_gen)
+        end
+
+        if is_immediate then
+            -- Add directly to stream for immediate execution
+            local new_message_id = redis.call('XADD', stream_key, '*', unpack(message))
+            redis.call('HSET', runs_key,
+                'state', 'queued',
+                'when', when_timestamp,
+                'known', when_timestamp,
+                'stream_id', new_message_id,
+                'function', function_name,
+                'args', args_data,
+                'kwargs', kwargs_data
+            )
+        else
+            -- Park task data for future execution
+            redis.call('HSET', parked_key, unpack(message))
+            redis.call('ZADD', queue_key, when_timestamp, task_key)
+            redis.call('HSET', runs_key,
+                'state', 'scheduled',
+                'when', when_timestamp,
+                'known', when_timestamp,
+                'function', function_name,
+                'args', args_data,
+                'kwargs', kwargs_data
+            )
+            redis.call('HDEL', runs_key, 'stream_id')
+        end
+
+        -- Clear fields written by the previous attempt's ``_claim`` so the
+        -- runs hash describes the rescheduled (queued/scheduled) attempt,
+        -- not the worker and start-time of the attempt that just failed.
+        redis.call('HDEL', runs_key, 'worker', 'started_at')
+
+        redis.call('PUBLISH', state_channel, state_payload)
+
+        return 'OK'
+    end
+
+    -- Handle replacement: cancel existing task if needed
+    if replace then
+        -- Get stream ID from runs hash (check new location first)
+        local existing_message_id = redis.call('HGET', runs_key, 'stream_id')
+
+        -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
+        if not existing_message_id then
+            existing_message_id = redis.call('GET', stream_id_key)
+        end
+
+        if existing_message_id then
+            redis.call('XDEL', stream_key, existing_message_id)
+        end
+
+        redis.call('ZREM', queue_key, task_key)
+        redis.call('DEL', parked_key)
+
+        -- TODO: Remove in next breaking release (v0.14.0) - clean up legacy keys
+        redis.call('DEL', known_key, stream_id_key)
+
+        -- Note: runs_key is updated below, not deleted
+    else
+        -- Check if task already exists (check new location first, then legacy)
+        local known_exists = redis.call('HEXISTS', runs_key, 'known') == 1
+        if not known_exists then
+            -- Check if task is currently running (known field deleted at claim time)
+            local state = redis.call('HGET', runs_key, 'state')
+            if state == 'running' then
+                return 'EXISTS'
+            end
+            -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
+            known_exists = redis.call('EXISTS', known_key) == 1
+        end
+        if known_exists then
+            return 'EXISTS'
+        end
+    end
+
+    -- Increment generation counter
+    local new_gen = redis.call('HINCRBY', runs_key, 'generation', 1)
+    if generation_index then
+        message[generation_index] = tostring(new_gen)
+    end
+
+    if is_immediate then
+        -- Add to stream for immediate execution
+        local message_id = redis.call('XADD', stream_key, '*', unpack(message))
+
+        -- Store state and metadata in runs hash
+        redis.call('HSET', runs_key,
+            'state', 'queued',
+            'when', when_timestamp,
+            'known', when_timestamp,
+            'stream_id', message_id,
+            'function', function_name,
+            'args', args_data,
+            'kwargs', kwargs_data
+        )
+    else
+        -- Park task data for future execution
+        redis.call('HSET', parked_key, unpack(message))
+
+        -- Add to sorted set queue
+        redis.call('ZADD', queue_key, when_timestamp, task_key)
+
+        -- Store state and metadata in runs hash
+        redis.call('HSET', runs_key,
+            'state', 'scheduled',
+            'when', when_timestamp,
+            'known', when_timestamp,
+            'function', function_name,
+            'args', args_data,
+            'kwargs', kwargs_data
+        )
+    end
+
+    redis.call('PUBLISH', state_channel, state_payload)
+
+    return 'OK'
+    """
+    ...
+
+
+@redis_script
+async def _claim(
+    redis: RedisClient,
+    *,
+    runs_key: Key[str],
+    progress_key: Key[str],
+    known_key: Key[str],
+    stream_id_key: Key[str],
+    state_channel: Key[str],
+    stream_key: Key[str],
+    worker: Arg[str],
+    started_at: Arg[str],
+    generation: Arg[int],
+    state_payload: Arg[str],
+    worker_group_name: Arg[str],
+    message_id: Arg[bytes],
+) -> list[Any]:
+    """
+    -- TODO: Remove known_key / stream_id_key handling in v0.14.0
+    -- (legacy key locations).
+
+    -- Every reply is {status, runs hash, progress hash}: the caller reads
+    -- the two hashes back from the claim instead of paying for its own
+    -- HGETALL pair a moment earlier.  On both paths the hashes are what
+    -- Redis holds once the script is done, so a refused claim reports the
+    -- key as its winner left it.
+
+    -- Check supersession: generation > 0 means tracking is active.  When the
+    -- claim is for a stale message we still ACK and XDEL it so the stream
+    -- entry doesn't linger -- nothing else will clean it up.
+    if generation > 0 then
+        local current = redis.call('HGET', runs_key, 'generation')
+        if not current or tonumber(current) > generation then
+            -- Either the runs hash was cleaned up (execution_ttl=0 after a
+            -- newer generation completed) or a newer generation holds it.
+            if message_id ~= '' then
+                redis.call('XACK', stream_key, worker_group_name, message_id)
+                redis.call('XDEL', stream_key, message_id)
+            end
+            return {
+                'SUPERSEDED',
+                redis.call('HGETALL', runs_key),
+                redis.call('HGETALL', progress_key)
+            }
+        end
+    end
+
+    -- Update execution state to running
+    redis.call('HSET', runs_key,
+        'state', 'running',
+        'worker', worker,
+        'started_at', started_at
+    )
+
+    -- Initialize progress tracking, tagged with the claimer's generation so
+    -- a stale predecessor finishing later can tell whether the progress hash
+    -- is still ours to clean up (see _terminal SUPERSEDED branch).  Also
+    -- drop any ``message``/``updated_at`` left behind by the previous
+    -- generation -- HSET doesn't remove optional fields, so without this
+    -- HDEL the successor's progress view would surface stale metadata.
+    redis.call('HSET', progress_key,
+        'current', '0',
+        'total', '100',
+        'generation', generation
+    )
+    redis.call('HDEL', progress_key, 'message', 'updated_at')
+
+    -- Delete known/stream_id fields to allow task rescheduling
+    redis.call('HDEL', runs_key, 'known', 'stream_id')
+
+    -- TODO: Remove in next breaking release (v0.14.0) - legacy key cleanup
+    redis.call('DEL', known_key, stream_id_key)
+
+    redis.call('PUBLISH', state_channel, state_payload)
+
+    return {
+        'OK',
+        redis.call('HGETALL', runs_key),
+        redis.call('HGETALL', progress_key)
+    }
+    """
+    ...
+
+
+@redis_script
+async def _terminal(
+    redis: RedisClient,
+    *,
+    runs_key: Key[str],
+    state_channel: Key[str],
+    progress_key: Key[str],
+    stream_key: Key[str],
+    generation: Arg[int],
+    state: Arg[str],
+    completed_at: Arg[str],
+    ttl_seconds: Arg[int],
+    state_payload: Arg[str],
+    worker_group_name: Arg[str],
+    message_id: Arg[bytes],
+    extra_fields: Args[list[str]],
+) -> bytes:
+    """
+    -- Check supersession (generation 0 = pre-tracking, always write).  Two
+    -- supersession shapes, both handled the same way:
+    --   * runs hash missing entirely -- a newer generation already completed
+    --     and its execution_ttl expired (or it was 0).
+    --   * runs hash present but its generation is newer -- a successor is in
+    --     flight or has just finished within its execution_ttl window.
+    -- In both cases we still publish the terminal-state event so subscribers
+    -- waiting on completion don't deadlock, and we still clean up this
+    -- execution's progress hash and stream entry.  We do NOT recreate or
+    -- mutate the runs hash on a supersession -- the successor owns it.
+    if generation > 0 then
+        local current = redis.call('HGET', runs_key, 'generation')
+        if not current or tonumber(current) > generation then
+            redis.call('PUBLISH', state_channel, state_payload)
+            -- Only DEL the progress hash if it belongs to us (matching
+            -- generation tag) or is untagged (pre-fix / pre-tracking data,
+            -- preserve the prior unconditional-DEL behaviour).  A newer
+            -- generation's tag means the successor is actively reporting
+            -- against the hash and we must not clobber its state.
+            local progress_gen = redis.call('HGET', progress_key, 'generation')
+            if not progress_gen or tonumber(progress_gen) <= generation then
+                redis.call('DEL', progress_key)
+            end
+            if message_id ~= '' then
+                redis.call('XACK', stream_key, worker_group_name, message_id)
+                redis.call('XDEL', stream_key, message_id)
+            end
+            return 'SUPERSEDED'
+        end
+    end
+
+    -- Build HSET args: state + completed_at + any extras
+    local hset_args = {'state', state, 'completed_at', completed_at}
+    for i = extra_fields_start, #ARGV, 2 do
+        hset_args[#hset_args + 1] = ARGV[i]
+        hset_args[#hset_args + 1] = ARGV[i + 1]
+    end
+    redis.call('HSET', runs_key, unpack(hset_args))
+
+    if ttl_seconds > 0 then
+        redis.call('EXPIRE', runs_key, ttl_seconds)
+    else
+        redis.call('DEL', runs_key)
+    end
+
+    redis.call('PUBLISH', state_channel, state_payload)
+    redis.call('DEL', progress_key)
+    if message_id ~= '' then
+        redis.call('XACK', stream_key, worker_group_name, message_id)
+        redis.call('XDEL', stream_key, message_id)
+    end
+
+    return 'OK'
+    """
+    ...
+
+
+@redis_script
+async def _cancel_task(
+    redis: RedisClient,
+    *,
+    stream_key: Key[str],
+    known_key: Key[str],
+    parked_key: Key[str],
+    queue_key: Key[str],
+    stream_id_key: Key[str],
+    runs_key: Key[str],
+    progress_key: Key[str],
+    task_key: Arg[str],
+    completed_at: Arg[str],
+) -> bytes:
+    """
+    -- TODO: Remove known_key / parked_key / stream_id_key handling in
+    -- v0.14.0 (legacy key locations).
+
+    -- Get stream ID (check new location first, then legacy)
+    local message_id = redis.call('HGET', runs_key, 'stream_id')
+
+    -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
+    if not message_id then
+        message_id = redis.call('GET', stream_id_key)
+    end
+
+    -- Delete from stream if message ID exists
+    if message_id then
+        redis.call('XDEL', stream_key, message_id)
+    end
+
+    -- Clean up legacy keys and parked data
+    redis.call('DEL', known_key, parked_key, stream_id_key)
+    redis.call('ZREM', queue_key, task_key)
+
+    -- Drop the per-task progress hash that ``Execution.claim``
+    -- creates -- without a TTL of its own, it would otherwise
+    -- leak when a task is cancelled after being claimed but
+    -- before it completes (e.g. parked on a side channel).
+    redis.call('DEL', progress_key)
+
+    -- Clear scheduling markers so add() can reschedule this key
+    redis.call('HDEL', runs_key, 'known', 'stream_id')
+
+    -- Only set CANCELLED if not already in a terminal state
+    local current_state = redis.call('HGET', runs_key, 'state')
+    if current_state ~= 'completed' and current_state ~= 'failed' and current_state ~= 'cancelled' then
+        redis.call('HSET', runs_key, 'state', 'cancelled', 'completed_at', completed_at)
+    end
+
+    return 'OK'
+    """
+    ...

--- a/src/docket/dependencies/_perpetual.py
+++ b/src/docket/dependencies/_perpetual.py
@@ -18,6 +18,7 @@ from ._base import (
 if TYPE_CHECKING:  # pragma: no cover
     from ..execution import Execution
 
+from ..execution import Disposition
 from ..instrumentation import TASKS_PERPETUATED, TASKS_SUPERSEDED
 
 logger = logging.getLogger("docket.dependencies")
@@ -106,8 +107,26 @@ class Perpetual(CompletionHandler["Perpetual"]):
                 await docket._cancel(redis, execution.key)
             return False
 
-        if await execution.is_superseded():
-            worker = current_worker.get()
+        docket = current_docket.get()
+        worker = current_worker.get()
+
+        if self._next_when:
+            when = self._next_when
+        else:
+            now = datetime.now(timezone.utc)
+            when = max(now, now + self.every - outcome.duration)
+
+        # Reschedule under this attempt's generation, so the one script both
+        # checks whether someone else has taken the key and, when nobody has,
+        # schedules the next run.
+        successor = await docket._replace(
+            execution.function, when, execution.key, execution.generation
+        )(
+            *self.args,
+            **self.kwargs,
+        )
+
+        if successor.disposition is Disposition.SUPERSEDED:
             TASKS_SUPERSEDED.add(
                 1,
                 {
@@ -122,20 +141,6 @@ class Perpetual(CompletionHandler["Perpetual"]):
                 execution.call_repr(),
             )
             return True
-
-        docket = current_docket.get()
-        worker = current_worker.get()
-
-        if self._next_when:
-            when = self._next_when
-        else:
-            now = datetime.now(timezone.utc)
-            when = max(now, now + self.every - outcome.duration)
-
-        await docket.replace(execution.function, when, execution.key)(
-            *self.args,
-            **self.kwargs,
-        )
 
         TASKS_PERPETUATED.add(1, {**worker.labels(), **execution.general_labels()})
 

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -24,7 +24,7 @@ from ._docket_snapshot import DocketSnapshot as DocketSnapshot
 from ._docket_snapshot import DocketSnapshotMixin
 from ._docket_snapshot import RunningExecution as RunningExecution
 from ._docket_snapshot import WorkerInfo as WorkerInfo
-from ._lua import Arg, Key, redis_script
+from ._execution_scripts import _cancel_task
 from ._redis import (
     PubSubClient,
     RedisClient,
@@ -63,61 +63,6 @@ from .strikelist import (
 
 logger: logging.Logger = logging.getLogger(__name__)
 tracer: trace.Tracer = trace.get_tracer(__name__)
-
-
-@redis_script
-async def _cancel_task(
-    redis: RedisClient,
-    *,
-    stream_key: Key[str],
-    known_key: Key[str],
-    parked_key: Key[str],
-    queue_key: Key[str],
-    stream_id_key: Key[str],
-    runs_key: Key[str],
-    progress_key: Key[str],
-    task_key: Arg[str],
-    completed_at: Arg[str],
-) -> bytes:
-    """
-    -- TODO: Remove known_key / parked_key / stream_id_key handling in
-    -- v0.14.0 (legacy key locations).
-
-    -- Get stream ID (check new location first, then legacy)
-    local message_id = redis.call('HGET', runs_key, 'stream_id')
-
-    -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
-    if not message_id then
-        message_id = redis.call('GET', stream_id_key)
-    end
-
-    -- Delete from stream if message ID exists
-    if message_id then
-        redis.call('XDEL', stream_key, message_id)
-    end
-
-    -- Clean up legacy keys and parked data
-    redis.call('DEL', known_key, parked_key, stream_id_key)
-    redis.call('ZREM', queue_key, task_key)
-
-    -- Drop the per-task progress hash that ``Execution.claim``
-    -- creates -- without a TTL of its own, it would otherwise
-    -- leak when a task is cancelled after being claimed but
-    -- before it completes (e.g. parked on a side channel).
-    redis.call('DEL', progress_key)
-
-    -- Clear scheduling markers so add() can reschedule this key
-    redis.call('HDEL', runs_key, 'known', 'stream_id')
-
-    -- Only set CANCELLED if not already in a terminal state
-    local current_state = redis.call('HGET', runs_key, 'state')
-    if current_state ~= 'completed' and current_state ~= 'failed' and current_state ~= 'cancelled' then
-        redis.call('HSET', runs_key, 'state', 'cancelled', 'completed_at', completed_at)
-    end
-
-    return 'OK'
-    """
-    ...
 
 
 P = ParamSpec("P")
@@ -478,6 +423,25 @@ class Docket(DocketSnapshotMixin):
             prior schedule for ``key``), or ``Disposition.STRUCK`` if a strike
             rule blocked the call.
         """
+        return self._replace(function, when, key)
+
+    def _replace(
+        self,
+        function: Callable[P, Awaitable[R]] | str,
+        when: datetime,
+        key: str,
+        expected_generation: int = 0,
+    ) -> Callable[..., Awaitable[Execution]]:
+        """Replace a task, optionally only while the caller still holds the key.
+
+        ``expected_generation`` is the generation the caller believes holds
+        ``key``.  When it is non-zero and Redis holds a newer one, the schedule
+        script leaves the key alone and the returned execution's disposition is
+        ``Disposition.SUPERSEDED``.  ``Perpetual`` passes the generation of the
+        attempt that just finished, so its reschedule and its supersession
+        check are one round-trip.  ``Docket.replace`` passes 0, which skips the
+        check entirely.
+        """
         function_name: str | None = None
         if isinstance(function, str):
             function_name = function
@@ -512,7 +476,9 @@ class Docket(DocketSnapshotMixin):
                     return execution
 
                 # Schedule atomically (includes state record write)
-                await execution.schedule(replace=True)
+                await execution.schedule(
+                    replace=True, expected_generation=expected_generation
+                )
                 span.set_attribute("docket.disposition", execution.disposition.value)
 
             self._record_schedule_metrics(execution, replace=True)
@@ -693,10 +659,11 @@ class Docket(DocketSnapshotMixin):
         """Increment the scheduling counters for one non-stricken execution,
         exactly as the single-call ``add`` / ``replace`` paths always have.
 
-        Executions whose Redis command failed during a batch don't count:
-        nothing was added, replaced, or scheduled for them.
+        Executions whose Redis command failed during a batch don't count, and
+        neither do those a newer generation superseded: nothing was added,
+        replaced, or scheduled for them.
         """
-        if execution.disposition is Disposition.FAILED:
+        if execution.disposition in (Disposition.FAILED, Disposition.SUPERSEDED):
             return
 
         labels = {**self.labels(), **execution.general_labels()}

--- a/src/docket/execution.py
+++ b/src/docket/execution.py
@@ -35,7 +35,7 @@ from uncalled_for.introspection import (
 )
 
 from ._execution_progress import ExecutionProgress, ProgressEvent, StateEvent
-from ._lua import Arg, Args, Key, redis_script
+from ._execution_scripts import _claim, _schedule, _terminal
 from ._redis import RedisClient, confirm_subscriptions, is_cluster_client
 from .annotations import Logged
 from .instrumentation import CACHE_SIZE, message_getter, message_setter
@@ -56,191 +56,10 @@ TaskFunction = Callable[..., Awaitable[Any]]
 Message = dict[bytes, bytes]
 
 
-@redis_script
-async def _schedule(
-    redis: RedisClient,
-    *,
-    stream_key: Key[str],
-    known_key: Key[str],
-    parked_key: Key[str],
-    queue_key: Key[str],
-    stream_id_key: Key[str],
-    runs_key: Key[str],
-    state_channel: Key[str],
-    task_key: Arg[str],
-    when_timestamp: Arg[float],
-    is_immediate: Arg[bool],
-    replace: Arg[bool],
-    reschedule_message_id: Arg[bytes],
-    worker_group_name: Arg[str],
-    state_payload: Arg[str],
-    message: Args[dict[bytes, bytes]],
-) -> bytes | str:
-    """
-    -- TODO: Remove known_key / parked_key / queue_key / stream_id_key
-    -- handling in v0.14.0 (legacy key locations).
-
-    -- Extract message fields
-    local message = {}
-    local function_name = nil
-    local args_data = nil
-    local kwargs_data = nil
-    local generation_index = nil
-
-    for i = message_start, #ARGV, 2 do
-        local field_name = ARGV[i]
-        local field_value = ARGV[i + 1]
-        message[#message + 1] = field_name
-        message[#message + 1] = field_value
-
-        -- Extract task data fields for runs hash
-        if field_name == 'function' then
-            function_name = field_value
-        elseif field_name == 'args' then
-            args_data = field_value
-        elseif field_name == 'kwargs' then
-            kwargs_data = field_value
-        elseif field_name == 'generation' then
-            generation_index = #message
-        end
-    end
-
-    -- Handle rescheduling from stream: atomically ACK the original message and
-    -- re-route the task.  Prevents both task loss (ACK before reschedule) and
-    -- duplicate execution (reschedule before ACK with slow reschedule causing
-    -- redelivery).  Honors is_immediate so a retry with delay=0 lands in the
-    -- stream right away instead of waiting for the scheduler poll.  Sets
-    -- 'known' so a concurrent docket.add() for the same key dedups against
-    -- this rescheduled task.
-    if reschedule_message_id ~= '' then
-        -- Acknowledge and delete the message from the stream
-        redis.call('XACK', stream_key, worker_group_name, reschedule_message_id)
-        redis.call('XDEL', stream_key, reschedule_message_id)
-
-        -- Increment generation counter
-        local new_gen = redis.call('HINCRBY', runs_key, 'generation', 1)
-        if generation_index then
-            message[generation_index] = tostring(new_gen)
-        end
-
-        if is_immediate then
-            -- Add directly to stream for immediate execution
-            local new_message_id = redis.call('XADD', stream_key, '*', unpack(message))
-            redis.call('HSET', runs_key,
-                'state', 'queued',
-                'when', when_timestamp,
-                'known', when_timestamp,
-                'stream_id', new_message_id,
-                'function', function_name,
-                'args', args_data,
-                'kwargs', kwargs_data
-            )
-        else
-            -- Park task data for future execution
-            redis.call('HSET', parked_key, unpack(message))
-            redis.call('ZADD', queue_key, when_timestamp, task_key)
-            redis.call('HSET', runs_key,
-                'state', 'scheduled',
-                'when', when_timestamp,
-                'known', when_timestamp,
-                'function', function_name,
-                'args', args_data,
-                'kwargs', kwargs_data
-            )
-            redis.call('HDEL', runs_key, 'stream_id')
-        end
-
-        -- Clear fields written by the previous attempt's ``_claim`` so the
-        -- runs hash describes the rescheduled (queued/scheduled) attempt,
-        -- not the worker and start-time of the attempt that just failed.
-        redis.call('HDEL', runs_key, 'worker', 'started_at')
-
-        redis.call('PUBLISH', state_channel, state_payload)
-
-        return 'OK'
-    end
-
-    -- Handle replacement: cancel existing task if needed
-    if replace then
-        -- Get stream ID from runs hash (check new location first)
-        local existing_message_id = redis.call('HGET', runs_key, 'stream_id')
-
-        -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
-        if not existing_message_id then
-            existing_message_id = redis.call('GET', stream_id_key)
-        end
-
-        if existing_message_id then
-            redis.call('XDEL', stream_key, existing_message_id)
-        end
-
-        redis.call('ZREM', queue_key, task_key)
-        redis.call('DEL', parked_key)
-
-        -- TODO: Remove in next breaking release (v0.14.0) - clean up legacy keys
-        redis.call('DEL', known_key, stream_id_key)
-
-        -- Note: runs_key is updated below, not deleted
-    else
-        -- Check if task already exists (check new location first, then legacy)
-        local known_exists = redis.call('HEXISTS', runs_key, 'known') == 1
-        if not known_exists then
-            -- Check if task is currently running (known field deleted at claim time)
-            local state = redis.call('HGET', runs_key, 'state')
-            if state == 'running' then
-                return 'EXISTS'
-            end
-            -- TODO: Remove in next breaking release (v0.14.0) - check legacy location
-            known_exists = redis.call('EXISTS', known_key) == 1
-        end
-        if known_exists then
-            return 'EXISTS'
-        end
-    end
-
-    -- Increment generation counter
-    local new_gen = redis.call('HINCRBY', runs_key, 'generation', 1)
-    if generation_index then
-        message[generation_index] = tostring(new_gen)
-    end
-
-    if is_immediate then
-        -- Add to stream for immediate execution
-        local message_id = redis.call('XADD', stream_key, '*', unpack(message))
-
-        -- Store state and metadata in runs hash
-        redis.call('HSET', runs_key,
-            'state', 'queued',
-            'when', when_timestamp,
-            'known', when_timestamp,
-            'stream_id', message_id,
-            'function', function_name,
-            'args', args_data,
-            'kwargs', kwargs_data
-        )
-    else
-        -- Park task data for future execution
-        redis.call('HSET', parked_key, unpack(message))
-
-        -- Add to sorted set queue
-        redis.call('ZADD', queue_key, when_timestamp, task_key)
-
-        -- Store state and metadata in runs hash
-        redis.call('HSET', runs_key,
-            'state', 'scheduled',
-            'when', when_timestamp,
-            'known', when_timestamp,
-            'function', function_name,
-            'args', args_data,
-            'kwargs', kwargs_data
-        )
-    end
-
-    redis.call('PUBLISH', state_channel, state_payload)
-
-    return 'OK'
-    """
-    ...
+def _hash_reply(flat: Sequence[bytes]) -> Message:
+    """Pair up a hash that a Lua script returned as a flat field/value array."""
+    fields = iter(flat)
+    return dict(zip(fields, fields))
 
 
 async def schedule_many(
@@ -330,158 +149,6 @@ async def schedule_many(
                 execution._apply_schedule_reply(reply, is_immediate)  # pyright: ignore[reportPrivateUsage]
 
 
-@redis_script
-async def _claim(
-    redis: RedisClient,
-    *,
-    runs_key: Key[str],
-    progress_key: Key[str],
-    known_key: Key[str],
-    stream_id_key: Key[str],
-    state_channel: Key[str],
-    stream_key: Key[str],
-    worker: Arg[str],
-    started_at: Arg[str],
-    generation: Arg[int],
-    state_payload: Arg[str],
-    worker_group_name: Arg[str],
-    message_id: Arg[bytes],
-) -> bytes:
-    """
-    -- TODO: Remove known_key / stream_id_key handling in v0.14.0
-    -- (legacy key locations).
-
-    -- Check supersession: generation > 0 means tracking is active.  When the
-    -- claim is for a stale message we still ACK and XDEL it so the stream
-    -- entry doesn't linger -- nothing else will clean it up.
-    if generation > 0 then
-        local current = redis.call('HGET', runs_key, 'generation')
-        if not current then
-            -- Runs hash was cleaned up (execution_ttl=0 after
-            -- a newer generation completed).  This message is stale.
-            if message_id ~= '' then
-                redis.call('XACK', stream_key, worker_group_name, message_id)
-                redis.call('XDEL', stream_key, message_id)
-            end
-            return 'SUPERSEDED'
-        end
-        if tonumber(current) > generation then
-            if message_id ~= '' then
-                redis.call('XACK', stream_key, worker_group_name, message_id)
-                redis.call('XDEL', stream_key, message_id)
-            end
-            return 'SUPERSEDED'
-        end
-    end
-
-    -- Update execution state to running
-    redis.call('HSET', runs_key,
-        'state', 'running',
-        'worker', worker,
-        'started_at', started_at
-    )
-
-    -- Initialize progress tracking, tagged with the claimer's generation so
-    -- a stale predecessor finishing later can tell whether the progress hash
-    -- is still ours to clean up (see _terminal SUPERSEDED branch).  Also
-    -- drop any ``message``/``updated_at`` left behind by the previous
-    -- generation -- HSET doesn't remove optional fields, so without this
-    -- HDEL the successor's progress view would surface stale metadata.
-    redis.call('HSET', progress_key,
-        'current', '0',
-        'total', '100',
-        'generation', generation
-    )
-    redis.call('HDEL', progress_key, 'message', 'updated_at')
-
-    -- Delete known/stream_id fields to allow task rescheduling
-    redis.call('HDEL', runs_key, 'known', 'stream_id')
-
-    -- TODO: Remove in next breaking release (v0.14.0) - legacy key cleanup
-    redis.call('DEL', known_key, stream_id_key)
-
-    redis.call('PUBLISH', state_channel, state_payload)
-
-    return 'OK'
-    """
-    ...
-
-
-@redis_script
-async def _terminal(
-    redis: RedisClient,
-    *,
-    runs_key: Key[str],
-    state_channel: Key[str],
-    progress_key: Key[str],
-    stream_key: Key[str],
-    generation: Arg[int],
-    state: Arg[str],
-    completed_at: Arg[str],
-    ttl_seconds: Arg[int],
-    state_payload: Arg[str],
-    worker_group_name: Arg[str],
-    message_id: Arg[bytes],
-    extra_fields: Args[list[str]],
-) -> bytes:
-    """
-    -- Check supersession (generation 0 = pre-tracking, always write).  Two
-    -- supersession shapes, both handled the same way:
-    --   * runs hash missing entirely -- a newer generation already completed
-    --     and its execution_ttl expired (or it was 0).
-    --   * runs hash present but its generation is newer -- a successor is in
-    --     flight or has just finished within its execution_ttl window.
-    -- In both cases we still publish the terminal-state event so subscribers
-    -- waiting on completion don't deadlock, and we still clean up this
-    -- execution's progress hash and stream entry.  We do NOT recreate or
-    -- mutate the runs hash on a supersession -- the successor owns it.
-    if generation > 0 then
-        local current = redis.call('HGET', runs_key, 'generation')
-        if not current or tonumber(current) > generation then
-            redis.call('PUBLISH', state_channel, state_payload)
-            -- Only DEL the progress hash if it belongs to us (matching
-            -- generation tag) or is untagged (pre-fix / pre-tracking data,
-            -- preserve the prior unconditional-DEL behaviour).  A newer
-            -- generation's tag means the successor is actively reporting
-            -- against the hash and we must not clobber its state.
-            local progress_gen = redis.call('HGET', progress_key, 'generation')
-            if not progress_gen or tonumber(progress_gen) <= generation then
-                redis.call('DEL', progress_key)
-            end
-            if message_id ~= '' then
-                redis.call('XACK', stream_key, worker_group_name, message_id)
-                redis.call('XDEL', stream_key, message_id)
-            end
-            return 'SUPERSEDED'
-        end
-    end
-
-    -- Build HSET args: state + completed_at + any extras
-    local hset_args = {'state', state, 'completed_at', completed_at}
-    for i = extra_fields_start, #ARGV, 2 do
-        hset_args[#hset_args + 1] = ARGV[i]
-        hset_args[#hset_args + 1] = ARGV[i + 1]
-    end
-    redis.call('HSET', runs_key, unpack(hset_args))
-
-    if ttl_seconds > 0 then
-        redis.call('EXPIRE', runs_key, ttl_seconds)
-    else
-        redis.call('DEL', runs_key)
-    end
-
-    redis.call('PUBLISH', state_channel, state_payload)
-    redis.call('DEL', progress_key)
-    if message_id ~= '' then
-        redis.call('XACK', stream_key, worker_group_name, message_id)
-        redis.call('XDEL', stream_key, message_id)
-    end
-
-    return 'OK'
-    """
-    ...
-
-
 def get_signature(function: Callable[..., Any]) -> inspect.Signature:
     signature = _uncalled_for_get_signature(function)
     CACHE_SIZE.set(len(_signature_cache), {"cache": "signature"})
@@ -534,6 +201,12 @@ class Disposition(enum.Enum):
 
     STRUCK = "struck"
     """A strike rule blocked the call before any Redis state was touched."""
+
+    SUPERSEDED = "superseded"
+    """A newer schedule already holds this key, so the attempt left it alone.
+    Only possible when the caller states the generation it expects, which
+    ``Perpetual`` does when it reschedules the attempt that just finished;
+    ``Docket.add`` and ``Docket.replace`` never produce it."""
 
     FAILED = "failed"
     """The Redis command scheduling this task returned an error.  Only
@@ -699,7 +372,14 @@ class Execution:
         redelivered: bool = False,
         fallback_task: TaskFunction | None = None,
         message_id: "RedisMessageID | None" = None,
+        sync: bool = True,
     ) -> Self:
+        """Rebuild an execution from the stream message that carries it.
+
+        ``sync`` reads the current lifecycle state back from Redis.  A worker
+        about to claim the task passes ``sync=False``, because ``claim()``
+        fills in the same attributes from its own reply a moment later.
+        """
         function_name = message[b"function"].decode()
         if not (function := docket.tasks.get(function_name)):
             if fallback_task is None:
@@ -722,7 +402,8 @@ class Execution:
             generation=int(message.get(b"generation", b"0")),
             message_id=message_id,
         )
-        await instance.sync()
+        if sync:
+            await instance.sync()
         return instance
 
     def general_labels(self) -> Mapping[str, str]:
@@ -770,7 +451,10 @@ class Execution:
         return [trace.Link(initiating_context)] if initiating_context.is_valid else []
 
     async def schedule(
-        self, replace: bool = False, reschedule_message: "RedisMessageID | None" = None
+        self,
+        replace: bool = False,
+        reschedule_message: "RedisMessageID | None" = None,
+        expected_generation: int = 0,
     ) -> Disposition:
         """Schedule this task atomically in Redis.
 
@@ -794,18 +478,21 @@ class Execution:
             reschedule_message: If provided, atomically acknowledges and deletes
                     this stream message ID before rescheduling the task to the queue.
                     Used when a task needs to be rescheduled from an active stream message.
+            expected_generation: The generation the caller believes holds this
+                    key.  When it is non-zero and Redis holds a newer one, the
+                    script leaves the key alone.  0 skips the check.
 
         Returns:
             ``Disposition.SCHEDULED`` if the task was placed on the queue/stream,
-            or ``Disposition.ALREADY_SCHEDULED`` if a task with the same key was
+            ``Disposition.ALREADY_SCHEDULED`` if a task with the same key was
             already known and ``replace=False`` (in which case the existing
-            schedule is preserved and no local state changes are published).
+            schedule is preserved and no local state changes are published),
+            or ``Disposition.SUPERSEDED`` if ``expected_generation`` was stale.
             Sets ``self.disposition`` to the same value.
         """
         script_args, is_immediate = self._schedule_script_args(
-            replace, reschedule_message
+            replace, reschedule_message, expected_generation
         )
-
         async with self.docket.redis() as redis:
             reply = await _schedule(redis, **script_args)
 
@@ -815,6 +502,7 @@ class Execution:
         self,
         replace: bool,
         reschedule_message: "RedisMessageID | None" = None,
+        expected_generation: int = 0,
     ) -> tuple[dict[str, Any], bool]:
         """Build the keyword arguments for one ``_schedule`` script invocation.
 
@@ -863,6 +551,7 @@ class Execution:
             "is_immediate": is_immediate,
             "replace": replace,
             "reschedule_message_id": reschedule_message or b"",
+            "expected_generation": expected_generation,
             "worker_group_name": self.docket.worker_group_name,
             "state_payload": state_payload,
             "message": message,
@@ -876,6 +565,12 @@ class Execution:
         reschedule_message: "RedisMessageID | None" = None,
     ) -> Disposition:
         """Fold one ``_schedule`` script reply back into this execution."""
+        if reply in (b"SUPERSEDED", "SUPERSEDED"):
+            # A newer generation holds the key and the script left it alone,
+            # so this execution never became real anywhere.
+            self.disposition = Disposition.SUPERSEDED
+            return self.disposition
+
         if reply in (b"EXISTS", "EXISTS"):
             # An existing schedule for this key remains untouched; leave local
             # state alone and do not publish a misleading state event.
@@ -906,6 +601,15 @@ class Execution:
         - Initializes progress tracking (current=0, total=100)
         - Deletes known/stream_id fields to allow task rescheduling
         - Cleans up legacy keys for backwards compatibility
+        - Reads the runs hash and the progress hash back
+
+        The script returns those two hashes as they stand when it finishes, so
+        the claim leaves this execution's lifecycle attributes exactly where a
+        ``sync()`` would.  That holds on both paths: a claimed task reports its
+        own running state and reset progress, and a refused one reports what
+        the newer generation left on the key (or the ``sync()`` defaults, if
+        the key is gone).  Callers on the delivery path can therefore skip the
+        ``sync()`` in ``from_message`` and let the claim fill the attributes in.
 
         Args:
             worker: Name of the worker claiming the task
@@ -930,7 +634,7 @@ class Execution:
 
         with self._maybe_suppress_instrumentation():
             async with self.docket.redis() as redis:
-                result = await _claim(
+                status, runs_data, progress_data = await _claim(
                     redis,
                     runs_key=self._redis_key,
                     progress_key=self.progress._redis_key,
@@ -946,18 +650,15 @@ class Execution:
                     message_id=self.message_id or b"",
                 )
 
-        if result == b"SUPERSEDED":
+        self._apply_runs_data(_hash_reply(runs_data))
+        self.progress._apply(_hash_reply(progress_data))  # pyright: ignore[reportPrivateUsage]
+
+        if status == b"SUPERSEDED":
             # The `_claim` Lua XACKed and XDELed the stale stream message
             # before returning SUPERSEDED (skipping the ack when message_id
             # is empty -- harmless either way).
             self._acked = True
             return False
-
-        self.state = ExecutionState.RUNNING
-        self.worker = worker
-        self.started_at = started_at
-        self.progress.current = 0
-        self.progress.total = 100
 
         return True
 
@@ -1170,27 +871,18 @@ class Execution:
         # No result stored - task returned None
         return None
 
-    async def sync(self) -> None:
-        """Synchronize instance attributes with current execution data from Redis.
+    def _apply_runs_data(self, data: Mapping[bytes, bytes]) -> None:
+        """Take the lifecycle attributes from one read of the runs hash.
 
-        Updates self.state, execution metadata, and progress data from Redis.
-        Sets attributes to None if no data exists.  No branch sits between the
-        two reads, so the runs hash and the progress hash go out together.
+        An empty hash means Redis holds nothing for this key, so everything
+        goes back to the defaults of a task that has not started.  A hash
+        without a ``state`` field leaves the current state alone.
         """
-        with self._maybe_suppress_instrumentation():
-            async with self.docket.redis() as redis:
-                async with redis.pipeline() as pipe:
-                    pipe.hgetall(self._redis_key)
-                    self.progress._read(pipe)  # pyright: ignore[reportPrivateUsage]
-                    data, progress_data = await pipe.execute()
-
         if data:
-            # Update state
             state_value = data.get(b"state")
             if state_value:
                 self.state = ExecutionState(state_value.decode())
 
-            # Update metadata
             self.worker = data[b"worker"].decode() if b"worker" in data else None
             self.started_at = (
                 datetime.fromisoformat(data[b"started_at"].decode())
@@ -1207,7 +899,6 @@ class Execution:
                 data[b"result_key"].decode() if b"result_key" in data else None
             )
         else:
-            # No data exists - reset to defaults
             self.state = ExecutionState.SCHEDULED
             self.worker = None
             self.started_at = None
@@ -1215,6 +906,21 @@ class Execution:
             self.error = None
             self.result_key = None
 
+    async def sync(self) -> None:
+        """Synchronize instance attributes with current execution data from Redis.
+
+        Updates self.state, execution metadata, and progress data from Redis.
+        Sets attributes to None if no data exists.  No branch sits between the
+        two reads, so the runs hash and the progress hash go out together.
+        """
+        with self._maybe_suppress_instrumentation():
+            async with self.docket.redis() as redis:
+                async with redis.pipeline() as pipe:
+                    pipe.hgetall(self._redis_key)
+                    self.progress._read(pipe)  # pyright: ignore[reportPrivateUsage]
+                    data, progress_data = await pipe.execute()
+
+        self._apply_runs_data(data)
         self.progress._apply(progress_data)  # pyright: ignore[reportPrivateUsage]
 
     async def is_superseded(self) -> bool:

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -689,12 +689,14 @@ class Worker:
             message: RedisMessage,
             is_redelivery: bool = False,
         ) -> None:
+            # No sync: the claim in `_execute` reads the same hashes back.
             execution = await Execution.from_message(
                 self.docket,
                 message,
                 redelivered=is_redelivery,
                 fallback_task=self.fallback_task,
                 message_id=message_id,
+                sync=False,
             )
 
             task = asyncio.create_task(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -7,8 +7,14 @@ from datetime import datetime, timedelta, timezone
 
 from docket import Docket, Worker
 from docket.annotations import Logged
-from docket.dependencies import CurrentDocket, CurrentWorker, Depends
-from docket.execution import Execution, TaskFunction, compact_signature, get_signature
+from docket.dependencies import CurrentDocket, CurrentExecution, CurrentWorker, Depends
+from docket.execution import (
+    Execution,
+    ExecutionState,
+    TaskFunction,
+    compact_signature,
+    get_signature,
+)
 
 
 async def no_args() -> None: ...  # pragma: no cover
@@ -186,3 +192,66 @@ async def test_schedule_does_not_wait_on_a_per_key_lock(docket: Docket):
 
     snapshot = await docket.snapshot()
     assert [execution.key for execution in snapshot.future] == ["unblocked"]
+
+
+def lifecycle_attributes(execution: Execution) -> dict[str, object]:
+    """The attributes a claim or a sync fills in from Redis."""
+    return {
+        "state": execution.state,
+        "worker": execution.worker,
+        "started_at": execution.started_at,
+        "completed_at": execution.completed_at,
+        "error": execution.error,
+        "result_key": execution.result_key,
+        "current": execution.progress.current,
+        "total": execution.progress.total,
+        "message": execution.progress.message,
+        "updated_at": execution.progress.updated_at,
+    }
+
+
+async def test_the_claimed_execution_matches_a_synced_one(
+    docket: Docket, worker: Worker
+):
+    """The task body sees exactly what a sync of the same message would report."""
+    seen: list[tuple[dict[str, object], dict[str, object]]] = []
+
+    async def report(execution: Execution = CurrentExecution()) -> None:
+        async with docket.redis() as redis:
+            messages = await redis.xrange(docket.stream_key, count=1)
+        _, message = messages[0]
+        synced = await Execution.from_message(docket, message)
+        seen.append((lifecycle_attributes(execution), lifecycle_attributes(synced)))
+
+    await docket.add(report, key="claimed")()
+
+    await worker.run_until_finished()
+
+    claimed, synced = seen[0]
+    assert claimed == synced
+
+
+async def test_a_refused_claim_reports_what_redis_holds(docket: Docket):
+    """A superseded execution shows the state of the key it lost, not stale defaults."""
+    await docket.add(no_args, key="refused")()
+
+    async with docket.redis() as redis:
+        messages = await redis.xrange(docket.stream_key, count=1)
+    _, message = messages[0]
+    stale = await Execution.from_message(docket, message)
+
+    await docket.replace(no_args, datetime.now(timezone.utc), "refused")()
+
+    assert not await stale.claim("worker-1")
+    assert lifecycle_attributes(stale) == {
+        "state": ExecutionState.QUEUED,
+        "worker": None,
+        "started_at": None,
+        "completed_at": None,
+        "error": None,
+        "result_key": None,
+        "current": None,
+        "total": 100,
+        "message": None,
+        "updated_at": None,
+    }

--- a/tests/test_perpetual_reliability.py
+++ b/tests/test_perpetual_reliability.py
@@ -157,8 +157,8 @@ async def test_chain_survives_on_complete_failure_in_failure_path_no_retry(
 
 async def test_chain_survives_replace_failure_inside_on_complete(docket: Docket):
     """A more targeted failure than patching ``on_complete`` itself: simulate
-    a Redis outage on the ``Docket.replace`` call that ``Perpetual.on_complete``
-    makes at ``_perpetual.py:132``. Because ``replace`` fails on every call
+    a Redis outage on the ``Docket._replace`` call that ``Perpetual.on_complete``
+    makes to schedule the next run. Because ``replace`` fails on every call
     during worker_a's run, both the success-path ``on_complete`` and the
     in-place recovery's repeat call fail, the worker dies; redelivery brings
     the message back; once the patch is gone, ``replace`` works and the chain
@@ -177,13 +177,14 @@ async def test_chain_survives_replace_failure_inside_on_complete(docket: Docket)
         function: TaskFunction | str,
         when: datetime,
         key: str,
+        expected_generation: int = 0,
     ) -> Callable[..., Awaitable[Execution]]:
         raise ConnectionError("simulated Redis blip during docket.replace")
 
     async with Worker(
         docket, redelivery_timeout=timedelta(milliseconds=200)
     ) as worker_a:
-        with patch.object(Docket, "replace", crashing_replace):
+        with patch.object(Docket, "_replace", crashing_replace):
             with pytest.raises(ExceptionGroup):
                 await worker_a.run_until_finished()
         assert len(executions) == 1

--- a/tests/test_perpetual_reschedule.py
+++ b/tests/test_perpetual_reschedule.py
@@ -1,0 +1,97 @@
+"""Whether a finished Perpetual schedules its own next run.
+
+``Perpetual.on_complete`` reschedules under the generation of the attempt
+that just ran, so one script both checks who holds the key and, when nobody
+else has taken it, schedules the successor.
+"""
+
+import asyncio
+import contextlib
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, call
+
+import pytest
+from opentelemetry.metrics import Counter
+
+from docket import Docket, Perpetual, Worker
+from tests.conftest import wait_until
+
+
+async def test_a_replaced_perpetual_does_not_reschedule_itself(
+    docket: Docket, worker: Worker, monkeypatch: pytest.MonkeyPatch
+):
+    """A Perpetual replaced while it runs leaves the replacement's time alone."""
+    superseded = Mock(spec=Counter.add)
+    monkeypatch.setattr("docket.instrumentation.TASKS_SUPERSEDED.add", superseded)
+
+    running = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def slow_perpetual(
+        perpetual: Perpetual = Perpetual(every=timedelta(hours=1)),
+    ):
+        running.set()
+        await asyncio.wait_for(finish.wait(), timeout=10)
+
+    key = "replaced-mid-run"
+    await docket.add(slow_perpetual, key=key)()
+
+    worker_task = asyncio.create_task(worker.run_until_finished())
+    await asyncio.wait_for(running.wait(), timeout=10)
+
+    replacement = datetime.now(timezone.utc) + timedelta(hours=3)
+    await docket.replace(slow_perpetual, replacement, key)()
+    finish.set()
+
+    await wait_until(lambda: superseded.called, description="the superseded branch")
+    worker_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker_task
+
+    snapshot = await docket.snapshot()
+    assert [(e.key, e.when) for e in snapshot.future] == [(key, replacement)]
+    assert superseded.call_args == call(
+        1,
+        {
+            "docket.name": docket.name,
+            "docket.worker": worker.name,
+            "docket.task": "slow_perpetual",
+            "docket.where": "on_complete",
+        },
+    )
+
+
+async def test_an_untouched_perpetual_reschedules_itself(
+    docket: Docket, worker: Worker
+):
+    """A Perpetual nobody replaced schedules its own next run."""
+    finished = asyncio.Event()
+
+    async def hourly_perpetual(
+        perpetual: Perpetual = Perpetual(every=timedelta(hours=1)),
+    ):
+        finished.set()
+
+    key = "untouched"
+    before = datetime.now(timezone.utc)
+    await docket.add(hourly_perpetual, key=key)()
+
+    worker_task = asyncio.create_task(worker.run_until_finished())
+    await asyncio.wait_for(finished.wait(), timeout=10)
+
+    async def successor_is_queued() -> bool:
+        return bool((await docket.snapshot()).future)
+
+    await wait_until(successor_is_queued, description="the successor's schedule")
+    worker_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await worker_task
+
+    snapshot = await docket.snapshot()
+    (successor,) = snapshot.future
+    assert successor.key == key
+    assert (
+        before + timedelta(minutes=59)
+        < successor.when
+        < before + timedelta(hours=1, minutes=1)
+    )

--- a/tests/test_task_cycle_round_trips.py
+++ b/tests/test_task_cycle_round_trips.py
@@ -1,0 +1,155 @@
+"""How many Redis round-trips one task cycle costs.
+
+A worker pays for every round-trip twice: about half a millisecond of Python
+in redis-py and asyncio, and another Redis call the server has to serialize
+against everything else on the key.  These tests pin the count for the two
+shapes that matter, a plain task and a Perpetual that reschedules itself, so
+a round-trip cannot creep back in unnoticed.
+"""
+
+# pyright: reportPrivateUsage=false
+
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any, AsyncGenerator
+
+from docket import Docket, Perpetual, Worker
+from docket._execution_scripts import _claim, _schedule, _terminal
+from tests.conftest import wait_until
+
+SCRIPT_NAMES = {
+    _claim.sha: "claim",
+    _schedule.sha: "schedule",
+    _terminal.sha: "terminal",
+}
+
+
+class RecordingClient:
+    """A Redis client that appends ``(command, arguments)`` for every call.
+
+    Wraps rather than replaces the real client, so the commands still run.
+    Pipelines come back wrapped too, because a pipelined read is a read.
+    """
+
+    def __init__(self, client: Any, calls: list[tuple[str, tuple[Any, ...]]]) -> None:
+        self._client = client
+        self._calls = calls
+
+    def __getattr__(self, name: str) -> Any:
+        # Docket only ever calls methods on a client, so every attribute that
+        # reaches here is one.
+        attribute = getattr(self._client, name)
+
+        def recording(*args: Any, **kwargs: Any) -> Any:
+            self._calls.append((name, args))
+            result = attribute(*args, **kwargs)
+            return (
+                RecordingClient(result, self._calls) if name == "pipeline" else result
+            )
+
+        return recording
+
+    async def __aenter__(self) -> "RecordingClient":
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, *exception: Any) -> Any:
+        return await self._client.__aexit__(*exception)
+
+
+@asynccontextmanager
+async def recording_commands(
+    docket: Docket, key: str
+) -> AsyncGenerator[list[str], None]:
+    """Name every command that touches ``key``'s runs or progress hash.
+
+    Script calls are named for the script they run, so the list reads as the
+    sequence of round-trips one task key cost.  It is filled when the block
+    closes, so assert on it after the block, not inside.
+    """
+    # Prime the server's script cache.  A script the server has never seen
+    # costs a second EVALSHA after the NOSCRIPT reload, which is a one-time
+    # cost of the fresh backend, not of the task cycle under test.
+    async with docket.redis() as redis:
+        for script in (_claim, _schedule, _terminal):
+            await redis.script_load(script.lua)
+
+    task_keys = {docket.key(f"runs:{key}"), docket.key(f"progress:{key}")}
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+    commands: list[str] = []
+    real_redis = docket.redis
+
+    @asynccontextmanager
+    async def recording_redis() -> AsyncGenerator[RecordingClient, None]:
+        async with real_redis() as client:
+            yield RecordingClient(client, calls)
+
+    docket.redis = recording_redis  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        yield commands
+    finally:
+        del docket.redis
+        commands.extend(
+            SCRIPT_NAMES.get(arguments[0], command)
+            for command, arguments in calls
+            if task_keys & {a for a in arguments if isinstance(a, str)}
+        )
+
+
+async def test_a_plain_task_costs_two_round_trips(docket: Docket, worker: Worker):
+    """Claiming and finishing a task is the whole cost of running it."""
+
+    async def plain_task() -> None:
+        pass
+
+    await docket.add(plain_task, key="plain")()
+
+    async with recording_commands(docket, "plain") as commands:
+        await worker.run_until_finished()
+
+    assert commands == ["claim", "terminal"]
+
+
+async def test_a_perpetual_cycle_costs_three_round_trips(
+    docket: Docket, worker: Worker
+):
+    """A Perpetual adds its own reschedule, and nothing else, to the cycle.
+
+    Two cycles, six round-trips.  A cycle's terminal can land after the next
+    cycle's claim, so the assertion counts the commands rather than ordering
+    them.
+    """
+    runs: list[int] = []
+
+    async def perpetual_task(
+        perpetual: Perpetual = Perpetual(every=timedelta(0)),
+    ) -> None:
+        runs.append(len(runs))
+        if len(runs) == 2:
+            perpetual.after(timedelta(hours=1))
+
+    await docket.add(perpetual_task, key="perpetual")()
+
+    async def both_cycles_have_finished() -> bool:
+        # An empty stream means the second cycle's terminal has ACKed and
+        # deleted its message; the third is an hour away in the queue.
+        async with docket.redis() as redis:
+            return len(runs) == 2 and await redis.xlen(docket.stream_key) == 0
+
+    async with recording_commands(docket, "perpetual") as commands:
+        worker_task = asyncio.create_task(worker.run_until_finished())
+        await wait_until(both_cycles_have_finished, description="two cycles")
+        worker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker_task
+
+    assert sorted(commands) == [
+        "claim",
+        "claim",
+        "schedule",
+        "schedule",
+        "terminal",
+        "terminal",
+    ]


### PR DESCRIPTION
A task cycle cost five Redis round trips: a read before the claim, the claim, a read before the reschedule, the reschedule, and the terminal write. Two of those reads did work the scripts could return themselves.

The claim script now returns the runs hash and the progress hash on every path, so the worker skips the separate `sync()` it used to run right before claiming. The schedule script takes an expected generation, so `Perpetual.on_complete` folds its supersession check into the reschedule instead of reading the generation first. That brings the cycle down to three round trips.

The scripts move to a new `_execution_scripts` module, which also keeps `execution.py` and `docket.py` under their size limits.

## Compatibility

This changes the `_claim` and `_schedule` Lua scripts. No data-model keys change: the same runs hash, progress hash, queue, and stream carry the same fields as before. The concern is a rolling deploy where old and new worker versions run against the **same** Redis at once.

**Both script versions coexist.** redis-py loads each script by the SHA of its source, so an old worker calls the old `_claim`/`_schedule` by their SHAs and a new worker calls the new ones by theirs. Redis keeps both cached. Neither version's `EVALSHA` disturbs the other, and there is no shared script state to migrate.

**A task claimed by one version and completed by another.** Claim and completion both key off the `generation` counter in the runs hash, and that counter is unchanged. The new `_claim` writes exactly the same `state`, `worker`, `started_at`, and progress fields as the old one; its only addition is returning the runs and progress hashes in the reply. So a task the old `_claim` started completes correctly under the new `_terminal`, and vice versa. `_terminal` itself is byte-for-byte the same script as on `main`; it just lives in a new module.

**Return-shape change is caller-local.** The old `_claim` returned a bare status; the new one returns `{status, runs_hash, progress_hash}`. Only the caller that invoked a given SHA reads that SHA's reply, so the new reply shape is only ever parsed by the new `Execution.claim` that asked for it. An old worker never sees the new shape, and a new worker never sees the old one. The same holds for the worker's `sync=False`: it only skips the pre-claim read on the new path, where the new `_claim` fills those fields in from its reply.

**`expected_generation` degrades safely.** The new `_schedule` takes an optional expected generation and reports `SUPERSEDED` when the stored generation is newer. Only `Perpetual.on_complete` passes a non-zero value, through the new `Docket._replace`; every other caller (including `Docket.replace`, `add`, and the `schedule_many` batch path) passes 0, which skips the check and preserves the old behavior exactly. An old worker's `_schedule` has no such parameter and behaves as it always did. If a new worker schedules with a generation check and an old worker later claims the result, the old `_claim` still does its own generation comparison, so supersession stays correct regardless of which version handled the schedule.

**Ordering.** No constraint. Workers can be upgraded in any order, and mixed versions can run indefinitely against the same Redis. No migration step and no data backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)