### PR TITLE
Renew leases with JUSTID in bounded chunks

### DIFF
--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1409
+max_lines = 1405
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1405
+max_lines = 1421
 
 [[rules]]
 path = "src/docket/cli/__init__.py"

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -1,4 +1,11 @@
-"""How a worker finds messages that another worker abandoned.
+"""How a worker keeps its own messages and finds ones another worker abandoned.
+
+A worker keeps a message by renewing its lease: XCLAIM with ``idle=0`` resets
+the message's idle clock, so the sweep below does not take it away while the
+task is still running.  A renewal names every message the worker holds, so it
+goes out in chunks of at most ``LEASE_RENEWAL_BATCH`` ids, and it asks for
+JUSTID.  A plain XCLAIM answers with the whole body of every message, and Redis
+blocks while it builds that reply for a worker that discards it.
 
 A worker sweeps its consumer group's pending list with XAUTOCLAIM to find
 messages that another worker left behind.  ``RedeliverySweep`` owns that claim:
@@ -44,15 +51,23 @@ takes many passes to walk.
 
 from __future__ import annotations
 
+import logging
 import random
 import time
 from datetime import timedelta
+from typing import Sequence
 
 from redis.exceptions import ResponseError
 
 from ._lua import Arg, Key, redis_script
-from ._redis import RedisClient, RedisMessages
+from ._redis import RedisClient, RedisMessageID, RedisMessages
 from .docket import Docket
+
+logger = logging.getLogger(__name__)
+
+# The most message ids one XCLAIM may name, so no single renewal command blocks
+# Redis long or ships a large reply.
+LEASE_RENEWAL_BATCH = 5000
 
 # The cursor Redis returns at the end of the pending list, and the one that
 # starts a fresh sweep from the front.
@@ -78,6 +93,39 @@ async def _refresh_lease(
     return 0
     """
     ...
+
+
+async def renew_leases(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    group_name: str,
+    consumer_name: str,
+    message_ids: Sequence[RedisMessageID],
+) -> None:
+    """Reset the idle time of the messages one worker holds.
+
+    Each XCLAIM asks for JUSTID, so Redis returns only the claimed ids, not the
+    message bodies the worker already has and would discard.  The ids go out in
+    chunks of at most ``LEASE_RENEWAL_BATCH``, so no single command names every
+    held message and blocks Redis while it runs.
+
+    A chunk that Redis refuses is logged and passed over, so the rest of the
+    worker's messages still have their leases renewed on this pass.
+    """
+    for start in range(0, len(message_ids), LEASE_RENEWAL_BATCH):
+        try:
+            await redis.xclaim(
+                name=stream_key,
+                groupname=group_name,
+                consumername=consumer_name,
+                min_idle_time=0,
+                message_ids=message_ids[start : start + LEASE_RENEWAL_BATCH],
+                idle=0,
+                justid=True,
+            )
+        except Exception:
+            logger.warning("Failed to renew leases", exc_info=True)
 
 
 class RedeliverySweep:

--- a/src/docket/_redis.py
+++ b/src/docket/_redis.py
@@ -28,6 +28,7 @@ from typing import (
     Sequence,
     TypeAlias,
     TypedDict,
+    TypeVar,
     cast,
     overload,
     runtime_checkable,
@@ -38,6 +39,7 @@ from redis.asyncio import ConnectionPool, Redis
 from redis.asyncio.client import PubSub
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import Connection, SSLConnection
+from redis.exceptions import ConnectionError
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -583,6 +585,22 @@ async def close_resource(resource: AsyncCloseable, name: str) -> None:
         logger.warning("Failed to close %s", name, exc_info=True)
 
 
+_Client = TypeVar("_Client")
+
+
+def require_open(client: _Client | None) -> _Client:
+    """Return the client, or report that the connection is closed.
+
+    A caller can reach a RedisConnection after its exit stack has torn the
+    clients down; a worker on its way out still asks the docket for a client.
+    ConnectionError puts that in the same family as a server that went away,
+    which every caller already handles.
+    """
+    if client is None:
+        raise ConnectionError("Redis connection is closed")
+    return client
+
+
 class RedisConnection:
     """Manages Redis connections for standalone, Sentinel, and cluster modes.
 
@@ -844,7 +862,8 @@ class RedisConnection:
         context leaves it open for the next caller.  Concurrent callers may
         hold it at the same time, because redis-py checks a connection out of
         the pool per command.  Pipelines, pub/sub objects, and locks are
-        per-use and each caller must still close its own.
+        per-use and each caller must still close its own.  Once the connection
+        has closed, this raises ConnectionError.
 
         Casts at the redis-py boundary translate from redis-py's
         ``Awaitable[T] | T`` dual-mode signatures into our async-only protocol.
@@ -856,8 +875,7 @@ class RedisConnection:
         elif self._memory_client is not None:
             yield self._memory_client
         else:
-            assert self._client is not None
-            yield cast(RedisClient, self._client)
+            yield cast(RedisClient, require_open(self._client))
 
     @asynccontextmanager
     async def pubsub(self) -> AsyncGenerator[PubSubClient, None]:
@@ -872,20 +890,19 @@ class RedisConnection:
             finally:
                 await ps.aclose()
         else:
-            assert self._client is not None
-            async with self._client.pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
+            async with require_open(self._client).pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
                 yield cast(PubSubClient, pubsub)
 
     async def publish(self, channel: str, message: str) -> int:
         """Publish a message to a pub/sub channel."""
         if self._cluster_client is not None:  # pragma: no cover
-            assert self._node_client is not None
-            return cast(int, await self._node_client.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
+            node_client = require_open(self._node_client)
+            return cast(int, await node_client.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
         elif self._memory_client is not None:
             return await self._memory_client.publish(channel, message)
         else:
-            assert self._client is not None
-            return cast(int, await self._client.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
+            client = require_open(self._client)
+            return cast(int, await client.publish(channel, message))  # pyright: ignore[reportUnknownMemberType]
 
     @asynccontextmanager
     async def _cluster_pubsub(self) -> AsyncGenerator[PubSub, None]:  # pragma: no cover
@@ -899,8 +916,7 @@ class RedisConnection:
         Yields:
             A PubSub object connected to a cluster node
         """
-        assert self._node_client is not None
-        pubsub = self._node_client.pubsub()  # pyright: ignore[reportUnknownMemberType]
+        pubsub = require_open(self._node_client).pubsub()  # pyright: ignore[reportUnknownMemberType]
         try:
             yield pubsub
         finally:

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -571,6 +571,14 @@ class Worker:
                 except ConnectionError:
                     if stopping.is_set():
                         return
+                    if not self.docket._redis.is_connected:
+                        # The docket closed while this worker was still
+                        # running, so there is nothing to reconnect to.
+                        logger.debug(
+                            "Docket connection is closed, stopping worker",
+                            extra=self._log_context(),
+                        )
+                        return
                     REDIS_DISRUPTIONS.add(1, self.labels())
                     logger.warning(
                         "Error connecting to redis, retrying in %s...",
@@ -1268,6 +1276,14 @@ class Worker:
                     pipeline.zrem(self.task_workers_set(task_name), self.name)
                 pipeline.delete(self.worker_tasks_set(self.name))
                 await pipeline.execute()
+        except ConnectionError:
+            # A worker that loses Redis on the way out ages out on its own:
+            # every other heartbeat prunes members older than the missed
+            # heartbeat window, and the worker's task set carries a TTL.
+            logger.debug(
+                "Could not clear worker heartbeat, connection is gone",
+                extra=self._log_context(),
+            )
         except Exception:
             logger.exception(
                 "Error clearing worker heartbeat",

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -36,7 +36,7 @@ from opentelemetry.trace import Status, StatusCode, Tracer
 
 from ._cancellation import CANCEL_MSG_CLEANUP, _wait_for_event, cancel_task
 from ._lua import Arg, Key, redis_script
-from ._redelivery import RedeliverySweep
+from ._redelivery import RedeliverySweep, renew_leases
 from ._redis import RedisClient
 from ._telemetry import suppress_instrumentation
 from redis.asyncio import Redis
@@ -906,8 +906,8 @@ class Worker:
     ) -> None:
         """Periodically renew leases on stream messages.
 
-        Calls XCLAIM with idle=0 to reset the message's idle time, preventing
-        XAUTOCLAIM from reclaiming it while we're still processing.
+        See _redelivery for how a renewal keeps XAUTOCLAIM from reclaiming a
+        message that this worker is still processing.
         """
         session = self._processing_session
         if session is None:
@@ -924,18 +924,14 @@ class Worker:
             if not message_ids:
                 continue
 
-            try:
-                with self._maybe_suppress_instrumentation():
-                    await redis.xclaim(
-                        name=self.docket.stream_key,
-                        groupname=self.docket.worker_group_name,
-                        consumername=self.name,
-                        min_idle_time=0,
-                        message_ids=message_ids,
-                        idle=0,
-                    )
-            except Exception:
-                logger.warning("Failed to renew leases", exc_info=True)
+            with self._maybe_suppress_instrumentation():
+                await renew_leases(
+                    cast(RedisClient, redis),
+                    stream_key=self.docket.stream_key,
+                    group_name=self.docket.worker_group_name,
+                    consumer_name=self.name,
+                    message_ids=message_ids,
+                )
 
     async def _reseed_automatic_perpetual_tasks_loop(self) -> None:
         """Periodically re-sow automatic perpetuals so a chain severed after

--- a/tests/test_lease_renewal.py
+++ b/tests/test_lease_renewal.py
@@ -1,0 +1,116 @@
+"""Tests for chunked, JUSTID lease renewal.
+
+A worker keeps the messages it holds by renewing their leases: XCLAIM with
+``idle=0`` resets each message's idle clock so the sweep does not take it away.
+Renewal names every held message, so it goes out in bounded chunks and asks for
+JUSTID, and Redis returns only the claimed ids rather than the bodies the worker
+already has.
+"""
+
+from typing import Any, Sequence, cast
+
+import pytest
+from redis.exceptions import ConnectionError
+
+from docket._redelivery import LEASE_RENEWAL_BATCH, renew_leases
+from docket._redis import RedisClient, RedisMessageID
+
+
+class SpyRedis:
+    """A stand-in redis client that records every XCLAIM and can fail chosen ones.
+
+    ``renew_leases`` calls only ``xclaim``, so this narrow spy captures the
+    kwargs of each chunk.  A chunk whose index is in ``fail_on`` raises, to prove
+    one refused chunk does not stop the rest.
+    """
+
+    def __init__(self, *, fail_on: Sequence[int] = ()) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_on = set(fail_on)
+
+    async def xclaim(self, **kwargs: Any) -> list[RedisMessageID]:
+        index = len(self.calls)
+        self.calls.append(kwargs)
+        if index in self.fail_on:
+            raise ConnectionError("Redis refused this chunk")
+        return []
+
+
+def ids(count: int) -> list[RedisMessageID]:
+    return [f"{i}-0".encode() for i in range(count)]
+
+
+async def do_renew(spy: SpyRedis, message_ids: Sequence[RedisMessageID]) -> None:
+    await renew_leases(
+        cast(RedisClient, spy),
+        stream_key="docket:stream",
+        group_name="docket:workers",
+        consumer_name="worker",
+        message_ids=message_ids,
+    )
+
+
+async def test_a_short_list_renews_in_one_call():
+    """Fewer ids than one batch renew in a single XCLAIM."""
+    spy = SpyRedis()
+    await do_renew(spy, ids(3))
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["message_ids"] == ids(3)
+
+
+async def test_more_ids_than_the_batch_renew_in_several_calls():
+    """More held messages than one batch split across several XCLAIM calls.
+
+    Each chunk names at most ``LEASE_RENEWAL_BATCH`` ids, so no single command
+    names every held message and blocks Redis while it runs.
+    """
+    message_ids = ids(LEASE_RENEWAL_BATCH + 1)
+    spy = SpyRedis()
+
+    await do_renew(spy, message_ids)
+
+    assert len(spy.calls) == 2
+    assert spy.calls[0]["message_ids"] == message_ids[:LEASE_RENEWAL_BATCH]
+    assert spy.calls[1]["message_ids"] == message_ids[LEASE_RENEWAL_BATCH:]
+
+
+async def test_every_chunk_asks_for_justid_and_zero_idle():
+    """Every renewal asks for JUSTID and keeps the idle-resetting semantics.
+
+    JUSTID makes Redis return only ids, not the bodies the worker discards.
+    ``min_idle_time=0`` and ``idle=0`` reset the idle clock of every held
+    message under the same consumer.
+    """
+    message_ids = ids(LEASE_RENEWAL_BATCH * 2 + 1)
+    spy = SpyRedis()
+
+    await do_renew(spy, message_ids)
+
+    assert len(spy.calls) == 3
+    for call in spy.calls:
+        assert call["justid"] is True
+        assert call["min_idle_time"] == 0
+        assert call["idle"] == 0
+        assert call["consumername"] == "worker"
+
+
+async def test_a_refused_chunk_is_logged_and_the_rest_still_renew(
+    caplog: pytest.LogCaptureFixture,
+):
+    """One chunk Redis refuses is logged, and the remaining chunks still renew."""
+    message_ids = ids(LEASE_RENEWAL_BATCH * 2 + 1)
+    spy = SpyRedis(fail_on=[1])
+
+    await do_renew(spy, message_ids)
+
+    assert len(spy.calls) == 3
+    assert spy.calls[0]["message_ids"] == message_ids[:LEASE_RENEWAL_BATCH]
+    assert spy.calls[2]["message_ids"] == message_ids[LEASE_RENEWAL_BATCH * 2 :]
+    assert "Failed to renew leases" in caplog.text
+
+
+async def test_no_held_messages_issues_no_call():
+    """A worker holding nothing issues no XCLAIM."""
+    spy = SpyRedis()
+    await do_renew(spy, [])
+    assert spy.calls == []

--- a/tests/test_redis_connection.py
+++ b/tests/test_redis_connection.py
@@ -2,6 +2,9 @@
 
 # pyright: reportPrivateUsage=false
 
+import pytest
+from redis.exceptions import ConnectionError
+
 from docket._redis import RedisConnection
 from tests.conftest import skip_cluster, skip_memory
 
@@ -60,3 +63,23 @@ async def test_connection_pool_closes_when_the_connection_exits(  # pragma: no c
         assert any(c.is_connected for c in pool._available_connections)
 
     assert not any(c.is_connected for c in pool._available_connections)
+
+
+async def test_a_closed_connection_reports_a_disconnect(redis_url: str) -> None:
+    """Reaching a torn-down connection looks like a Redis server going away.
+
+    A worker shutting down races the docket's teardown and still asks for a
+    client on its way out.  Every caller already handles ConnectionError.
+    """
+    connection = RedisConnection(redis_url)
+    async with connection:
+        pass
+
+    with pytest.raises(ConnectionError, match="Redis connection is closed"):
+        await connection.client().__aenter__()
+
+    with pytest.raises(ConnectionError, match="Redis connection is closed"):
+        await connection.pubsub().__aenter__()
+
+    with pytest.raises(ConnectionError, match="Redis connection is closed"):
+        await connection.publish("channel", "message")

--- a/tests/worker/test_liveness.py
+++ b/tests/worker/test_liveness.py
@@ -249,3 +249,17 @@ async def test_remove_heartbeat_suppresses_cleanup_errors(docket: Docket):
     async with Worker(docket) as worker:
         with patch.object(Docket, "redis", broken_redis):
             await worker._remove_heartbeat()  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_remove_heartbeat_tolerates_a_closed_connection(docket: Docket):
+    """Clearing the heartbeat is best-effort once the docket has closed.
+
+    A worker on its way out can outlive its docket's connection.  Every
+    heartbeat entry ages out on its own, so skipping the cleanup is safe.
+    """
+    async with Worker(docket) as worker:
+        await docket._redis.__aexit__(None, None, None)  # pyright: ignore[reportPrivateUsage]
+
+        await worker._remove_heartbeat()  # pyright: ignore[reportPrivateUsage]
+
+        await docket._redis.__aenter__()  # pyright: ignore[reportPrivateUsage]

--- a/tests/worker/test_reconnection.py
+++ b/tests/worker/test_reconnection.py
@@ -1,5 +1,6 @@
 """Tests for how the worker survives losing its Redis connection."""
 
+import sys
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any, AsyncGenerator
@@ -9,6 +10,11 @@ from docket._redis import RedisClient
 from redis.exceptions import ConnectionError
 
 from docket import Docket, Worker
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from asyncio import timeout as async_timeout
+else:  # pragma: no cover
+    from async_timeout import timeout as async_timeout
 
 
 async def test_worker_reconnects_when_connection_is_lost(
@@ -88,3 +94,25 @@ async def test_worker_reconnects_when_main_loop_read_disconnects(
 
     the_task.assert_called_once()
     assert reads["count"] >= 2
+
+
+async def test_worker_stops_when_the_docket_connection_closes(docket: Docket):
+    """A worker whose docket closed underneath it stops instead of raising.
+
+    Docket teardown closes the one client every caller shares.  The worker's
+    own read fails, and the retry that follows has nothing to reconnect to,
+    so the worker has to finish rather than spin or raise.
+    """
+    worker = Worker(docket, reconnection_delay=timedelta(milliseconds=10))
+
+    async def disconnected_worker_loop(redis: RedisClient, forever: bool = False):
+        await docket._redis.__aexit__(None, None, None)  # pyright: ignore[reportPrivateUsage]
+        raise ConnectionError("Simulated server loss")
+
+    worker._worker_loop = disconnected_worker_loop  # type: ignore[protected-access]
+
+    async with worker:
+        async with async_timeout(5):
+            await worker.run_forever()
+
+        await docket._redis.__aenter__()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
A worker renews the lease on every message it holds in one XCLAIM. Two
things make that expensive at scale. Without JUSTID, Redis serializes the
full body of every claimed message back to the worker, which discards it,
tens of megabytes for tens of thousands of in-flight tasks. And one XCLAIM
naming every held id blocks Redis while it runs.

Renewal now asks for JUSTID, so Redis returns only the ids, and it splits
the ids into chunks of at most `LEASE_RENEWAL_BATCH` (5000) so no single
command names every held message or ships a large reply. A chunk Redis
refuses is logged and skipped, so the remaining chunks still renew. The
renewal moves into `_redelivery.py`, beside the sweep it protects against.

This is PR 5 of the stack unbundling #463.

## The teardown race on the shared Redis client

The second commit fixes a separate bug that predates this stack. It rides
here because this PR is the top of the stack and the fix is wanted now.

`RedisConnection` holds one `redis.asyncio.Redis` client for the life of
the connection, and `client()`, `pubsub()`, and `publish()` each asserted
that the client was still there. A worker shutting down races the docket's
teardown: it reaches for a client after the exit stack has closed one. An
`AssertionError` is not a connection failure, so it escaped every handler
the worker has. `tests/worker/test_lifecycle.py::test_worker_rapid_start_cancel_cycles`
saw it twice in one run, once caught by `_remove_heartbeat` and once
uncaught in the reconnect at the top of `Worker._run`.

The three accessors now raise `redis.exceptions.ConnectionError`, which is
in the family the worker already treats as a disconnect. On top of that,
the worker's teardown is best-effort: `_run` stops when its docket is
closed instead of retrying a connection that will not come back, and
`_remove_heartbeat` logs at debug and skips. Skipping is safe because the
heartbeat entries age out on their own.

## Compatibility

Observable-equivalent. Leases are renewed on the same cadence
(`redelivery_timeout / 4`) with the same effect: XCLAIM with `idle=0`
resets each held message's idle clock so the sweep does not reclaim it.
JUSTID only changes what Redis sends back, not what gets claimed. Chunking
only splits one command into several over the same ids under the same
consumer.

`client()`, `pubsub()`, and `publish()` on a closed connection now raise
`ConnectionError` instead of `AssertionError`. That is a behavior change
only on an already-broken path.

No data-model, wire, or public-API change. Safe in a mixed-version rolling
deploy: old and new workers renew the same leases the same way, and JUSTID
is a per-call flag with no shared state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
