### PR TITLE
Use RESP2 on the pub/sub connections

### DIFF
--- a/.coveragerc-core
+++ b/.coveragerc-core
@@ -14,6 +14,7 @@ omit =
     tests/cli/*.py
     # real-Redis-only; skips on the memory and cluster legs
     tests/test_socket_timeout.py
+    tests/test_pubsub_resp_version.py
 
 [report]
 exclude_also = ["\\.\\.\\.$"]

--- a/loq.toml
+++ b/loq.toml
@@ -26,11 +26,11 @@ max_lines = 1105
 
 [[rules]]
 path = "src/docket/_redis.py"
-max_lines = 969
+max_lines = 996
 
 [[rules]]
 path = "src/docket/dependencies/_concurrency.py"
-max_lines = 867
+max_lines = 862
 
 [[rules]]
 path = "tests/instrumentation/test_counters.py"

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -60,6 +60,18 @@ BLOCKING_READ_SOCKET_TIMEOUT: float | None = None
 # caller (a worker clearing its heartbeat during shutdown, for example).
 CONNECT_TIMEOUT: float = 10.0
 
+# hiredis-py leaks one small list for every RESP3 push reply: it passes a new
+# list to PyList_SetSlice, which does not steal the reference, so nothing ever
+# frees it.  Under RESP3 every pub/sub message is a push reply, and docket's
+# subscribers listen for the life of a worker, so the leak has no bound: about
+# 100 bytes per message until the process dies.  Streams and ordinary commands
+# are not push replies, so only the pub/sub connections drop to RESP2 and the
+# rest of the client keeps whatever redis-py negotiates.  Remove this once
+# hiredis-py releases the fix.
+# https://github.com/redis/hiredis-py/issues/235
+# https://github.com/redis/hiredis-py/pull/239
+PUBSUB_RESP_VERSION: int = 2
+
 
 # ---------------------------------------------------------------------------
 # Input type aliases (mirror redis-py's type domain)
@@ -622,6 +634,8 @@ class RedisConnection:
     # client copies its whole response-callback table, so a client per call
     # costs real CPU.
     _client: Redis | None
+    # Standalone mode: a second pool, at PUBSUB_RESP_VERSION, for pub/sub only
+    _pubsub_pool: ConnectionPool | None
     # Cluster mode: the RedisCluster client for data operations
     _cluster_client: RedisCluster | None
     # Cluster mode: connection pool to a single node for pub/sub (cluster doesn't
@@ -652,6 +666,7 @@ class RedisConnection:
         )
         self._connection_pool = None
         self._client = None
+        self._pubsub_pool = None
         self._cluster_client = None
         self._node_pool = None
         self._node_client = None
@@ -700,6 +715,14 @@ class RedisConnection:
             self._client = Redis(connection_pool=self._connection_pool)
             self._stack.callback(lambda: setattr(self, "_client", None))
             self._stack.push_async_callback(close_resource, self._client, "client")
+
+            self._pubsub_pool = await self._connection_pool_from_url(
+                protocol=PUBSUB_RESP_VERSION
+            )
+            self._stack.callback(lambda: setattr(self, "_pubsub_pool", None))
+            self._stack.push_async_callback(
+                close_resource, self._pubsub_pool, "pub/sub pool"
+            )
 
         return self
 
@@ -819,12 +842,13 @@ class RedisConnection:
             if self._parsed.scheme == "rediss+cluster"
             else Connection,
             decode_responses=False,
+            protocol=PUBSUB_RESP_VERSION,
             socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
             socket_connect_timeout=CONNECT_TIMEOUT,
         )
 
     async def _connection_pool_from_url(
-        self, decode_responses: bool = False
+        self, decode_responses: bool = False, protocol: int | None = None
     ) -> ConnectionPool:
         """Create a Redis connection pool from the URL.
 
@@ -834,6 +858,7 @@ class RedisConnection:
 
         Args:
             decode_responses: If True, decode Redis responses from bytes to strings
+            protocol: The RESP version to negotiate, or None for redis-py's default
 
         Returns:
             A ConnectionPool ready for use with Redis clients
@@ -844,12 +869,14 @@ class RedisConnection:
             return sentinel_connection_pool(
                 self.url,
                 decode_responses=decode_responses,
+                protocol=protocol,
                 socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
                 socket_connect_timeout=CONNECT_TIMEOUT,
             )
         return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
             self.url,
             decode_responses=decode_responses,
+            protocol=protocol,
             socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
             socket_connect_timeout=CONNECT_TIMEOUT,
         )
@@ -890,8 +917,9 @@ class RedisConnection:
             finally:
                 await ps.aclose()
         else:
-            async with require_open(self._client).pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
-                yield cast(PubSubClient, pubsub)
+            async with Redis(connection_pool=require_open(self._pubsub_pool)) as r:
+                async with r.pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
+                    yield cast(PubSubClient, pubsub)
 
     async def publish(self, channel: str, message: str) -> int:
         """Publish a message to a pub/sub channel."""

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -858,25 +858,31 @@ class RedisConnection:
 
         Args:
             decode_responses: If True, decode Redis responses from bytes to strings
-            protocol: The RESP version to negotiate, or None for redis-py's default
+            protocol: The RESP version to negotiate, or None to leave redis-py's
+                default alone.  redis-py 5 and 6 send ``HELLO None`` when the
+                pool carries an explicit ``protocol=None``, so the key is only
+                passed when a version is set.
 
         Returns:
             A ConnectionPool ready for use with Redis clients
         """
+        protocol_kwargs: dict[str, int] = (
+            {"protocol": protocol} if protocol is not None else {}
+        )
         if self.is_sentinel:
             from ._redis_sentinel import sentinel_connection_pool
 
             return sentinel_connection_pool(
                 self.url,
                 decode_responses=decode_responses,
-                protocol=protocol,
+                **protocol_kwargs,
                 socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
                 socket_connect_timeout=CONNECT_TIMEOUT,
             )
         return ConnectionPool.from_url(  # pyright: ignore[reportUnknownMemberType]
             self.url,
             decode_responses=decode_responses,
-            protocol=protocol,
+            **protocol_kwargs,
             socket_timeout=BLOCKING_READ_SOCKET_TIMEOUT,
             socket_connect_timeout=CONNECT_TIMEOUT,
         )

--- a/src/docket/_redis_sentinel.py
+++ b/src/docket/_redis_sentinel.py
@@ -259,6 +259,7 @@ def sentinel_connection_pool(
     url: str,
     *,
     decode_responses: bool,
+    protocol: int | None,
     socket_timeout: float | None,
     socket_connect_timeout: float | None,
 ) -> ConnectionPool:
@@ -273,6 +274,7 @@ def sentinel_connection_pool(
     Args:
         url: The redis+sentinel:// or rediss+sentinel:// URL.
         decode_responses: If True, decode Redis responses from bytes to strings.
+        protocol: The RESP version to negotiate, or None for redis-py's default.
         socket_timeout: The read timeout for data-node connections.
         socket_connect_timeout: The TCP connect timeout for data-node
             connections.
@@ -287,6 +289,7 @@ def sentinel_connection_pool(
     pool_kwargs: dict[str, Any] = {
         "db": config.db,
         "decode_responses": decode_responses,
+        "protocol": protocol,
         "socket_timeout": socket_timeout,
         "socket_connect_timeout": socket_connect_timeout,
         "socket_keepalive": True,

--- a/src/docket/_redis_sentinel.py
+++ b/src/docket/_redis_sentinel.py
@@ -259,7 +259,7 @@ def sentinel_connection_pool(
     url: str,
     *,
     decode_responses: bool,
-    protocol: int | None,
+    protocol: int | None = None,
     socket_timeout: float | None,
     socket_connect_timeout: float | None,
 ) -> ConnectionPool:
@@ -274,7 +274,8 @@ def sentinel_connection_pool(
     Args:
         url: The redis+sentinel:// or rediss+sentinel:// URL.
         decode_responses: If True, decode Redis responses from bytes to strings.
-        protocol: The RESP version to negotiate, or None for redis-py's default.
+        protocol: The RESP version to negotiate, or None to leave redis-py's
+            default alone.
         socket_timeout: The read timeout for data-node connections.
         socket_connect_timeout: The TCP connect timeout for data-node
             connections.
@@ -289,11 +290,14 @@ def sentinel_connection_pool(
     pool_kwargs: dict[str, Any] = {
         "db": config.db,
         "decode_responses": decode_responses,
-        "protocol": protocol,
         "socket_timeout": socket_timeout,
         "socket_connect_timeout": socket_connect_timeout,
         "socket_keepalive": True,
         "socket_keepalive_options": SENTINEL_SOCKET_KEEPALIVE_OPTIONS,
         **config.connection_kwargs,
     }
+    # redis-py 5 and 6 send ``HELLO None`` for an explicit ``protocol=None``, so
+    # the key is only present when a version is set.
+    if protocol is not None:
+        pool_kwargs["protocol"] = protocol
     return OwnedSentinelConnectionPool(config.service_name, sentinel, **pool_kwargs)

--- a/src/docket/dependencies/_concurrency.py
+++ b/src/docket/dependencies/_concurrency.py
@@ -693,8 +693,7 @@ class ConcurrencyLimit(Dependency["ConcurrencyLimit"]):
         publish.
         """
         pattern = f"{docket.prefix}:cancel:*"
-        async with docket.redis() as redis:
-            pubsub = redis.pubsub()
+        async with docket._pubsub() as pubsub:
             try:
                 await pubsub.psubscribe(pattern)
                 async for message in pubsub.listen():
@@ -715,10 +714,6 @@ class ConcurrencyLimit(Dependency["ConcurrencyLimit"]):
             finally:
                 try:
                     await pubsub.punsubscribe(pattern)
-                except Exception:  # pragma: no cover
-                    pass
-                try:
-                    await pubsub.aclose()
                 except Exception:  # pragma: no cover
                     pass
 

--- a/tests/concurrency_limits/test_errors_and_resilience.py
+++ b/tests/concurrency_limits/test_errors_and_resilience.py
@@ -141,10 +141,15 @@ async def test_worker_concurrency_refresh_handles_redis_errors(docket: Docket):
     error_count = 0
     original_redis = docket.redis
 
+    # The third client the worker asks for is the one its heartbeat opens, the
+    # first client a background loop takes after startup.  Failing it exercises
+    # the reconnect path while the task itself still runs to completion.
+    HEARTBEAT_CLIENT = 2
+
     @asynccontextmanager
     async def flaky_redis():
         nonlocal error_count
-        if error_count == 1:
+        if error_count == HEARTBEAT_CLIENT:
             error_count += 1
             raise ConnectionError("Simulated Redis error")
         error_count += 1

--- a/tests/test_pubsub_resp_version.py
+++ b/tests/test_pubsub_resp_version.py
@@ -1,0 +1,42 @@
+"""Regression tests for the RESP version of docket's pub/sub connections.
+
+These need a real, standalone Redis: the memory backend never speaks RESP, and
+cluster mode subscribes through a different pool.  They run on the real-Redis
+legs of the main matrix and across every redis-py major in the test-redis-py
+job.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from typing import cast
+
+from redis.asyncio.connection import AbstractConnection, Connection
+
+from docket.docket import Docket
+from tests.conftest import skip_cluster, skip_memory
+
+
+@skip_memory
+@skip_cluster
+async def test_pubsub_connections_speak_resp2(docket: Docket):
+    """Subscribers must negotiate RESP2, where a message is not a push reply.
+
+    Under RESP3 every pub/sub message arrives as a push reply, and hiredis-py
+    leaks a list for each one.  Docket's subscribers listen for the life of a
+    worker, so that leak has no bound.
+    """
+    async with docket._pubsub() as pubsub:
+        await pubsub.subscribe(docket.key("resp-version"))
+        connection = cast(AbstractConnection, getattr(pubsub, "connection"))
+
+    assert connection.protocol == 2
+
+
+@skip_memory
+@skip_cluster
+async def test_data_connections_keep_the_client_default_resp_version(docket: Docket):
+    """Only pub/sub drops to RESP2; every other command keeps redis-py's default."""
+    assert docket._redis._connection_pool is not None
+    connection = docket._redis._connection_pool.make_connection()
+
+    assert connection.protocol == Connection().protocol

--- a/tests/test_pubsub_resp_version.py
+++ b/tests/test_pubsub_resp_version.py
@@ -35,8 +35,14 @@ async def test_pubsub_connections_speak_resp2(docket: Docket):
 @skip_memory
 @skip_cluster
 async def test_data_connections_keep_the_client_default_resp_version(docket: Docket):
-    """Only pub/sub drops to RESP2; every other command keeps redis-py's default."""
+    """Only pub/sub drops to RESP2; every other command keeps redis-py's default.
+
+    The data pool must not carry an explicit ``protocol`` at all: redis-py 5
+    and 6 turn ``protocol=None`` into a ``HELLO None`` handshake that fails on
+    every connection, which the newer versions mask by normalizing None.
+    """
     assert docket._redis._connection_pool is not None
+    assert "protocol" not in docket._redis._connection_pool.connection_kwargs
     connection = docket._redis._connection_pool.make_connection()
 
     assert connection.protocol == Connection().protocol


### PR DESCRIPTION
hiredis-py leaks a Python list for every RESP3 push reply, and under RESP3
every pub/sub message is a push reply. Docket's subscribers listen for the
life of a worker, so the leak has no bound. hiredis is not a docket
dependency, but `redis[hiredis]` is a common install and redis-py has
defaulted to RESP3 since 8.0.

Pub/sub connections now come from their own pool at RESP2. Streams, commands,
and everything else keep RESP3 and hiredis. The concurrency cancel subscriber
moves onto the same pub/sub path as every other subscriber, which changes how
many clients a worker checks out; the resilience test that injects a Redis
error by counting those checkouts now names the heartbeat's client. Drop the
workaround once hiredis-py releases the fix:
https://github.com/redis/hiredis-py/issues/235
https://github.com/redis/hiredis-py/pull/239

## Measurements

A subscriber on `RedisConnection.pubsub()` receiving 50,000 published
messages of 200 bytes each, against a local Redis 7. RSS is sampled after the
first 5,000 messages and again at the end, so the numbers cover 45,000
messages. hiredis 3.4.1, redis-py 8.1.0, Python 3.13.

| Parser | RESP | Bytes per message | RSS |
| --- | --- | --- | --- |
| hiredis | 3 (before) | 97.2 | 42.4 MiB to 46.6 MiB |
| hiredis | 2 (after) | 0.7 | flat at 42.1 MiB |
| pure Python | 3 | 1.3 | flat at 43.1 MiB |

The pure-Python row is what a default `pip install pydocket` gets today: no
hiredis, no leak. The first row is what `pip install pydocket redis[hiredis]`
got.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01TqNuYs7vKaCFV6ENuUnkBN
