### PR TITLE
Give the redelivery sweep its own claim

### DIFF
--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -1,0 +1,76 @@
+"""How a worker finds messages that another worker abandoned.
+
+A worker sweeps its consumer group's pending list with XAUTOCLAIM to find
+messages that another worker left behind.  ``RedeliverySweep`` owns that claim:
+it bounds each call, keeps the cursor across calls, and creates the consumer
+group again when Redis reports it missing.
+
+Each call claims at most ``REDELIVERY_SCAN_BATCH`` entries, so Redis reads at
+most about ten times that many entries of the pending list per call.  The cost
+of one call stays bounded however long the list grows.
+
+Each call starts where the last one stopped.  A sweep that always restarted at
+``0-0`` would never read the entries past its first window, so those could
+never be redelivered.  The sweep keeps the cursor that XAUTOCLAIM returns.
+Redis returns the cursor ``0-0`` at the end of the pending list, and the next
+call then starts a fresh sweep from the front.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from redis.exceptions import ResponseError
+
+from ._redis import RedisClient, RedisMessages
+from .docket import Docket
+
+# Most entries one XAUTOCLAIM call may claim, and so about a tenth of the
+# entries Redis reads for it.
+REDELIVERY_SCAN_BATCH = 1000
+
+# The cursor Redis returns at the end of the pending list, and the one that
+# starts a fresh sweep from the front.
+SWEEP_START = "0-0"
+
+
+class RedeliverySweep:
+    """A worker's bounded, cursor-kept claim on abandoned messages."""
+
+    def __init__(
+        self,
+        docket: Docket,
+        *,
+        worker_name: str,
+        redelivery_timeout: timedelta,
+    ) -> None:
+        self.docket = docket
+        self.worker_name = worker_name
+        self.min_idle_time = int(redelivery_timeout.total_seconds() * 1000)
+        self.start_id = SWEEP_START
+
+    async def claim(self, redis: RedisClient, available_slots: int) -> RedisMessages:
+        """Claim the messages that another worker has left idle too long.
+
+        The claim starts where the last one stopped, and asks for no more than
+        ``REDELIVERY_SCAN_BATCH`` entries however many slots are free.  A
+        docket that no worker has bootstrapped yet has no consumer group, so a
+        NOGROUP answer means creating the group and claiming again.
+        """
+        try:
+            cursor, redeliveries, *_ = await redis.xautoclaim(
+                name=self.docket.stream_key,
+                groupname=self.docket.worker_group_name,
+                consumername=self.worker_name,
+                min_idle_time=self.min_idle_time,
+                start_id=self.start_id,
+                count=min(available_slots, REDELIVERY_SCAN_BATCH),
+            )
+        except ResponseError as e:
+            if "NOGROUP" in str(e):
+                await self.docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+                return await self.claim(redis, available_slots)
+            raise  # pragma: no cover
+
+        self.start_id = cursor.decode()
+        return redeliveries

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -36,6 +36,7 @@ from opentelemetry.trace import Status, StatusCode, Tracer
 
 from ._cancellation import CANCEL_MSG_CLEANUP, _wait_for_event, cancel_task
 from ._lua import Arg, Key, redis_script
+from ._redelivery import RedeliverySweep
 from ._redis import RedisClient
 from ._telemetry import suppress_instrumentation
 from redis.asyncio import Redis
@@ -607,6 +608,11 @@ class Worker:
         active_tasks: dict[asyncio.Task[None], RedisMessageID] = {}
         task_executions: dict[asyncio.Task[None], Execution] = {}
         available_slots = self.concurrency
+        redelivery_sweep = RedeliverySweep(
+            self.docket,
+            worker_name=self.name,
+            redelivery_timeout=self.redelivery_timeout,
+        )
         log_context = self._log_context()
 
         async def check_for_work() -> bool:
@@ -621,23 +627,10 @@ class Worker:
 
         async def get_redeliveries(redis: Redis) -> RedisReadGroupResponse:
             logger.debug("Getting redeliveries", extra=log_context)
-            try:
-                with self._maybe_suppress_instrumentation():
-                    _, redeliveries, *_ = await redis.xautoclaim(
-                        name=self.docket.stream_key,
-                        groupname=self.docket.worker_group_name,
-                        consumername=self.name,
-                        min_idle_time=int(
-                            self.redelivery_timeout.total_seconds() * 1000
-                        ),
-                        start_id="0-0",
-                        count=available_slots,
-                    )
-            except ResponseError as e:
-                if "NOGROUP" in str(e):
-                    await self.docket._ensure_stream_and_group()
-                    return await get_redeliveries(redis)
-                raise  # pragma: no cover
+            with self._maybe_suppress_instrumentation():
+                redeliveries = await redelivery_sweep.claim(redis, available_slots)
+            # The poll loop reads this sentinel stream name to mark the
+            # messages it starts as redeliveries.
             return [(b"__redelivery__", redeliveries)]
 
         async def get_new_deliveries(redis: Redis) -> RedisReadGroupResponse:

--- a/tests/test_redelivery_sweep.py
+++ b/tests/test_redelivery_sweep.py
@@ -1,0 +1,163 @@
+"""Tests for the bounded, cursor-kept redelivery sweep.
+
+The sweep claims its consumer group's pending list with XAUTOCLAIM to find
+messages another worker abandoned.  Each claim is bounded, and the cursor is
+kept across claims so entries past the first window are still reached.
+"""
+
+import inspect
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from docket import Docket, Worker
+from docket._redelivery import SWEEP_START, RedeliverySweep
+
+
+@pytest.fixture
+def the_task() -> AsyncMock:
+    task = AsyncMock()
+    task.__name__ = "the_task"
+    task.__signature__ = inspect.signature(lambda *args, **kwargs: None)
+    task.return_value = None
+    return task
+
+
+@pytest.fixture
+def sweep(docket: Docket) -> RedeliverySweep:
+    """A sweep that treats every pending message as abandoned.
+
+    A zero timeout means XAUTOCLAIM claims whatever is pending, so a test does
+    not have to wait for messages to go idle.
+    """
+    return RedeliverySweep(
+        docket,
+        worker_name="the-sweeping-worker",
+        redelivery_timeout=timedelta(0),
+    )
+
+
+def test_a_fresh_sweep_starts_at_the_front(sweep: RedeliverySweep):
+    """A sweep that has claimed nothing yet starts at the front of the list."""
+    assert sweep.start_id == SWEEP_START
+
+
+async def abandon_many(docket: Docket, the_task: AsyncMock, count: int) -> None:
+    """Leave ``count`` messages pending under a dead consumer.
+
+    Immediate adds land on the stream.  Reading them into a consumer that never
+    acks them mimics a worker that took the messages and then crashed, so the
+    pending list holds every one for a later sweep to reclaim.
+    """
+    for i in range(count):
+        await docket.add(the_task, key=f"abandoned-{i}")()
+
+    await docket._ensure_stream_and_group()  # pyright: ignore[reportPrivateUsage]
+    async with docket.redis() as redis:
+        await redis.xreadgroup(
+            groupname=docket.worker_group_name,
+            consumername="dead-worker",
+            streams={docket.stream_key: ">"},
+            count=count,
+        )
+
+
+async def test_one_claim_asks_for_no_more_than_the_scan_batch(
+    docket: Docket,
+    sweep: RedeliverySweep,
+    the_task: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A worker with more free slots than one batch still caps its ask.
+
+    Twenty free slots against a scan batch of five claims five, so Redis reads
+    a bounded slice of the pending list however many slots are free.
+    """
+    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
+
+    await abandon_many(docket, the_task, count=20)
+
+    async with docket.redis() as redis:
+        claimed = await sweep.claim(redis, available_slots=20)
+
+    assert len(claimed) == 5
+
+
+async def test_the_kept_cursor_reaches_entries_past_the_first_window(
+    docket: Docket,
+    sweep: RedeliverySweep,
+    the_task: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A second claim picks up where the first one stopped.
+
+    A sweep that restarted at the front every time would claim the same five
+    entries forever, and the rest of the pending list would never be
+    redelivered.
+    """
+    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
+
+    await abandon_many(docket, the_task, count=20)
+
+    async with docket.redis() as redis:
+        first = await sweep.claim(redis, available_slots=5)
+        second = await sweep.claim(redis, available_slots=5)
+
+    first_ids = {message_id for message_id, _ in first}
+    second_ids = {message_id for message_id, _ in second}
+    assert len(first_ids) == 5
+    assert len(second_ids) == 5
+    assert not first_ids & second_ids
+
+
+async def test_reaching_the_end_starts_the_next_sweep_over(
+    docket: Docket, sweep: RedeliverySweep, the_task: AsyncMock
+):
+    """Redis answers with the front of the list once the sweep has read it all."""
+    await abandon_many(docket, the_task, count=5)
+
+    async with docket.redis() as redis:
+        claimed = await sweep.claim(redis, available_slots=20)
+
+    assert len(claimed) == 5
+    assert sweep.start_id == SWEEP_START
+
+
+async def test_a_missing_consumer_group_is_created_and_the_claim_retried(
+    docket: Docket, sweep: RedeliverySweep
+):
+    """A docket that no worker has bootstrapped yet has no consumer group.
+
+    Redis answers NOGROUP, and the sweep creates the group and claims again
+    rather than failing the worker's poll.
+    """
+    async with docket.redis() as redis:
+        assert await sweep.claim(redis, available_slots=10) == []
+
+        groups = await redis.xinfo_groups(docket.stream_key)
+        assert len(groups) == 1
+
+
+async def test_the_worker_redelivers_every_abandoned_message(
+    docket: Docket, the_task: AsyncMock, monkeypatch: pytest.MonkeyPatch
+):
+    """A worker reaches entries past a single bounded claim.
+
+    Shrinking the scan batch to one caps each XAUTOCLAIM at about ten scanned
+    entries, so no single claim can reach the whole list.  The kept cursor
+    walks the rest, so every abandoned message is redelivered and run.
+    """
+    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 1)
+
+    await abandon_many(docket, the_task, count=25)
+
+    async with Worker(
+        docket,
+        redelivery_timeout=timedelta(milliseconds=50),
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert the_task.await_count == 25


### PR DESCRIPTION
XAUTOCLAIM ran on every worker pass and always started at `0-0`, so Redis rescanned the front of the pending list each time and never reached the entries past that first window. Those entries could never be redelivered.

This PR adds a `_redelivery` module whose `RedeliverySweep` owns the claim. Each claim asks for at most `REDELIVERY_SCAN_BATCH` entries, so Redis reads a bounded slice of the pending list per call. The sweep keeps the cursor that XAUTOCLAIM returns, so later claims reach the rest of the list. It also recovers from NOGROUP by creating the stream and consumer group and claiming again.

The worker keeps what is worker policy: it suppresses instrumentation around the claim, and it tags the claimed messages with the sentinel its poll loop reads.

The constructor takes the docket, the worker's consumer name, and the redelivery timeout. That is everything the rest of this stack needs, so the sweep cadence and the fleet lease add behavior without moving the constructor again.

This is PR 1 of a stack unbundling #463. The sweep cadence and the fleet lease come in later PRs.

## Compatibility

No data-model or wire change. The sweep now walks the pending list in bounded steps and reaches the whole list over successive passes; it previously rescanned only the front. Redelivery still triggers on the same `min_idle_time` drawn from `redelivery_timeout`. Safe in a mixed-version rolling deploy: old and new workers share the same stream, consumer group, and XAUTOCLAIM semantics, and differ only in where each worker's own scan starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
