### PR TITLE
Survive Redis disruptions instead of dying or going invisible

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1426
+max_lines = 1424
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1423
+max_lines = 1426
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -39,7 +39,7 @@ from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import PubSub
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, TimeoutError
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -71,6 +71,13 @@ CONNECT_TIMEOUT: float = 10.0
 # https://github.com/redis/hiredis-py/issues/235
 # https://github.com/redis/hiredis-py/pull/239
 PUBSUB_RESP_VERSION: int = 2
+
+# Losing Redis reaches a caller two ways: the socket breaks, or a read or a
+# connect runs out of time.  redis-py raises ConnectionError for the first and
+# TimeoutError for the second, and neither is a subclass of the other, so the
+# code that reconnects catches both.
+Disconnected: TypeAlias = ConnectionError | TimeoutError
+DISCONNECTED = (ConnectionError, TimeoutError)
 
 
 # ---------------------------------------------------------------------------

--- a/src/docket/dependencies/_perpetual.py
+++ b/src/docket/dependencies/_perpetual.py
@@ -16,12 +16,26 @@ from ._base import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
+    from .._redis import RedisClient
+    from ..docket import Docket
     from ..execution import Execution
 
 from ..execution import Disposition
 from ..instrumentation import TASKS_PERPETUATED, TASKS_SUPERSEDED
 
 logger = logging.getLogger("docket.dependencies")
+
+
+async def perpetual_is_live(docket: Docket, redis: RedisClient, key: str) -> bool:
+    """Whether an automatic perpetual already has a live schedule entry.
+
+    Mirrors the dedup in the scheduling script: a task is live when it's parked
+    or queued (``known`` is set) or currently running.
+    """
+    runs_key = docket.runs_key(key)
+    if (await redis.hget(runs_key, "known")) is not None:
+        return True
+    return (await redis.hget(runs_key, "state")) == b"running"
 
 
 class Perpetual(CompletionHandler["Perpetual"]):

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -37,7 +37,7 @@ from opentelemetry.trace import Status, StatusCode, Tracer
 from ._cancellation import CANCEL_MSG_CLEANUP, _wait_for_event, cancel_task
 from ._lua import Arg, Key, redis_script
 from ._redelivery import RedeliverySweep, renew_leases
-from ._redis import RedisClient
+from ._redis import DISCONNECTED, Disconnected, RedisClient
 from ._telemetry import suppress_instrumentation
 from redis.asyncio import Redis
 from redis.exceptions import ConnectionError, LockError, ResponseError
@@ -63,6 +63,7 @@ from .dependencies import (
     get_single_dependency_parameter_of_type,
     resolved_dependencies,
 )
+from .dependencies._perpetual import perpetual_is_live
 from .dependencies._resolution import (
     detect_single_conflicts,
     validate_worker_dependencies,
@@ -327,7 +328,8 @@ class Worker:
         self._stack.callback(lambda: delattr(self, "_tasks_by_key"))
 
         # The heartbeat task is owned by each processing attempt, not the
-        # Worker context.  It starts only after that attempt can claim work.
+        # Worker context.  It starts with that attempt's session and ends
+        # with it.
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._stack.callback(lambda: delattr(self, "_heartbeat_task"))
         self._processing_session: _ProcessingSession | None = None
@@ -568,7 +570,7 @@ class Worker:
                 try:
                     async with self.docket.redis() as redis:
                         return await self._worker_loop(redis, forever=forever)
-                except ConnectionError:
+                except DISCONNECTED:
                     if stopping.is_set():
                         return
                     if not self.docket._redis.is_connected:
@@ -753,8 +755,17 @@ class Worker:
                 if not execution._acked:
                     await execution.mark_as_failed(error=None)
 
-        disconnect: ConnectionError | None = None
+        disconnect: Disconnected | None = None
         try:
+            # The heartbeat says the worker is alive, not that it is ready to
+            # claim work, so it starts with the session and stops with it.  A
+            # worker that reconnects and then waits on its cancellation
+            # subscription is alive, and the fleet has to see that.
+            self._heartbeat_task = asyncio.create_task(
+                self._heartbeat(session),
+                name=f"{self.docket.name} - heartbeat",
+            )
+
             async with AsyncExitStack() as dependency_stack:
                 # Each Dependency class used by a registered task may declare
                 # a ``worker_lifecycle`` classmethod that returns an async
@@ -782,73 +793,80 @@ class Worker:
                         session.stopping.set()
                         return
                     if self.schedule_automatic_tasks:
-                        await self._schedule_all_automatic_perpetual_tasks()
-                        infra.create_task(
-                            self._reseed_automatic_perpetual_tasks_loop(),
-                            name=f"{self.docket.name} - automatic perpetual reseed",
-                        )
-                    infra.create_task(
-                        self._scheduler_loop(redis),
-                        name=f"{self.docket.name} - scheduler",
-                    )
-                    infra.create_task(
-                        self._renew_leases(redis, active_tasks),
-                        name=f"{self.docket.name} - lease renewal",
-                    )
-                    self._heartbeat_task = asyncio.create_task(
-                        self._heartbeat(),
-                        name=f"{self.docket.name} - heartbeat",
-                    )
-                    has_work: bool = True
-                    while (
-                        forever or has_work or active_tasks
-                    ) and not stopping.is_set():
-                        await process_completed_tasks()
-                        available_slots = self.concurrency - len(active_tasks)
-                        if available_slots <= 0:
-                            await asyncio.sleep(
-                                self.minimum_check_interval.total_seconds()
-                            )
-                            continue
                         try:
-                            sources = [get_new_deliveries]
-                            with self._maybe_suppress_instrumentation():
-                                sweep_due = await redelivery_sweep.due(redis)
-                            if sweep_due:
-                                sources.insert(0, get_redeliveries)
-                            for source in sources:
-                                for stream_key, messages in await source(redis):
-                                    is_redelivery = stream_key == b"__redelivery__"
-                                    for message_id, message in messages:
-                                        if not message:  # pragma: no cover
-                                            continue
-
-                                        await start_task(
-                                            message_id, message, is_redelivery
-                                        )
-
-                                if available_slots <= 0:
-                                    break
-
-                            if not forever and not active_tasks:
-                                has_work = await check_for_work()
-                        except ConnectionError as error:
-                            # The worker's own polling read lost its connection --
-                            # a failover or a server restart drops a blocked
-                            # XREADGROUP this way.  Stop the loop and let _run
-                            # reconnect; in-flight tasks still drain in the finally
-                            # below.  A ConnectionError raised by a task body
-                            # surfaces through process_completed_tasks instead,
-                            # which stays outside this guard so it keeps its
-                            # die-and-redeliver behavior.
+                            await self._schedule_all_automatic_perpetual_tasks()
+                        except DISCONNECTED as error:
+                            # Seeding lost Redis.  An error escaping the
+                            # TaskGroup body comes back wrapped in an
+                            # ExceptionGroup, which _run's `except DISCONNECTED`
+                            # does not match, so hold it, skip the rest of the
+                            # startup, and re-raise it bare below.
                             disconnect = error
-                            break
+                        else:
+                            infra.create_task(
+                                self._reseed_automatic_perpetual_tasks_loop(),
+                                name=f"{self.docket.name} - automatic perpetual reseed",
+                            )
+                    if disconnect is None:
+                        infra.create_task(
+                            self._scheduler_loop(redis),
+                            name=f"{self.docket.name} - scheduler",
+                        )
+                        infra.create_task(
+                            self._renew_leases(redis, active_tasks),
+                            name=f"{self.docket.name} - lease renewal",
+                        )
+                        has_work: bool = True
+                        while (
+                            forever or has_work or active_tasks
+                        ) and not stopping.is_set():
+                            await process_completed_tasks()
+                            available_slots = self.concurrency - len(active_tasks)
+                            if available_slots <= 0:
+                                await asyncio.sleep(
+                                    self.minimum_check_interval.total_seconds()
+                                )
+                                continue
+                            try:
+                                sources = [get_new_deliveries]
+                                with self._maybe_suppress_instrumentation():
+                                    sweep_due = await redelivery_sweep.due(redis)
+                                if sweep_due:
+                                    sources.insert(0, get_redeliveries)
+                                for source in sources:
+                                    for stream_key, messages in await source(redis):
+                                        is_redelivery = stream_key == b"__redelivery__"
+                                        for message_id, message in messages:
+                                            if not message:  # pragma: no cover
+                                                continue
+
+                                            await start_task(
+                                                message_id, message, is_redelivery
+                                            )
+
+                                    if available_slots <= 0:
+                                        break
+
+                                if not forever and not active_tasks:
+                                    has_work = await check_for_work()
+                            except DISCONNECTED as error:
+                                # The worker's own polling read lost Redis -- a
+                                # failover, a server restart, or a server too busy
+                                # to answer drops a blocked XREADGROUP this way.
+                                # Stop the loop and let _run reconnect; in-flight
+                                # tasks still drain in the finally below.  A
+                                # disconnection raised by a task body surfaces
+                                # through process_completed_tasks instead, which
+                                # stays outside this guard so it keeps its
+                                # die-and-redeliver behavior.
+                                disconnect = error
+                                break
 
                     session.stopping.set()
 
-            # A disconnection in the poll loop above leaves the TaskGroup intact
-            # (no exception escaped it), so re-raise it here as a bare
-            # ConnectionError for _run to catch and reconnect on.
+            # A disconnection caught above leaves the TaskGroup intact (no
+            # exception escaped it), so re-raise it here on its own for _run
+            # to catch and reconnect on.
             if disconnect is not None:
                 raise disconnect
         except asyncio.CancelledError:
@@ -999,24 +1017,13 @@ class Worker:
                             # iterator advances on every call, so reseeding a
                             # healthy cron would drift its schedule into the
                             # future.  Only touch a task once its chain is gone.
-                            if await self._automatic_perpetual_is_live(redis, key):
+                            if await perpetual_is_live(self.docket, redis, key):
                                 continue
                             await self.docket.add(
                                 task_function, when=perpetual.initial_when, key=key
                             )()
             except LockError:  # pragma: no cover
                 return
-
-    async def _automatic_perpetual_is_live(self, redis: RedisClient, key: str) -> bool:
-        """Whether an automatic perpetual already has a live schedule entry.
-
-        Mirrors the dedup in the scheduling script: a task is live when it's
-        parked or queued (``known`` is set) or currently running.
-        """
-        runs_key = self.docket.runs_key(key)
-        if (await redis.hget(runs_key, "known")) is not None:
-            return True
-        return (await redis.hget(runs_key, "state")) == b"running"
 
     async def _delete_known_task(self, redis: Redis, execution: Execution) -> None:
         logger.debug("Deleting known task", extra=self._log_context())
@@ -1293,11 +1300,7 @@ class Worker:
                 extra=self._log_context(),
             )
 
-    async def _heartbeat(self) -> None:
-        session = self._processing_session
-        if session is None:
-            return  # pragma: no cover
-
+    async def _heartbeat(self, session: _ProcessingSession) -> None:
         while not session.stopping.is_set():  # pragma: no branch
             try:
                 now = datetime.now(timezone.utc).timestamp()
@@ -1345,7 +1348,7 @@ class Worker:
 
             except asyncio.CancelledError:  # pragma: no cover
                 return
-            except ConnectionError:
+            except DISCONNECTED:
                 REDIS_DISRUPTIONS.add(1, self.labels())
                 logger.exception(
                     "Error sending worker heartbeat",

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -328,8 +328,7 @@ class Worker:
         self._stack.callback(lambda: delattr(self, "_tasks_by_key"))
 
         # The heartbeat task is owned by each processing attempt, not the
-        # Worker context.  It starts with that attempt's session and ends
-        # with it.
+        # Worker context.  It starts only after that attempt can claim work.
         self._heartbeat_task: asyncio.Task[None] | None = None
         self._stack.callback(lambda: delattr(self, "_heartbeat_task"))
         self._processing_session: _ProcessingSession | None = None
@@ -757,15 +756,6 @@ class Worker:
 
         disconnect: Disconnected | None = None
         try:
-            # The heartbeat says the worker is alive, not that it is ready to
-            # claim work, so it starts with the session and stops with it.  A
-            # worker that reconnects and then waits on its cancellation
-            # subscription is alive, and the fleet has to see that.
-            self._heartbeat_task = asyncio.create_task(
-                self._heartbeat(session),
-                name=f"{self.docket.name} - heartbeat",
-            )
-
             async with AsyncExitStack() as dependency_stack:
                 # Each Dependency class used by a registered task may declare
                 # a ``worker_lifecycle`` classmethod that returns an async
@@ -815,6 +805,10 @@ class Worker:
                         infra.create_task(
                             self._renew_leases(redis, active_tasks),
                             name=f"{self.docket.name} - lease renewal",
+                        )
+                        self._heartbeat_task = asyncio.create_task(
+                            self._heartbeat(),
+                            name=f"{self.docket.name} - heartbeat",
                         )
                         has_work: bool = True
                         while (
@@ -1300,7 +1294,11 @@ class Worker:
                 extra=self._log_context(),
             )
 
-    async def _heartbeat(self, session: _ProcessingSession) -> None:
+    async def _heartbeat(self) -> None:
+        session = self._processing_session
+        if session is None:
+            return  # pragma: no cover
+
         while not session.stopping.is_set():  # pragma: no branch
             try:
                 now = datetime.now(timezone.utc).timestamp()

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -32,9 +32,15 @@ async def test_worker_context_without_processing_loop_is_not_announced(
     assert {worker.name for worker in snapshot.workers} == set()
 
 
-async def test_worker_waits_for_cancellation_readiness_before_announcement(
+async def test_worker_is_announced_before_it_can_claim_work(
     docket: Docket,
 ):
+    """A worker announces itself as soon as it has a processing session.
+
+    The workers set is liveness, not readiness.  A worker waiting on its
+    cancellation subscription is alive, and a fleet that could not see it
+    would treat it as dead.
+    """
     heartbeat = timedelta(milliseconds=20)
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
@@ -75,7 +81,7 @@ async def test_worker_waits_for_cancellation_readiness_before_announcement(
                 worker_run.cancel()
                 await asyncio.gather(worker_run, return_exceptions=True)
 
-    assert {worker.name for worker in snapshot.workers} == set()
+    assert {worker.name for worker in snapshot.workers} == {"not-ready-worker"}
     assert task_complete
 
 
@@ -94,7 +100,7 @@ async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket)
             scheduling_resolution=timedelta(milliseconds=5),
         ) as worker:
 
-            async def blocked_heartbeat() -> None:
+            async def blocked_heartbeat(session: _ProcessingSession) -> None:
                 heartbeat_started.set()
                 try:
                     await asyncio.Event().wait()
@@ -226,7 +232,7 @@ async def test_heartbeat_recovers_from_connection_error(docket: Docket):
         worker._processing_session = session  # pyright: ignore[reportPrivateUsage]
         with patch.object(Docket, "redis", flaky_redis):
             heartbeat_task = asyncio.create_task(
-                worker._heartbeat()  # pyright: ignore[reportPrivateUsage]
+                worker._heartbeat(session)  # pyright: ignore[reportPrivateUsage]
             )
             try:
                 await wait_until(

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -32,15 +32,9 @@ async def test_worker_context_without_processing_loop_is_not_announced(
     assert {worker.name for worker in snapshot.workers} == set()
 
 
-async def test_worker_is_announced_before_it_can_claim_work(
+async def test_worker_waits_for_cancellation_readiness_before_announcement(
     docket: Docket,
 ):
-    """A worker announces itself as soon as it has a processing session.
-
-    The workers set is liveness, not readiness.  A worker waiting on its
-    cancellation subscription is alive, and a fleet that could not see it
-    would treat it as dead.
-    """
     heartbeat = timedelta(milliseconds=20)
     docket.heartbeat_interval = heartbeat
     docket.missed_heartbeats = 3
@@ -81,7 +75,7 @@ async def test_worker_is_announced_before_it_can_claim_work(
                 worker_run.cancel()
                 await asyncio.gather(worker_run, return_exceptions=True)
 
-    assert {worker.name for worker in snapshot.workers} == {"not-ready-worker"}
+    assert {worker.name for worker in snapshot.workers} == set()
     assert task_complete
 
 
@@ -100,7 +94,7 @@ async def test_context_exit_cancels_blocked_processing_heartbeat(docket: Docket)
             scheduling_resolution=timedelta(milliseconds=5),
         ) as worker:
 
-            async def blocked_heartbeat(session: _ProcessingSession) -> None:
+            async def blocked_heartbeat() -> None:
                 heartbeat_started.set()
                 try:
                     await asyncio.Event().wait()
@@ -232,7 +226,7 @@ async def test_heartbeat_recovers_from_connection_error(docket: Docket):
         worker._processing_session = session  # pyright: ignore[reportPrivateUsage]
         with patch.object(Docket, "redis", flaky_redis):
             heartbeat_task = asyncio.create_task(
-                worker._heartbeat(session)  # pyright: ignore[reportPrivateUsage]
+                worker._heartbeat()  # pyright: ignore[reportPrivateUsage]
             )
             try:
                 await wait_until(

--- a/tests/worker/test_reconnection.py
+++ b/tests/worker/test_reconnection.py
@@ -1,15 +1,23 @@
-"""Tests for how the worker survives losing its Redis connection."""
+"""Tests for how the worker survives losing its Redis connection.
 
+redis-py reports a lost server two ways: a ConnectionError when the socket
+breaks, and a TimeoutError when a read or a connect runs out of time.  Neither
+is a subclass of the other, so these tests cover both.
+"""
+
+import asyncio
 import sys
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import timedelta
 from typing import Any, AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from docket._redis import RedisClient
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, TimeoutError
 
-from docket import Docket, Worker
+if sys.version_info < (3, 11):  # pragma: no cover
+    from exceptiongroup import ExceptionGroup
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     from asyncio import timeout as async_timeout
@@ -17,8 +25,13 @@ else:  # pragma: no cover
     from async_timeout import timeout as async_timeout
 
 
+from docket import Docket, Perpetual, Worker
+from tests.conftest import wait_until
+
+
+@pytest.mark.parametrize("error", [ConnectionError, TimeoutError])
 async def test_worker_reconnects_when_connection_is_lost(
-    docket: Docket, the_task: AsyncMock
+    docket: Docket, the_task: AsyncMock, error: type[Exception]
 ):
     """The worker should reconnect when the connection is lost"""
     worker = Worker(docket, reconnection_delay=timedelta(milliseconds=100))
@@ -31,7 +44,7 @@ async def test_worker_reconnects_when_connection_is_lost(
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise ConnectionError("Simulated connection error")
+            raise error("Simulated connection error")
         return await original_worker_loop(redis, forever=forever)  # type: ignore[arg-type]
 
     worker._worker_loop = mock_worker_loop  # type: ignore[protected-access]
@@ -45,17 +58,18 @@ async def test_worker_reconnects_when_connection_is_lost(
         the_task.assert_called_once()
 
 
+@pytest.mark.parametrize("error", [ConnectionError, TimeoutError])
 async def test_worker_reconnects_when_main_loop_read_disconnects(
-    docket: Docket, the_task: AsyncMock
+    docket: Docket, the_task: AsyncMock, error: type[Exception]
 ):
-    """A ConnectionError raised by the worker's own blocking read should
+    """A connection error raised by the worker's own blocking read should
     reconnect, not kill the worker.
 
     The main poll loop runs inside a TaskGroup, which re-raises a body
-    exception wrapped in an ExceptionGroup. A failover (or a plain server
-    restart) drops a blocked XREADGROUP with a ConnectionError; the worker must
-    treat that as a disconnection and reconnect rather than dying with an
-    unhandled ExceptionGroup.
+    exception wrapped in an ExceptionGroup. A failover, a plain server
+    restart, or a Redis too busy to answer drops a blocked XREADGROUP; the
+    worker must treat that as a disconnection and reconnect rather than dying
+    with an unhandled ExceptionGroup.
 
     The fault is injected by wrapping the client the worker actually uses, so
     this exercises the real reconnect path on every backend -- standalone,
@@ -74,7 +88,7 @@ async def test_worker_reconnects_when_main_loop_read_disconnects(
         async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
             reads["count"] += 1
             if reads["count"] == 1:
-                raise ConnectionError("Simulated server loss mid-XREADGROUP")
+                raise error("Simulated server loss mid-XREADGROUP")
             return await self._wrapped.xreadgroup(*args, **kwargs)
 
     original_redis = Docket.redis
@@ -116,3 +130,167 @@ async def test_worker_stops_when_the_docket_connection_closes(docket: Docket):
             await worker.run_forever()
 
         await docket._redis.__aenter__()  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_heartbeat_resumes_after_reconnect(docket: Docket):
+    """The worker keeps heartbeating after it reconnects.
+
+    The heartbeat is the worker's liveness, not its readiness.  A worker that
+    reconnects but stops heartbeating leaves the workers set, so
+    `docket.workers()` and every decision that reads that set treat a live
+    worker as dead.  Here the cancellation listener cannot resubscribe after
+    the reconnect, which is the slowest the second pass can be to claim work.
+    """
+    docket.heartbeat_interval = timedelta(milliseconds=20)
+
+    fail_next_read = asyncio.Event()
+    read_failed = asyncio.Event()
+    read_ok = asyncio.Event()
+    fail_pubsub = asyncio.Event()
+
+    class FailNextRead:
+        def __init__(self, wrapped: Any):
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._wrapped, name)
+
+        async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+            if fail_next_read.is_set() and not read_failed.is_set():
+                read_failed.set()
+                raise ConnectionError("Simulated server loss mid-XREADGROUP")
+            result = await self._wrapped.xreadgroup(*args, **kwargs)
+            read_ok.set()
+            return result
+
+    original_redis = Docket.redis
+    original_pubsub = Docket._pubsub  # pyright: ignore[reportPrivateUsage]
+
+    @asynccontextmanager
+    async def flaky_redis(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as redis:
+            yield FailNextRead(redis)  # type: ignore[arg-type]
+
+    @asynccontextmanager
+    async def flaky_pubsub(self: Docket) -> AsyncGenerator[Any, None]:
+        if fail_pubsub.is_set():
+            raise ConnectionError("Simulated server loss on PSUBSCRIBE")
+        async with original_pubsub(self) as pubsub:
+            yield pubsub
+
+    async def worker_is_visible(name: str) -> bool:
+        return any(worker.name == name for worker in await docket.workers())
+
+    async def worker_is_absent(name: str) -> bool:
+        return not await worker_is_visible(name)
+
+    with (
+        patch.object(Docket, "redis", flaky_redis),
+        patch.object(Docket, "_pubsub", flaky_pubsub),
+    ):
+        async with Worker(
+            docket,
+            name="reconnecting-worker",
+            reconnection_delay=timedelta(milliseconds=500),
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+        ) as worker:
+            worker_run = asyncio.create_task(worker.run_forever())
+            try:
+                await wait_until(
+                    lambda: worker_is_visible(worker.name),
+                    timeout=10.0,
+                    description="the first heartbeat",
+                )
+
+                await asyncio.wait_for(read_ok.wait(), timeout=10.0)
+
+                fail_pubsub.set()
+                fail_next_read.set()
+                await asyncio.wait_for(read_failed.wait(), timeout=10.0)
+                await wait_until(
+                    lambda: worker_is_absent(worker.name),
+                    timeout=10.0,
+                    description="the draining worker to leave the workers set",
+                )
+
+                await wait_until(
+                    lambda: worker_is_visible(worker.name),
+                    timeout=10.0,
+                    description="the heartbeat to resume after reconnecting",
+                )
+            finally:
+                worker_run.cancel()
+                with suppress(asyncio.CancelledError):
+                    await worker_run
+
+
+@pytest.mark.parametrize("error", [ConnectionError, TimeoutError])
+async def test_worker_reconnects_when_automatic_seeding_disconnects(
+    docket: Docket, error: type[Exception]
+):
+    """Losing Redis while seeding automatic perpetuals should reconnect.
+
+    The worker seeds its automatic perpetuals inside the TaskGroup that runs
+    its infrastructure, so an error there comes back wrapped in an
+    ExceptionGroup that `except DISCONNECTED` cannot match.  The worker has to
+    reconnect and seed again, not die on its first blip."""
+    calls = 0
+
+    async def automatic_task(
+        perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
+    ):
+        nonlocal calls
+        calls += 1
+
+    docket.register(automatic_task)
+
+    seedings = 0
+    original_seeding = Worker._schedule_all_automatic_perpetual_tasks  # type: ignore[protected-access]
+
+    async def flaky_seeding(self: Worker) -> None:
+        nonlocal seedings
+        seedings += 1
+        if seedings == 1:
+            raise error("Simulated server loss while seeding automatic perpetuals")
+        await original_seeding(self)
+
+    with patch.object(Worker, "_schedule_all_automatic_perpetual_tasks", flaky_seeding):
+        async with Worker(
+            docket, reconnection_delay=timedelta(milliseconds=50)
+        ) as worker:
+            await worker.run_at_most({"automatic_task": 1})
+
+    assert seedings == 2
+    assert calls == 1
+
+    await docket.cancel("automatic_task")
+
+
+async def test_worker_fails_when_automatic_seeding_raises_a_real_error(docket: Docket):
+    """A bug in seeding still fails the worker.
+
+    Only a lost connection earns a reconnect.  Anything else has to reach the
+    caller, so the worker cannot swallow real errors while it handles a lost
+    connection."""
+
+    async def automatic_task(
+        perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
+    ):
+        pass  # pragma: no cover
+
+    docket.register(automatic_task)
+
+    async def broken_seeding(self: Worker) -> None:
+        raise ValueError("a real bug while seeding automatic perpetuals")
+
+    with patch.object(
+        Worker, "_schedule_all_automatic_perpetual_tasks", broken_seeding
+    ):
+        async with Worker(
+            docket, reconnection_delay=timedelta(milliseconds=50)
+        ) as worker:
+            with pytest.raises(ExceptionGroup) as caught:
+                await worker.run_until_finished()
+
+    assert [type(error) for error in caught.value.exceptions] == [ValueError]

--- a/tests/worker/test_reconnection.py
+++ b/tests/worker/test_reconnection.py
@@ -133,13 +133,13 @@ async def test_worker_stops_when_the_docket_connection_closes(docket: Docket):
 
 
 async def test_heartbeat_resumes_after_reconnect(docket: Docket):
-    """The worker keeps heartbeating after it reconnects.
+    """The worker heartbeats again once it has reconnected and is ready.
 
-    The heartbeat is the worker's liveness, not its readiness.  A worker that
-    reconnects but stops heartbeating leaves the workers set, so
-    `docket.workers()` and every decision that reads that set treat a live
-    worker as dead.  Here the cancellation listener cannot resubscribe after
-    the reconnect, which is the slowest the second pass can be to claim work.
+    A worker leaves the workers set while it drains after a disconnect, and
+    it must come back once it can claim work again, or `docket.workers()` and
+    every decision that reads that set treat a live worker as dead.  Here the
+    cancellation listener fails once to resubscribe after the reconnect, so
+    the worker is announced again only after that second attempt succeeds.
     """
     docket.heartbeat_interval = timedelta(milliseconds=20)
 
@@ -147,6 +147,7 @@ async def test_heartbeat_resumes_after_reconnect(docket: Docket):
     read_failed = asyncio.Event()
     read_ok = asyncio.Event()
     fail_pubsub = asyncio.Event()
+    pubsub_failed = asyncio.Event()
 
     class FailNextRead:
         def __init__(self, wrapped: Any):
@@ -173,7 +174,8 @@ async def test_heartbeat_resumes_after_reconnect(docket: Docket):
 
     @asynccontextmanager
     async def flaky_pubsub(self: Docket) -> AsyncGenerator[Any, None]:
-        if fail_pubsub.is_set():
+        if fail_pubsub.is_set() and not pubsub_failed.is_set():
+            pubsub_failed.set()
             raise ConnectionError("Simulated server loss on PSUBSCRIBE")
         async with original_pubsub(self) as pubsub:
             yield pubsub


### PR DESCRIPTION
redis-py raises `TimeoutError`, not `ConnectionError`, when a socket read or a connect runs out of time, and neither is a subclass of the other. A slow Redis raised an uncaught `TimeoutError` that killed the worker. This defines `DISCONNECTED = (ConnectionError, TimeoutError)` and catches it everywhere the worker reconnects: the `_run` reconnect handler, the poll-loop disconnect handler, and the heartbeat's disruption counter. All three keep the same warning, the same `REDIS_DISRUPTIONS` counter, the same reconnection delay, and the same drain-then-reconnect.

Seeding automatic perpetuals runs inside the worker's `TaskGroup`, so a disconnect there escaped as a `BaseExceptionGroup` that the `except DISCONNECTED` reconnect handler did not match, and the worker died on its first blip. A disconnect caught while seeding is now held and re-raised bare after the group, so `_run` reconnects. A non-disconnect error there (a real bug) still propagates and fails the worker.

The automatic-perpetual liveness check moves to the Perpetual module, next to the dedup rule it mirrors.

## Compatibility

No data-model or wire change: no Redis key, stream, sorted set, hash, or message format changes.

No behavior change to worker announcement. The heartbeat still starts only after the cancellation subscription is confirmed, so a worker appears in the `{docket}:workers` set and the task-workers indexes only once it can claim work. The reconnect test covers the case that motivated an earlier version of this change: a worker that reconnects and whose resubscribe fails once comes back into the workers set when its next pass is ready.

Safe in a mixed-version rolling deploy: old and new workers read and write the same keys the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMsrxBxd2yYmx6fxsMooE
