### PR TITLE
Sweep for redeliveries on a jittered timer, not every pass

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -13,7 +13,7 @@ async with Worker(
     docket,
     name="worker-1",                                    # Unique worker identifier
     concurrency=20,                                     # Parallel task limit
-    redelivery_timeout=timedelta(minutes=5),           # When to redeliver tasks
+    redelivery_timeout=timedelta(minutes=5),           # When tasks become redeliverable
     reconnection_delay=timedelta(seconds=5),           # Redis reconnection backoff
     minimum_check_interval=timedelta(milliseconds=100), # Polling frequency
     scheduling_resolution=timedelta(milliseconds=250),  # Future task check frequency
@@ -21,6 +21,8 @@ async with Worker(
 ) as worker:
     await worker.run_forever()
 ```
+
+`redelivery_timeout` sets when a task becomes eligible for redelivery, not when redelivery happens. Each worker sweeps for eligible tasks on a timer at a quarter of the timeout, jittered 0.75–1.25×. A task therefore waits up to about 31% past the timeout before another worker claims it, and usually less.
 
 ### Environment Variable Configuration
 

--- a/loq.toml
+++ b/loq.toml
@@ -14,7 +14,7 @@ max_lines = 1394
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
-max_lines = 945
+max_lines = 950
 
 [[rules]]
 path = "src/docket/execution.py"

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -14,10 +14,23 @@ Each call starts where the last one stopped.  A sweep that always restarted at
 never be redelivered.  The sweep keeps the cursor that XAUTOCLAIM returns.
 Redis returns the cursor ``0-0`` at the end of the pending list, and the next
 call then starts a fresh sweep from the front.
+
+Walking the whole pending list once reads O(pending list) entries, so sweeping
+on every poll pass pins Redis once that list grows large.  A worker sweeps on a
+timer instead, at a quarter of the redelivery timeout.  Each wait is jittered by
+``JITTER`` so a fleet that started together does not sweep in lockstep.  An
+abandoned message therefore waits at most about a jittered quarter of the
+timeout beyond the timeout itself before a sweep reclaims it.
+
+Once a sweep is under way the worker keeps sweeping on every pass until the
+cursor returns to the front, so a long pending list is walked promptly rather
+than one window per timer tick.
 """
 
 from __future__ import annotations
 
+import random
+import time
 from datetime import timedelta
 
 from redis.exceptions import ResponseError
@@ -33,6 +46,10 @@ REDELIVERY_SCAN_BATCH = 1000
 # starts a fresh sweep from the front.
 SWEEP_START = "0-0"
 
+# The narrowest and widest wait between sweeps, as a fraction of the interval.
+# The jitter keeps a fleet that started together from sweeping in lockstep.
+JITTER = (0.75, 1.25)
+
 
 class RedeliverySweep:
     """A worker's bounded, cursor-kept claim on abandoned messages."""
@@ -47,7 +64,21 @@ class RedeliverySweep:
         self.docket = docket
         self.worker_name = worker_name
         self.min_idle_time = int(redelivery_timeout.total_seconds() * 1000)
+        self.interval = redelivery_timeout.total_seconds() / 4
         self.start_id = SWEEP_START
+        # Due immediately, so a worker that replaces a dead one picks up its
+        # messages without waiting a whole interval first.
+        self.next_sweep = time.monotonic()
+
+    @property
+    def due(self) -> bool:
+        """Whether the worker should sweep on this pass.
+
+        A sweep already under way (the cursor is past the front) keeps running
+        on every pass so it finishes quickly.  Otherwise the sweep waits for the
+        jittered timer to elapse.
+        """
+        return self.start_id != SWEEP_START or time.monotonic() >= self.next_sweep
 
     async def claim(self, redis: RedisClient, available_slots: int) -> RedisMessages:
         """Claim the messages that another worker has left idle too long.
@@ -56,6 +87,10 @@ class RedeliverySweep:
         ``REDELIVERY_SCAN_BATCH`` entries however many slots are free.  A
         docket that no worker has bootstrapped yet has no consumer group, so a
         NOGROUP answer means creating the group and claiming again.
+
+        Redis answers with ``SWEEP_START`` at the end of the pending list.  The
+        sweep then arms the next jittered timer, and a later pass starts a fresh
+        sweep from the front once that timer elapses.
         """
         try:
             cursor, redeliveries, *_ = await redis.xautoclaim(
@@ -73,4 +108,6 @@ class RedeliverySweep:
             raise  # pragma: no cover
 
         self.start_id = cursor.decode()
+        if self.start_id == SWEEP_START:
+            self.next_sweep = time.monotonic() + random.uniform(*JITTER) * self.interval
         return redeliveries

--- a/src/docket/cli/__init__.py
+++ b/src/docket/cli/__init__.py
@@ -121,7 +121,12 @@ def worker(
         timedelta,
         typer.Option(
             parser=duration,
-            help="How long to wait before redelivering a task to another worker",
+            help=(
+                "How long a task must sit idle before it becomes eligible for "
+                "redelivery to another worker.  A worker sweeps for eligible "
+                "tasks on a jittered timer at a quarter of this timeout, so "
+                "redelivery lands up to about 31% past it, and usually sooner"
+            ),
             envvar="DOCKET_WORKER_REDELIVERY_TIMEOUT",
         ),
     ] = timedelta(minutes=5),

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -776,7 +776,11 @@ class Worker:
                             )
                             continue
                         try:
-                            for source in [get_redeliveries, get_new_deliveries]:
+                            # Sweep the pending list only when the timer is due.
+                            sources = [get_new_deliveries]
+                            if redelivery_sweep.due:
+                                sources.insert(0, get_redeliveries)
+                            for source in sources:
                                 for stream_key, messages in await source(redis):
                                     is_redelivery = stream_key == b"__redelivery__"
                                     for message_id, message in messages:

--- a/tests/test_redelivery_sweep.py
+++ b/tests/test_redelivery_sweep.py
@@ -2,17 +2,20 @@
 
 The sweep claims its consumer group's pending list with XAUTOCLAIM to find
 messages another worker abandoned.  Each claim is bounded, and the cursor is
-kept across claims so entries past the first window are still reached.
+kept across claims so entries past the first window are still reached.  A
+worker sweeps on a jittered timer rather than on every poll pass, and keeps
+sweeping until the cursor comes back to the front of the list.
 """
 
 import inspect
+import time
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
 
 from docket import Docket, Worker
-from docket._redelivery import SWEEP_START, RedeliverySweep
+from docket._redelivery import JITTER, SWEEP_START, RedeliverySweep
 
 
 @pytest.fixture
@@ -41,6 +44,25 @@ def sweep(docket: Docket) -> RedeliverySweep:
 def test_a_fresh_sweep_starts_at_the_front(sweep: RedeliverySweep):
     """A sweep that has claimed nothing yet starts at the front of the list."""
     assert sweep.start_id == SWEEP_START
+
+
+def a_sweep(docket: Docket, timeout: timedelta) -> RedeliverySweep:
+    """A sweep whose redelivery timeout sets the interval between its sweeps."""
+    return RedeliverySweep(
+        docket,
+        worker_name="the-sweeping-worker",
+        redelivery_timeout=timeout,
+    )
+
+
+def test_the_interval_is_a_quarter_of_the_timeout(docket: Docket):
+    """A worker sweeps four times per redelivery timeout."""
+    assert a_sweep(docket, timedelta(seconds=8)).interval == 2.0
+
+
+def test_the_first_sweep_is_due_immediately(sweep: RedeliverySweep):
+    """A fresh worker sweeps at once, to reclaim a dead worker's messages."""
+    assert sweep.due is True
 
 
 async def abandon_many(docket: Docket, the_task: AsyncMock, count: int) -> None:
@@ -111,6 +133,26 @@ async def test_the_kept_cursor_reaches_entries_past_the_first_window(
     assert not first_ids & second_ids
 
 
+async def test_a_sweep_under_way_stays_due_regardless_of_the_timer(
+    docket: Docket,
+    sweep: RedeliverySweep,
+    the_task: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """While the cursor is past the front the worker sweeps on every pass."""
+    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
+
+    await abandon_many(docket, the_task, count=20)
+
+    async with docket.redis() as redis:
+        await sweep.claim(redis, available_slots=5)
+
+    assert sweep.start_id != SWEEP_START
+    # Push the timer far into the future; the sweep under way is still due.
+    sweep.next_sweep = time.monotonic() + 3600
+    assert sweep.due is True
+
+
 async def test_reaching_the_end_starts_the_next_sweep_over(
     docket: Docket, sweep: RedeliverySweep, the_task: AsyncMock
 ):
@@ -122,6 +164,32 @@ async def test_reaching_the_end_starts_the_next_sweep_over(
 
     assert len(claimed) == 5
     assert sweep.start_id == SWEEP_START
+
+
+async def test_a_completed_sweep_is_not_due_until_the_timer_elapses(docket: Docket):
+    """Between sweeps the worker skips the scan until the timer comes due."""
+    sweep = a_sweep(docket, timedelta(seconds=8))
+
+    async with docket.redis() as redis:
+        await sweep.claim(redis, available_slots=10)
+
+    assert sweep.start_id == SWEEP_START
+    assert sweep.due is False
+
+
+@pytest.mark.parametrize("attempt", range(8))
+async def test_the_next_wait_falls_inside_the_jitter_band(docket: Docket, attempt: int):
+    """After a sweep reaches the front, the next wait lands within the band."""
+    interval = 2.0
+    sweep = a_sweep(docket, timedelta(seconds=interval * 4))
+
+    before = time.monotonic()
+    async with docket.redis() as redis:
+        await sweep.claim(redis, available_slots=10)
+    after = time.monotonic()
+
+    low, high = JITTER
+    assert before + low * interval <= sweep.next_sweep <= after + high * interval
 
 
 async def test_a_missing_consumer_group_is_created_and_the_claim_retried(


### PR DESCRIPTION
A sweep reads O(pending list) entries to walk the whole pending list once, so running one on every poll pass pins Redis once that list grows large.  The sweep now runs on a timer at a quarter of the redelivery timeout, jittered so a fleet that started together does not sweep in lockstep.  A fresh worker still sweeps immediately, and a sweep already under way keeps running each pass until it reaches the front, so a dead worker's messages are reclaimed promptly.

## Compatibility

No data-model or wire change.  Redelivery latency now has a small upper bound: an abandoned message waits at most about a jittered quarter of the timeout beyond the timeout itself before a sweep reclaims it.  Safe in a mixed-version rolling deploy: old workers still sweep on every pass, new workers sweep on the timer, and both are correct.

This is PR 2 of the stack unbundling #463.  The fleet lease is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)