### PR TITLE
Sweep for redeliveries under a fleet-wide lease

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Rich dependency injection supporting:
 - **Sorted Sets**: `{docket}:queue` (scheduled tasks), `{docket}:workers` (heartbeats)
 - **Hashes**: `{docket}:{key}` (parked task data)
 - **Sets**: `{docket}:worker-tasks:{worker}` (worker capabilities)
+- **Strings**: `{docket}:leases:redelivery-sweep` (fleet-wide sweep lease, expiring)
 
 ### Task Lifecycle
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -22,7 +22,7 @@ async with Worker(
     await worker.run_forever()
 ```
 
-`redelivery_timeout` sets when a task becomes eligible for redelivery, not when redelivery happens. Each worker sweeps for eligible tasks on a timer at a quarter of the timeout, jittered 0.75–1.25×. A task therefore waits up to about 31% past the timeout before another worker claims it, and usually less.
+`redelivery_timeout` sets when a task becomes eligible for redelivery, not when redelivery happens. Each worker sweeps for eligible tasks on a timer at a quarter of the timeout, jittered 0.75–1.25×. A task therefore waits up to about 31% past the timeout before another worker claims it, and usually less. A sweep walks a very long pending list in bounded steps, one per poll pass, so that walk can add time beyond that.
 
 ### Environment Variable Configuration
 

--- a/loq.toml
+++ b/loq.toml
@@ -14,7 +14,7 @@ max_lines = 1394
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
-max_lines = 950
+max_lines = 952
 
 [[rules]]
 path = "src/docket/execution.py"
@@ -22,7 +22,7 @@ max_lines = 1336
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 1098
+max_lines = 1105
 
 [[rules]]
 path = "src/docket/_redis.py"

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -22,9 +22,24 @@ timer instead, at a quarter of the redelivery timeout.  Each wait is jittered by
 abandoned message therefore waits at most about a jittered quarter of the
 timeout beyond the timeout itself before a sweep reclaims it.
 
-Once a sweep is under way the worker keeps sweeping on every pass until the
-cursor returns to the front, so a long pending list is walked promptly rather
-than one window per timer tick.
+One sweep costs O(pending list) no matter how many workers run, so the fleet
+sweeps once per interval rather than once per worker.  When a worker's timer
+elapses it takes a fleet-wide lease with ``SET {docket}:leases:redelivery-sweep
+<worker> NX PX <interval>``, and only the worker holding the lease sweeps.  The
+holder keeps it: it refreshes the lease on every pass while its sweep is under
+way, so the lease covers the whole sweep and one worker sweeps at a time even
+on a long pending list.  A worker whose timer fires while its own lease is
+still live keeps that lease, rather than losing the sweep to itself.  Nobody
+deletes the lease; it expires one interval after its last refresh, and that
+expiry is what paces the fleet to at most one sweep per interval.  A worker
+whose lease lapses mid-walk keeps its place in the walk and takes the lease
+again when it can: at once if nobody else has it, or after resting if another
+worker took it, so that worker can walk the list alone.
+
+Once a sweep is under way the worker sweeps on every pass until the cursor
+returns to the front.  Each pass claims no more entries than the worker has
+free slots, so a worker with few free slots takes many passes to walk a long
+pending list.
 """
 
 from __future__ import annotations
@@ -35,6 +50,7 @@ from datetime import timedelta
 
 from redis.exceptions import ResponseError
 
+from ._lua import Arg, Key, redis_script
 from ._redis import RedisClient, RedisMessages
 from .docket import Docket
 
@@ -49,6 +65,23 @@ SWEEP_START = "0-0"
 # The narrowest and widest wait between sweeps, as a fraction of the interval.
 # The jitter keeps a fleet that started together from sweeping in lockstep.
 JITTER = (0.75, 1.25)
+
+
+@redis_script
+async def _refresh_lease(
+    redis: RedisClient,
+    *,
+    lease_key: Key[str],
+    holder: Arg[str],
+    duration_ms: Arg[int],
+) -> int:
+    """
+    if redis.call('GET', lease_key) == holder then
+        return redis.call('PEXPIRE', lease_key, duration_ms)
+    end
+    return 0
+    """
+    ...
 
 
 class RedeliverySweep:
@@ -70,15 +103,56 @@ class RedeliverySweep:
         # messages without waiting a whole interval first.
         self.next_sweep = time.monotonic()
 
-    @property
-    def due(self) -> bool:
+    async def due(self, redis: RedisClient) -> bool:
         """Whether the worker should sweep on this pass.
 
-        A sweep already under way (the cursor is past the front) keeps running
-        on every pass so it finishes quickly.  Otherwise the sweep waits for the
-        jittered timer to elapse.
+        A sweep already under way (the cursor is past the front) sweeps on
+        every pass, and refreshes the lease each time so the lease spans the
+        whole walk.  A worker that lost the lease mid-walk keeps its place and
+        takes the lease again when it can: at once if the lease merely lapsed,
+        or after resting if another worker holds it.
+
+        Otherwise the sweep waits for the jittered timer, and then for the
+        fleet-wide lease: the worker sweeps this interval only if it takes
+        ``SET {docket}:leases:redelivery-sweep worker NX PX interval`` or
+        already holds that lease.  A worker that finds another worker on the
+        lease arms its next timer and waits, rather than spinning.
         """
-        return self.start_id != SWEEP_START or time.monotonic() >= self.next_sweep
+        # A holder mid-walk keeps rolling; refreshing the lease each pass makes
+        # it span the whole walk.  Anyone else goes through the timer and the
+        # lease below, and a worker that lost its lease mid-walk resumes from
+        # its kept place once it takes the lease again.
+        if self.start_id != SWEEP_START and await self._holds_lease(redis):
+            return True
+        if time.monotonic() < self.next_sweep:
+            return False
+        took_lease = await redis.set(
+            self.docket.redelivery_sweep_key,
+            self.worker_name,
+            nx=True,
+            px=int(self.interval * 1000),
+        )
+        if took_lease:
+            return True
+        if await self._holds_lease(redis):
+            return True
+        self._rest()
+        return False
+
+    async def _holds_lease(self, redis: RedisClient) -> bool:
+        """Whether this worker holds the lease, refreshed for another interval.
+
+        The refresh is one script so that reading the holder and extending the
+        lease cannot straddle another worker taking it.  A lease another worker
+        holds is neither extended nor taken.
+        """
+        refreshed = await _refresh_lease(
+            redis,
+            lease_key=self.docket.redelivery_sweep_key,
+            holder=self.worker_name,
+            duration_ms=int(self.interval * 1000),
+        )
+        return bool(refreshed)
 
     async def claim(self, redis: RedisClient, available_slots: int) -> RedisMessages:
         """Claim the messages that another worker has left idle too long.
@@ -109,5 +183,9 @@ class RedeliverySweep:
 
         self.start_id = cursor.decode()
         if self.start_id == SWEEP_START:
-            self.next_sweep = time.monotonic() + random.uniform(*JITTER) * self.interval
+            self._rest()
         return redeliveries
+
+    def _rest(self) -> None:
+        """Hold off the next sweep for a jittered interval."""
+        self.next_sweep = time.monotonic() + random.uniform(*JITTER) * self.interval

--- a/src/docket/cli/__init__.py
+++ b/src/docket/cli/__init__.py
@@ -125,7 +125,9 @@ def worker(
                 "How long a task must sit idle before it becomes eligible for "
                 "redelivery to another worker.  A worker sweeps for eligible "
                 "tasks on a jittered timer at a quarter of this timeout, so "
-                "redelivery lands up to about 31% past it, and usually sooner"
+                "redelivery lands up to about 31% past it, and usually sooner.  "
+                "A sweep walks a very long pending list in bounded steps, one "
+                "per poll pass, so that walk can add time beyond that"
             ),
             envvar="DOCKET_WORKER_REDELIVERY_TIMEOUT",
         ),

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -887,6 +887,13 @@ class Docket(DocketSnapshotMixin):
     def stream_key(self) -> str:
         return self.key("stream")
 
+    @property
+    def redelivery_sweep_key(self) -> str:
+        # Under `leases:` rather than beside the task keys, because a parked
+        # task lives at `{docket}:{task_key}` and one keyed `redelivery-sweep`
+        # would otherwise write over the lease.
+        return self.key("leases:redelivery-sweep")
+
     def known_task_key(self, task_key: str) -> str:
         return self.key(f"known:{task_key}")
 

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -776,9 +776,10 @@ class Worker:
                             )
                             continue
                         try:
-                            # Sweep the pending list only when the timer is due.
                             sources = [get_new_deliveries]
-                            if redelivery_sweep.due:
+                            with self._maybe_suppress_instrumentation():
+                                sweep_due = await redelivery_sweep.due(redis)
+                            if sweep_due:
                                 sources.insert(0, get_redeliveries)
                             for source in sources:
                                 for stream_key, messages in await source(redis):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,6 +389,9 @@ async def key_leak_checker(docket: Docket) -> AsyncGenerator[KeyCountChecker, No
             for task_name in docket.tasks:
                 await r.zrem(docket.task_workers_set(task_name), temp_worker.name)
             await r.delete(docket.worker_tasks_set(temp_worker.name))
+            # Release the sweep lease the temp worker took, so the test's own
+            # worker can win it and sweep instead of waiting it out.
+            await r.delete(docket.redelivery_sweep_key)
 
     await checker.capture_baseline()
 

--- a/tests/test_redelivery_sweep.py
+++ b/tests/test_redelivery_sweep.py
@@ -4,9 +4,14 @@ The sweep claims its consumer group's pending list with XAUTOCLAIM to find
 messages another worker abandoned.  Each claim is bounded, and the cursor is
 kept across claims so entries past the first window are still reached.  A
 worker sweeps on a jittered timer rather than on every poll pass, and keeps
-sweeping until the cursor comes back to the front of the list.
+sweeping until the cursor comes back to the front of the list.  Once its timer
+elapses a worker sweeps only if it holds the fleet-wide lease, so the fleet
+runs at most one sweep per interval.  A worker that holds the lease keeps it:
+it refreshes the lease on every pass of a sweep under way, and it does not lose
+the lease to itself when its own timer fires.
 """
 
+import asyncio
 import inspect
 import time
 from datetime import timedelta
@@ -31,14 +36,17 @@ def the_task() -> AsyncMock:
 def sweep(docket: Docket) -> RedeliverySweep:
     """A sweep that treats every pending message as abandoned.
 
-    A zero timeout means XAUTOCLAIM claims whatever is pending, so a test does
-    not have to wait for messages to go idle.
+    A zero idle time means XAUTOCLAIM claims whatever is pending, so a test
+    does not have to wait for messages to go idle.  The timeout still sets a
+    workable lease interval.
     """
-    return RedeliverySweep(
+    sweep = RedeliverySweep(
         docket,
         worker_name="the-sweeping-worker",
-        redelivery_timeout=timedelta(0),
+        redelivery_timeout=timedelta(seconds=8),
     )
+    sweep.min_idle_time = 0
+    return sweep
 
 
 def test_a_fresh_sweep_starts_at_the_front(sweep: RedeliverySweep):
@@ -46,11 +54,15 @@ def test_a_fresh_sweep_starts_at_the_front(sweep: RedeliverySweep):
     assert sweep.start_id == SWEEP_START
 
 
-def a_sweep(docket: Docket, timeout: timedelta) -> RedeliverySweep:
+def a_sweep(
+    docket: Docket,
+    timeout: timedelta,
+    worker_name: str = "the-sweeping-worker",
+) -> RedeliverySweep:
     """A sweep whose redelivery timeout sets the interval between its sweeps."""
     return RedeliverySweep(
         docket,
-        worker_name="the-sweeping-worker",
+        worker_name=worker_name,
         redelivery_timeout=timeout,
     )
 
@@ -60,9 +72,51 @@ def test_the_interval_is_a_quarter_of_the_timeout(docket: Docket):
     assert a_sweep(docket, timedelta(seconds=8)).interval == 2.0
 
 
-def test_the_first_sweep_is_due_immediately(sweep: RedeliverySweep):
+async def test_the_first_sweep_is_due_immediately(docket: Docket):
     """A fresh worker sweeps at once, to reclaim a dead worker's messages."""
-    assert sweep.due is True
+    sweep = a_sweep(docket, timedelta(seconds=8))
+
+    async with docket.redis() as redis:
+        assert await sweep.due(redis) is True
+
+
+async def test_only_the_lease_holder_sweeps_in_an_interval(docket: Docket):
+    """Two workers whose timers are due, but only the lease holder sweeps.
+
+    A sweep costs O(pending list) no matter how many workers run, so only the
+    worker that takes the lease sweeps this interval.  The other one skips.
+    """
+    worker_a = a_sweep(docket, timedelta(seconds=8), worker_name="worker-a")
+    worker_b = a_sweep(docket, timedelta(seconds=8), worker_name="worker-b")
+
+    async with docket.redis() as redis:
+        assert await worker_a.due(redis) is True
+        assert await worker_b.due(redis) is False
+        assert await redis.get(docket.redelivery_sweep_key) == b"worker-a"
+
+
+async def test_a_worker_that_loses_the_lease_arms_its_next_timer(docket: Docket):
+    """A worker that loses the lease waits for its own next timer, not a spin.
+
+    Losing the lease arms the jittered timer, so an immediate second check
+    returns False rather than hammering Redis with another SET on every pass.
+    """
+    interval = 8.0
+    holder = a_sweep(docket, timedelta(seconds=interval * 4), worker_name="holder")
+    loser = a_sweep(docket, timedelta(seconds=interval * 4), worker_name="loser")
+
+    async with docket.redis() as redis:
+        assert await holder.due(redis) is True
+
+        before = time.monotonic()
+        assert await loser.due(redis) is False
+        after = time.monotonic()
+
+        low, high = JITTER
+        assert before + low * interval <= loser.next_sweep <= after + high * interval
+        assert loser.start_id == SWEEP_START
+        # A second immediate check does not spin; the timer holds it off.
+        assert await loser.due(redis) is False
 
 
 async def abandon_many(docket: Docket, the_task: AsyncMock, count: int) -> None:
@@ -139,18 +193,105 @@ async def test_a_sweep_under_way_stays_due_regardless_of_the_timer(
     the_task: AsyncMock,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """While the cursor is past the front the worker sweeps on every pass."""
+    """While the cursor is past the front the lease holder sweeps on every pass."""
     monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
 
     await abandon_many(docket, the_task, count=20)
 
     async with docket.redis() as redis:
+        assert await sweep.due(redis) is True
         await sweep.claim(redis, available_slots=5)
 
-    assert sweep.start_id != SWEEP_START
-    # Push the timer far into the future; the sweep under way is still due.
-    sweep.next_sweep = time.monotonic() + 3600
-    assert sweep.due is True
+        assert sweep.start_id != SWEEP_START
+        # Push the timer far into the future; the sweep under way is still due.
+        sweep.next_sweep = time.monotonic() + 3600
+
+        assert await sweep.due(redis) is True
+
+
+async def test_a_sweep_under_way_refreshes_the_lease_on_every_pass(docket: Docket):
+    """A sweep that outlasts one interval keeps its lease to the end.
+
+    The lease is taken for one interval, but a walk of a long pending list can
+    run longer than that.  Every pass refreshes the lease, so it covers the
+    whole sweep and no other worker starts one alongside it.
+    """
+    interval = 0.25
+    sweep = a_sweep(docket, timedelta(seconds=interval * 4))
+
+    async with docket.redis() as redis:
+        assert await sweep.due(redis) is True
+        sweep.start_id = "1000-0"
+
+        await asyncio.sleep(interval * 0.6)
+        assert await sweep.due(redis) is True
+        await asyncio.sleep(interval * 0.6)
+        assert await sweep.due(redis) is True
+        await asyncio.sleep(interval * 0.6)
+        assert await sweep.due(redis) is True
+
+        assert await redis.get(docket.redelivery_sweep_key) == b"the-sweeping-worker"
+
+
+async def test_a_lone_worker_does_not_lose_the_lease_to_itself(docket: Docket):
+    """A worker whose own lease is still live sweeps again when its timer fires.
+
+    Nothing else holds the lease, so a plain SET NX would fail and the only
+    worker in the fleet would rest for another interval.  Finding its own name
+    on the lease, the worker keeps the lease and sweeps.
+    """
+    sweep = a_sweep(docket, timedelta(seconds=8))
+
+    async with docket.redis() as redis:
+        assert await sweep.due(redis) is True
+
+        sweep.next_sweep = time.monotonic()
+        assert await sweep.due(redis) is True
+        assert await redis.get(docket.redelivery_sweep_key) == b"the-sweeping-worker"
+
+
+async def test_a_sweep_that_lost_its_lease_keeps_its_place(docket: Docket):
+    """A worker that stalls until its lease lapses keeps its place and rests.
+
+    Another worker holds the lease by the time this one comes back, so this
+    worker backs off without moving its cursor, so it resumes from where it
+    stopped once it takes the lease again, instead of re-reading the front.
+    It leaves the other worker's lease exactly as it found it.
+    """
+    sweep = a_sweep(docket, timedelta(seconds=8))
+    sweep.start_id = "1000-0"
+
+    async with docket.redis() as redis:
+        await redis.set(docket.redelivery_sweep_key, "another-worker", px=5000)
+
+        before = time.monotonic()
+        assert await sweep.due(redis) is False
+
+        assert sweep.start_id == "1000-0"
+        assert sweep.next_sweep > before
+        assert await redis.get(docket.redelivery_sweep_key) == b"another-worker"
+        # Still the five seconds the other worker asked for, not this one's eight.
+        assert 0 < await redis.ttl(docket.redelivery_sweep_key) <= 5
+
+
+async def test_a_sweep_whose_lease_lapsed_retakes_it_and_resumes(docket: Docket):
+    """A worker whose lease expired mid-walk takes it back and keeps going.
+
+    Nobody else took the lease, so the worker must not sit resting: it retakes
+    the lease on this pass and resumes from its kept place in the list.
+    """
+    sweep = a_sweep(docket, timedelta(seconds=8))
+    sweep.start_id = "1000-0"
+
+    async with docket.redis() as redis:
+        assert await redis.get(docket.redelivery_sweep_key) is None
+
+        assert await sweep.due(redis) is True
+
+        assert sweep.start_id == "1000-0"
+        assert (
+            await redis.get(docket.redelivery_sweep_key) == sweep.worker_name.encode()
+        )
 
 
 async def test_reaching_the_end_starts_the_next_sweep_over(
@@ -173,8 +314,8 @@ async def test_a_completed_sweep_is_not_due_until_the_timer_elapses(docket: Dock
     async with docket.redis() as redis:
         await sweep.claim(redis, available_slots=10)
 
-    assert sweep.start_id == SWEEP_START
-    assert sweep.due is False
+        assert sweep.start_id == SWEEP_START
+        assert await sweep.due(redis) is False
 
 
 @pytest.mark.parametrize("attempt", range(8))
@@ -215,6 +356,11 @@ async def test_the_worker_redelivers_every_abandoned_message(
     Shrinking the scan batch to one caps each XAUTOCLAIM at about ten scanned
     entries, so no single claim can reach the whole list.  The kept cursor
     walks the rest, so every abandoned message is redelivered and run.
+
+    The timeout leaves room for a poll pass inside a quarter of it, which is
+    how long the sweep's lease runs.  A worker whose pass outlasts its own
+    lease gives the walk up and starts over at the front, and can then reclaim
+    a message it is still running.
     """
     monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 1)
 
@@ -222,10 +368,37 @@ async def test_the_worker_redelivers_every_abandoned_message(
 
     async with Worker(
         docket,
-        redelivery_timeout=timedelta(milliseconds=50),
+        redelivery_timeout=timedelta(milliseconds=200),
         minimum_check_interval=timedelta(milliseconds=5),
         scheduling_resolution=timedelta(milliseconds=5),
     ) as worker:
         await worker.run_until_finished()
 
     assert the_task.await_count == 25
+
+
+async def test_an_abandoned_message_is_reclaimed_after_the_lease_expires(
+    docket: Docket, the_task: AsyncMock
+):
+    """A lease another worker holds only delays a sweep, never blocks it.
+
+    Another worker holds the sweep lease when this worker starts, so its first
+    sweep attempts lose the lease and arm the next timer.  The lease expires
+    after one interval, well before the message has been idle for the whole
+    redelivery timeout, so this worker still wins the lease and reclaims the
+    message.  The timeout, not the lease, bounds redelivery.
+    """
+    await abandon_many(docket, the_task, count=1)
+
+    async with docket.redis() as redis:
+        await redis.set(docket.redelivery_sweep_key, "other-worker", nx=True, px=100)
+
+    async with Worker(
+        docket,
+        redelivery_timeout=timedelta(milliseconds=400),
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as worker:
+        await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with()


### PR DESCRIPTION
A sweep walks the whole pending list, so its cost is O(pending list) no
matter how many workers run. Running one sweep per worker each interval
therefore pins Redis as the fleet grows. Now a worker takes
`SET {docket}:leases:redelivery-sweep <worker> NX PX interval` when its
timer elapses, and only the worker holding that lease sweeps.

A worker that holds the lease keeps it. It refreshes the lease on every
pass while its sweep is under way, so the lease spans the whole walk of a
long pending list rather than only its start, and no second worker starts
a sweep alongside it. A worker whose timer fires while its own lease is
still live keeps that lease, rather than losing the sweep to itself and
resting another interval. A worker that stalls long enough for its lease
to lapse gives the sweep up, starts over at the front next time, and
rests, so the next holder walks the list alone.

Nobody deletes the lease. It expires one interval after its last refresh,
and that expiry paces the fleet to at most one sweep per interval.

This is PR 3 of the stack unbundling #463.

## Compatibility

- A new Redis key `{docket}:leases:redelivery-sweep` appears — a lease
  string with a TTL of one sweep interval. Old workers ignore it. During
  a mixed-version window old workers still sweep every interval, so the
  "one sweeper per interval" benefit is full only once every worker is
  new.
- No change to task payloads or the stream/queue schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
