### PR TITLE
Make the per-command message batch one tunable knob

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -17,12 +17,15 @@ async with Worker(
     reconnection_delay=timedelta(seconds=5),           # Redis reconnection backoff
     minimum_check_interval=timedelta(milliseconds=100), # Polling frequency
     scheduling_resolution=timedelta(milliseconds=250),  # Future task check frequency
-    schedule_automatic_tasks=True                       # Enable perpetual task startup
+    schedule_automatic_tasks=True,                      # Enable perpetual task startup
+    message_batch=1000,                                 # Messages per Redis command
 ) as worker:
     await worker.run_forever()
 ```
 
 `redelivery_timeout` sets when a task becomes eligible for redelivery, not when redelivery happens. Each worker sweeps for eligible tasks on a timer at a quarter of the timeout, jittered 0.75–1.25×. A task therefore waits up to about 31% past the timeout before another worker claims it, and usually less. A sweep walks a very long pending list in bounded steps, one per poll pass, so that walk can add time beyond that.
+
+`message_batch` caps how many messages one Redis command may claim, for both the delivery read and the redelivery sweep. A larger batch costs fewer round trips. It also makes Redis serialize that many whole messages into one reply, and makes each sweep read about ten times the batch in pending-list entries. A burst larger than one batch still drains in full, because the worker reads again while slots stay free.
 
 ### Environment Variable Configuration
 
@@ -36,6 +39,7 @@ export DOCKET_URL=redis://redis.production.com:6379/0
 # Worker settings
 export DOCKET_WORKER_NAME=orders-worker-1
 export DOCKET_WORKER_CONCURRENCY=50
+export DOCKET_WORKER_MESSAGE_BATCH=1000
 export DOCKET_WORKER_REDELIVERY_TIMEOUT=10m
 export DOCKET_WORKER_RECONNECTION_DELAY=5s
 export DOCKET_WORKER_MINIMUM_CHECK_INTERVAL=100ms

--- a/loq.toml
+++ b/loq.toml
@@ -10,11 +10,11 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1394
+max_lines = 1409
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
-max_lines = 952
+max_lines = 968
 
 [[rules]]
 path = "src/docket/execution.py"

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -5,9 +5,9 @@ messages that another worker left behind.  ``RedeliverySweep`` owns that claim:
 it bounds each call, keeps the cursor across calls, and creates the consumer
 group again when Redis reports it missing.
 
-Each call claims at most ``REDELIVERY_SCAN_BATCH`` entries, so Redis reads at
-most about ten times that many entries of the pending list per call.  The cost
-of one call stays bounded however long the list grows.
+Each call claims at most the worker's ``message_batch`` entries, so Redis reads
+at most about ten times that many entries of the pending list per call.  The
+cost of one call stays bounded however long the list grows.
 
 Each call starts where the last one stopped.  A sweep that always restarted at
 ``0-0`` would never read the entries past its first window, so those could
@@ -38,8 +38,8 @@ worker took it, so that worker can walk the list alone.
 
 Once a sweep is under way the worker sweeps on every pass until the cursor
 returns to the front.  Each pass claims no more entries than the worker has
-free slots, so a worker with few free slots takes many passes to walk a long
-pending list.
+free slots, and no more than its ``message_batch``, so a long pending list
+takes many passes to walk.
 """
 
 from __future__ import annotations
@@ -53,10 +53,6 @@ from redis.exceptions import ResponseError
 from ._lua import Arg, Key, redis_script
 from ._redis import RedisClient, RedisMessages
 from .docket import Docket
-
-# Most entries one XAUTOCLAIM call may claim, and so about a tenth of the
-# entries Redis reads for it.
-REDELIVERY_SCAN_BATCH = 1000
 
 # The cursor Redis returns at the end of the pending list, and the one that
 # starts a fresh sweep from the front.
@@ -93,9 +89,11 @@ class RedeliverySweep:
         *,
         worker_name: str,
         redelivery_timeout: timedelta,
+        message_batch: int,
     ) -> None:
         self.docket = docket
         self.worker_name = worker_name
+        self.message_batch = message_batch
         self.min_idle_time = int(redelivery_timeout.total_seconds() * 1000)
         self.interval = redelivery_timeout.total_seconds() / 4
         self.start_id = SWEEP_START
@@ -158,9 +156,9 @@ class RedeliverySweep:
         """Claim the messages that another worker has left idle too long.
 
         The claim starts where the last one stopped, and asks for no more than
-        ``REDELIVERY_SCAN_BATCH`` entries however many slots are free.  A
-        docket that no worker has bootstrapped yet has no consumer group, so a
-        NOGROUP answer means creating the group and claiming again.
+        ``message_batch`` entries however many slots are free.  A docket that no
+        worker has bootstrapped yet has no consumer group, so a NOGROUP answer
+        means creating the group and claiming again.
 
         Redis answers with ``SWEEP_START`` at the end of the pending list.  The
         sweep then arms the next jittered timer, and a later pass starts a fresh
@@ -173,7 +171,7 @@ class RedeliverySweep:
                 consumername=self.worker_name,
                 min_idle_time=self.min_idle_time,
                 start_id=self.start_id,
-                count=min(available_slots, REDELIVERY_SCAN_BATCH),
+                count=min(available_slots, self.message_batch),
             )
         except ResponseError as e:
             if "NOGROUP" in str(e):

--- a/src/docket/cli/__init__.py
+++ b/src/docket/cli/__init__.py
@@ -39,7 +39,7 @@ from docket.cli._support import (
 from docket.docket import Docket, DocketSnapshot, WorkerInfo
 from docket.execution import ExecutionState
 from docket.strikelist import Operator
-from docket.worker import Worker
+from docket.worker import MESSAGE_BATCH, Worker
 
 
 app: typer.Typer = typer.Typer(
@@ -117,6 +117,21 @@ def worker(
             envvar="DOCKET_WORKER_CONCURRENCY",
         ),
     ] = 10,
+    message_batch: Annotated[
+        int,
+        typer.Option(
+            help=(
+                "The most messages one Redis command may claim, for both the "
+                "delivery read and the redelivery sweep. A larger batch costs "
+                "fewer round trips. It also makes Redis serialize that many "
+                "whole messages into one reply, and makes each sweep read "
+                "about ten times the batch in pending-list entries. A burst "
+                "larger than one batch still drains in full."
+            ),
+            envvar="DOCKET_WORKER_MESSAGE_BATCH",
+            min=1,
+        ),
+    ] = MESSAGE_BATCH,
     redelivery_timeout: Annotated[
         timedelta,
         typer.Option(
@@ -216,6 +231,7 @@ def worker(
             url=url,
             name=name,
             concurrency=concurrency,
+            message_batch=message_batch,
             redelivery_timeout=redelivery_timeout,
             reconnection_delay=reconnection_delay,
             minimum_check_interval=minimum_check_interval,

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -107,6 +107,11 @@ AUTOMATIC_PERPETUAL_RESEED_INTERVAL_SECONDS = 60
 # redelivery_timeout is very small (e.g., in tests with 200ms timeouts).
 MINIMUM_TTL_SECONDS = 1
 
+# The most messages one Redis command may claim, for the delivery read and for
+# the redelivery sweep's claim alike.  A larger batch trades fewer round trips
+# for bigger single replies.
+MESSAGE_BATCH = 1000
+
 TaskKey: TypeAlias = str
 
 
@@ -230,11 +235,19 @@ class Worker:
         async with Worker(docket) as worker:
             await worker.run_forever()
     ```
+
+    ``message_batch`` caps how many messages one Redis command may claim: both
+    the delivery read and the redelivery sweep's claim.  A larger batch costs
+    fewer round trips.  It also makes Redis serialize that many whole messages
+    into one reply, and makes each sweep read about ten times the batch in
+    pending-list entries.  A burst larger than one batch still drains in full,
+    because the poll loop reads again while slots stay free.
     """
 
     docket: Docket
     name: str
     concurrency: int
+    message_batch: int
     redelivery_timeout: timedelta
     reconnection_delay: timedelta
     minimum_check_interval: timedelta
@@ -258,10 +271,17 @@ class Worker:
         enable_internal_instrumentation: bool = False,
         fallback_task: TaskFunction | None = None,
         dependencies: (Mapping[str, Any] | Sequence[Any] | None) = None,
+        # Last in the list so that every positional call written against an
+        # earlier version keeps its meaning.
+        message_batch: int = MESSAGE_BATCH,
     ) -> None:
+        if message_batch < 1:
+            raise ValueError(f"message_batch must be at least 1, got {message_batch}")
+
         self.docket = docket
         self.name = name or f"{socket.gethostname()}#{os.getpid()}"
         self.concurrency = concurrency
+        self.message_batch = message_batch
         self.redelivery_timeout = redelivery_timeout
         self.reconnection_delay = reconnection_delay
         self.minimum_check_interval = minimum_check_interval
@@ -394,6 +414,9 @@ class Worker:
         metrics_port: int | None = None,
         tasks: list[str] = ["docket.tasks:standard_tasks"],
         fallback_task: str | None = None,
+        # Last in the list so that every positional call written against an
+        # earlier version keeps its meaning.
+        message_batch: int = MESSAGE_BATCH,
     ) -> None:
         """Run a worker as the main entry point (CLI).
 
@@ -427,6 +450,7 @@ class Worker:
                         docket=docket,
                         name=name,
                         concurrency=concurrency,
+                        message_batch=message_batch,
                         redelivery_timeout=redelivery_timeout,
                         reconnection_delay=reconnection_delay,
                         minimum_check_interval=minimum_check_interval,
@@ -612,6 +636,7 @@ class Worker:
             self.docket,
             worker_name=self.name,
             redelivery_timeout=self.redelivery_timeout,
+            message_batch=self.message_batch,
         )
         log_context = self._log_context()
 
@@ -642,7 +667,7 @@ class Worker:
                         consumername=self.name,
                         streams={self.docket.stream_key: ">"},
                         block=int(self.minimum_check_interval.total_seconds() * 1000),
-                        count=available_slots,
+                        count=min(available_slots, self.message_batch),
                     )
             except ResponseError as e:
                 if "NOGROUP" in str(e):

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -57,6 +57,36 @@ def test_worker_command_exposes_all_the_options_of_worker():
         )
 
 
+def test_message_batch_option_reaches_the_worker(monkeypatch: pytest.MonkeyPatch):
+    """`--message-batch` sets the cap the worker applies to its Redis reads."""
+    from docket.cli import worker as worker_cli_command
+
+    passed: dict[str, object] = {}
+
+    class RecordingWorker:
+        @staticmethod
+        async def run(**kwargs: object) -> None:
+            passed.update(kwargs)
+
+    monkeypatch.setattr("docket.cli.Worker", RecordingWorker)
+
+    worker_cli_command(message_batch=17)
+
+    assert passed["message_batch"] == 17
+
+
+async def test_message_batch_below_one_is_rejected():
+    """The CLI fails at startup rather than running a worker that reads no
+    messages."""
+    # Rich styles each segment of the flag separately, so on a color-capable
+    # terminal the name arrives split by escape codes. TERM=dumb turns the
+    # color system off and leaves the flag as one plain string.
+    result = await run_cli("worker", "--message-batch", "0", env={"TERM": "dumb"})
+
+    assert result.exit_code != 0
+    assert "--message-batch" in result.output
+
+
 async def test_worker_command(
     docket: Docket,
 ):

--- a/tests/test_redelivery_sweep.py
+++ b/tests/test_redelivery_sweep.py
@@ -32,6 +32,10 @@ def the_task() -> AsyncMock:
     return task
 
 
+# A batch small enough that a test pending list needs several claims to walk.
+A_SMALL_BATCH = 5
+
+
 @pytest.fixture
 def sweep(docket: Docket) -> RedeliverySweep:
     """A sweep that treats every pending message as abandoned.
@@ -44,6 +48,7 @@ def sweep(docket: Docket) -> RedeliverySweep:
         docket,
         worker_name="the-sweeping-worker",
         redelivery_timeout=timedelta(seconds=8),
+        message_batch=A_SMALL_BATCH,
     )
     sweep.min_idle_time = 0
     return sweep
@@ -64,6 +69,7 @@ def a_sweep(
         docket,
         worker_name=worker_name,
         redelivery_timeout=timeout,
+        message_batch=A_SMALL_BATCH,
     )
 
 
@@ -139,19 +145,16 @@ async def abandon_many(docket: Docket, the_task: AsyncMock, count: int) -> None:
         )
 
 
-async def test_one_claim_asks_for_no_more_than_the_scan_batch(
+async def test_one_claim_asks_for_no_more_than_the_message_batch(
     docket: Docket,
     sweep: RedeliverySweep,
     the_task: AsyncMock,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     """A worker with more free slots than one batch still caps its ask.
 
-    Twenty free slots against a scan batch of five claims five, so Redis reads
-    a bounded slice of the pending list however many slots are free.
+    Twenty free slots against a message batch of five claims five, so Redis
+    reads a bounded slice of the pending list however many slots are free.
     """
-    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
-
     await abandon_many(docket, the_task, count=20)
 
     async with docket.redis() as redis:
@@ -164,7 +167,6 @@ async def test_the_kept_cursor_reaches_entries_past_the_first_window(
     docket: Docket,
     sweep: RedeliverySweep,
     the_task: AsyncMock,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     """A second claim picks up where the first one stopped.
 
@@ -172,8 +174,6 @@ async def test_the_kept_cursor_reaches_entries_past_the_first_window(
     entries forever, and the rest of the pending list would never be
     redelivered.
     """
-    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
-
     await abandon_many(docket, the_task, count=20)
 
     async with docket.redis() as redis:
@@ -191,11 +191,8 @@ async def test_a_sweep_under_way_stays_due_regardless_of_the_timer(
     docket: Docket,
     sweep: RedeliverySweep,
     the_task: AsyncMock,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     """While the cursor is past the front the lease holder sweeps on every pass."""
-    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 5)
-
     await abandon_many(docket, the_task, count=20)
 
     async with docket.redis() as redis:
@@ -349,25 +346,24 @@ async def test_a_missing_consumer_group_is_created_and_the_claim_retried(
 
 
 async def test_the_worker_redelivers_every_abandoned_message(
-    docket: Docket, the_task: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    docket: Docket, the_task: AsyncMock
 ):
     """A worker reaches entries past a single bounded claim.
 
-    Shrinking the scan batch to one caps each XAUTOCLAIM at about ten scanned
-    entries, so no single claim can reach the whole list.  The kept cursor
-    walks the rest, so every abandoned message is redelivered and run.
+    Shrinking the message batch to one caps each XAUTOCLAIM at about ten
+    scanned entries, so no single claim can reach the whole list.  The kept
+    cursor walks the rest, so every abandoned message is redelivered and run.
 
     The timeout leaves room for a poll pass inside a quarter of it, which is
     how long the sweep's lease runs.  A worker whose pass outlasts its own
     lease gives the walk up and starts over at the front, and can then reclaim
     a message it is still running.
     """
-    monkeypatch.setattr("docket._redelivery.REDELIVERY_SCAN_BATCH", 1)
-
     await abandon_many(docket, the_task, count=25)
 
     async with Worker(
         docket,
+        message_batch=1,
         redelivery_timeout=timedelta(milliseconds=200),
         minimum_check_interval=timedelta(milliseconds=5),
         scheduling_resolution=timedelta(milliseconds=5),

--- a/tests/worker/test_delivery_batch.py
+++ b/tests/worker/test_delivery_batch.py
@@ -1,0 +1,122 @@
+"""Tests for the cap on how many messages one Redis command may claim."""
+
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any, AsyncGenerator
+from unittest.mock import patch
+
+import pytest
+
+from docket._redis import RedisClient
+from docket.worker import MESSAGE_BATCH
+
+from docket import Docket, Worker
+
+# A batch small enough that a test backlog needs several commands to drain.
+A_SMALL_BATCH = 5
+
+# More messages than one batch, and more than one round of batches.
+A_BURST = A_SMALL_BATCH * 4 + 1
+
+
+def test_the_default_batch_is_a_thousand_messages():
+    """The default balances round trips against the size of one reply."""
+    assert MESSAGE_BATCH == 1000
+
+
+@pytest.mark.parametrize("batch", [0, -1])
+def test_a_batch_below_one_is_rejected(docket: Docket, batch: int):
+    """A batch of zero would ask Redis for no messages, so the worker would
+    never make progress."""
+    with pytest.raises(ValueError, match="message_batch must be at least 1"):
+        Worker(docket, message_batch=batch)
+
+
+async def test_a_burst_larger_than_one_batch_still_drains(docket: Docket):
+    """The poll loop reads again while slots are free, so the cap splits a
+    burst across commands rather than leaving any of it behind."""
+    ran = 0
+
+    async def counter() -> None:
+        nonlocal ran
+        ran += 1
+
+    docket.register(counter)
+
+    await docket.add_many([docket.call(counter)() for _ in range(A_BURST)])
+
+    async with Worker(
+        docket,
+        concurrency=A_BURST * 2,
+        message_batch=A_SMALL_BATCH,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=5),
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert ran == A_BURST
+
+
+class CountingClient:
+    """Delegates to a real client, recording what each command asked for."""
+
+    def __init__(self, wrapped: Any, counts: list[int]):
+        self._wrapped = wrapped
+        self._counts = counts
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    async def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+        self._counts.append(kwargs["count"])
+        return await self._wrapped.xreadgroup(*args, **kwargs)
+
+    async def xautoclaim(self, *args: Any, **kwargs: Any) -> Any:
+        self._counts.append(kwargs["count"])
+        return await self._wrapped.xautoclaim(*args, **kwargs)
+
+
+@asynccontextmanager
+async def counting_redis(
+    docket: Docket, counts: list[int]
+) -> AsyncGenerator[None, None]:
+    """Record the ``count`` of every delivery read and sweep claim."""
+    original_redis = Docket.redis
+
+    @asynccontextmanager
+    async def wrapped(self: Docket) -> AsyncGenerator[RedisClient, None]:
+        async with original_redis(self) as redis:
+            yield CountingClient(redis, counts)  # type: ignore[arg-type]
+
+    with patch.object(Docket, "redis", wrapped):
+        yield
+
+
+async def test_no_command_asks_for_more_than_the_batch(docket: Docket):
+    """However many slots are free, no XREADGROUP or XAUTOCLAIM asks for more
+    messages than the worker's batch."""
+    counts: list[int] = []
+
+    ran = 0
+
+    async def counter() -> None:
+        nonlocal ran
+        ran += 1
+
+    docket.register(counter)
+
+    await docket.add_many([docket.call(counter)() for _ in range(A_BURST)])
+
+    async with counting_redis(docket, counts):
+        async with Worker(
+            docket,
+            concurrency=A_BURST * 2,
+            message_batch=A_SMALL_BATCH,
+            minimum_check_interval=timedelta(milliseconds=5),
+            scheduling_resolution=timedelta(milliseconds=5),
+        ) as worker:
+            await worker.run_until_finished()
+
+    assert ran == A_BURST
+    assert counts, "the worker never asked Redis for messages"
+    assert max(counts) == A_SMALL_BATCH


### PR DESCRIPTION
A worker capped its delivery read and its redelivery sweep at two separate constants, and neither one was tunable. Both bound the same thing: how many messages one Redis command may claim. This folds them into a single `Worker` setting, `message_batch`, with a `--message-batch` flag (`DOCKET_WORKER_MESSAGE_BATCH`) and a default of 1000.

The name is deliberately not `batch_size`, to keep it clear of `add_many`'s client-side `chunk_size`.

The tradeoff is now the operator's to make. A larger batch costs fewer round trips. It also makes Redis serialize that many whole messages into one reply, and makes each redelivery sweep read about ten times the batch in pending-list entries per `XAUTOCLAIM`. A burst larger than one batch still drains in full, because the poll loop reads again while slots stay free. A test proves that.

PR 4 of the stack unbundling #463.

## Compatibility

- A new optional `Worker` parameter and a new CLI flag. Existing callers are unaffected.
- The default changes delivery reads from 5000 to 1000 messages per command. That only splits a large read into more reads; bursts still drain in full.
- The redelivery sweep's default is unchanged at 1000.
- No data-model or wire change.
- Safe in a mixed-version rolling deploy: workers with different batches read from the same stream and consumer group with no coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
