### PR TITLE
Scan the scheduled queue under a fleet-wide lease

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Rich dependency injection supporting:
 - **Sorted Sets**: `{docket}:queue` (scheduled tasks), `{docket}:workers` (heartbeats)
 - **Hashes**: `{docket}:{key}` (parked task data)
 - **Sets**: `{docket}:worker-tasks:{worker}` (worker capabilities)
-- **Strings**: `{docket}:leases:redelivery-sweep` (fleet-wide sweep lease, expiring)
+- **Strings**: `{docket}:leases:redelivery-sweep` (fleet-wide sweep lease, expiring), `{docket}:leases:scheduler` (fleet-wide scheduler-scan lease, expiring)
 
 ### Task Lifecycle
 

--- a/loq.toml
+++ b/loq.toml
@@ -10,7 +10,7 @@ max_lines = 750
 # Source files that still need exceptions above 750
 [[rules]]
 path = "src/docket/worker.py"
-max_lines = 1405
+max_lines = 1429
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
@@ -22,7 +22,7 @@ max_lines = 1336
 
 [[rules]]
 path = "src/docket/docket.py"
-max_lines = 1105
+max_lines = 1111
 
 [[rules]]
 path = "src/docket/_redis.py"

--- a/src/docket/_lease.py
+++ b/src/docket/_lease.py
@@ -1,0 +1,28 @@
+"""A fleet-wide lease that lets one worker run a periodic, Redis-heavy job.
+
+Some jobs cost the same however large the fleet is: a scan of the whole
+scheduled-tasks queue, or of the whole pending list.  Every worker running one
+each interval multiplies that cost by the fleet size for no gain.  A lease gates
+the job to one worker per interval instead.
+
+The lease is a single SET with NX and PX: the first worker to set the key holds
+it, and later workers fail the NX and skip the job.  Nobody renews or deletes
+it, so it expires on its own after ``ttl_ms``, and that expiry is what paces the
+fleet to at most one run per interval.
+"""
+
+from __future__ import annotations
+
+from ._redis import RedisClient
+
+
+async def take_lease(redis: RedisClient, key: str, holder: str, ttl_ms: int) -> bool:
+    """Try to take the fleet-wide lease at ``key`` for ``ttl_ms`` milliseconds.
+
+    ``SET key holder NX PX ttl_ms`` succeeds only when the key is free, so at
+    most one caller per interval wins.  redis-py returns a truthy value on
+    success and ``None`` when the key already exists, so this returns whether
+    ``holder`` won the lease.  The caller that wins runs the job; a caller that
+    loses skips it and waits for its next turn.
+    """
+    return bool(await redis.set(key, holder, nx=True, px=ttl_ms))

--- a/src/docket/_redelivery.py
+++ b/src/docket/_redelivery.py
@@ -55,6 +55,7 @@ from typing import Sequence
 
 from redis.exceptions import ResponseError
 
+from ._lease import take_lease
 from ._redis import RedisClient, RedisMessageID, RedisMessages
 from .docket import Docket
 
@@ -141,15 +142,15 @@ class RedeliverySweep:
             return True
         if time.monotonic() < self.next_sweep:
             return False
-        took_lease = await redis.set(
+        took_lease = await take_lease(
+            redis,
             self.docket.redelivery_sweep_key,
             self.worker_name,
-            nx=True,
-            px=int(self.interval * 1000),
+            int(self.interval * 1000),
         )
         if not took_lease:
             self._rest()
-        return bool(took_lease)
+        return took_lease
 
     async def claim(self, redis: RedisClient, available_slots: int) -> RedisMessages:
         """Claim the messages that another worker has left idle too long.

--- a/src/docket/docket.py
+++ b/src/docket/docket.py
@@ -894,6 +894,12 @@ class Docket(DocketSnapshotMixin):
         # would otherwise write over the lease.
         return self.key("leases:redelivery-sweep")
 
+    @property
+    def scheduler_lease_key(self) -> str:
+        # Under `leases:` for the same reason as the sweep lease: a parked task
+        # keyed `scheduler` would otherwise write over it.
+        return self.key("leases:scheduler")
+
     def known_task_key(self, task_key: str) -> str:
         return self.key(f"known:{task_key}")
 

--- a/src/docket/worker.py
+++ b/src/docket/worker.py
@@ -35,6 +35,7 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode, Tracer
 
 from ._cancellation import CANCEL_MSG_CLEANUP, _wait_for_event, cancel_task
+from ._lease import take_lease
 from ._lua import Arg, Key, redis_script
 from ._redelivery import RedeliverySweep, renew_leases
 from ._redis import RedisClient
@@ -866,27 +867,50 @@ class Worker:
             return  # pragma: no cover
 
         log_context = self._log_context()
+        # Only the worker that takes the lease scans the queue this tick; the
+        # move is idempotent, so the lease only spares the fleet the redundant
+        # scans, never the scheduling itself.  The lease lasts one scheduling
+        # resolution, so a live holder's lease has expired by its own next tick
+        # and it can win again: a holder must not block its own next scan.  The
+        # short lease also lets a dead holder's scanning resume within about one
+        # resolution.  If the lease briefly lapses and two workers both scan in
+        # one tick, that is harmless; that is preferred over ever delaying due
+        # tasks to enforce a single scanner.
+        #
+        # The TTL follows the winner's own resolution but never exceeds one
+        # second, so a worker configured with a long resolution cannot win the
+        # lease and pause everyone else's scanning for that long.  Above one
+        # second the fleet therefore scans more often than one winner's
+        # resolution.  That extra scanning is cheap, and preferable to delaying
+        # due tasks.
+        lease_ttl_ms = min(int(self.scheduling_resolution.total_seconds() * 1000), 1000)
         while not session.stopping.is_set():  # pragma: no branch
             try:
                 logger.debug("Scheduling due tasks", extra=log_context)
                 with self._maybe_suppress_instrumentation():
-                    total_work, due_work = await _stream_due_tasks(
+                    if await take_lease(
                         cast(RedisClient, redis),
-                        queue_key=self.docket.queue_key,
-                        stream_key=self.docket.stream_key,
-                        now_timestamp=datetime.now(timezone.utc).timestamp(),
-                        docket_prefix=self.docket.prefix,
-                    )
+                        self.docket.scheduler_lease_key,
+                        self.name,
+                        lease_ttl_ms,
+                    ):
+                        total_work, due_work = await _stream_due_tasks(
+                            cast(RedisClient, redis),
+                            queue_key=self.docket.queue_key,
+                            stream_key=self.docket.stream_key,
+                            now_timestamp=datetime.now(timezone.utc).timestamp(),
+                            docket_prefix=self.docket.prefix,
+                        )
 
-                if due_work > 0:
-                    logger.debug(
-                        "Moved %d/%d due tasks from %s to %s",
-                        due_work,
-                        total_work,
-                        self.docket.queue_key,
-                        self.docket.stream_key,
-                        extra=log_context,
-                    )
+                        if due_work > 0:
+                            logger.debug(
+                                "Moved %d/%d due tasks from %s to %s",
+                                due_work,
+                                total_work,
+                                self.docket.queue_key,
+                                self.docket.stream_key,
+                                extra=log_context,
+                            )
             except Exception:  # pragma: no cover
                 logger.exception(
                     "Error in scheduler loop",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,9 +389,11 @@ async def key_leak_checker(docket: Docket) -> AsyncGenerator[KeyCountChecker, No
             for task_name in docket.tasks:
                 await r.zrem(docket.task_workers_set(task_name), temp_worker.name)
             await r.delete(docket.worker_tasks_set(temp_worker.name))
-            # Release the sweep lease the temp worker took, so the test's own
-            # worker can win it and sweep instead of waiting it out.
+            # Release the sweep and scheduler leases the temp worker took, so
+            # the test's own worker can win them and scan instead of waiting
+            # them out.
             await r.delete(docket.redelivery_sweep_key)
+            await r.delete(docket.scheduler_lease_key)
 
     await checker.capture_baseline()
 

--- a/tests/test_lease.py
+++ b/tests/test_lease.py
@@ -1,0 +1,58 @@
+"""Tests for the fleet-wide lease that paces a periodic, Redis-heavy job.
+
+Only one worker per interval should run a scan that costs the same however
+large the fleet is.  ``take_lease`` is that gate: the first caller wins the
+lease, later callers lose it until it expires on its own.
+"""
+
+import asyncio
+import importlib
+import time
+from typing import cast
+
+import pytest
+
+from docket._lease import take_lease
+from docket._redis import RedisClient
+
+
+@pytest.fixture
+def lease_redis() -> RedisClient:
+    """An in-process Redis for the lease.
+
+    The lease logic is backend-independent, so these unit tests run it against a
+    burner Redis whatever backend the suite targets.
+    """
+    burner_redis = importlib.import_module("burner_redis")
+    return cast(RedisClient, burner_redis.BurnerRedis())
+
+
+async def test_the_first_caller_wins_the_lease(lease_redis: RedisClient):
+    """The first caller to take a free lease wins it."""
+    assert await take_lease(lease_redis, "lease", "worker-a", 1000) is True
+
+
+async def test_a_second_caller_loses_a_held_lease(lease_redis: RedisClient):
+    """While one caller holds the lease, a second caller loses it."""
+    assert await take_lease(lease_redis, "lease", "worker-a", 1000) is True
+    assert await take_lease(lease_redis, "lease", "worker-b", 1000) is False
+
+
+async def test_the_holder_is_recorded_on_the_key(lease_redis: RedisClient):
+    """The winner's name is stored on the lease key."""
+    await take_lease(lease_redis, "lease", "worker-a", 1000)
+    assert await lease_redis.get("lease") == b"worker-a"
+
+
+async def test_the_lease_is_winnable_again_after_it_expires(lease_redis: RedisClient):
+    """Once the lease expires nobody renews it, so the next caller wins it.
+
+    A short expiry with a real Redis: poll until the key lapses rather than
+    sleeping a fixed time that races the backend's clock.
+    """
+    assert await take_lease(lease_redis, "lease", "worker-a", 50) is True
+
+    deadline = time.monotonic() + 2.0
+    while await take_lease(lease_redis, "lease", "worker-b", 50) is False:
+        assert time.monotonic() < deadline, "lease never expired"
+        await asyncio.sleep(0.01)

--- a/tests/worker/test_scheduler_lease.py
+++ b/tests/worker/test_scheduler_lease.py
@@ -1,0 +1,180 @@
+"""Tests for the fleet-wide lease that gates the scheduler's queue scan.
+
+Every worker runs the scheduler loop, but only the worker that takes the lease
+scans the scheduled-tasks queue each tick.  The move is idempotent, so the lease
+changes no scheduling outcome; it only spares the fleet the redundant scans.  It
+must never delay a due task.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+
+from docket import Docket, Worker
+from docket import worker as worker_module
+
+
+async def test_a_scheduled_task_still_moves_and_runs_with_the_lease(
+    docket: Docket, worker: Worker, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """A future task the scheduler must move to the stream still runs promptly.
+
+    A single worker always wins its own lease, so the lease never keeps it from
+    scanning.  The task lands in the queue, the scheduler moves it, and it runs.
+    """
+    when = now() + timedelta(milliseconds=50)
+    await docket.add(the_task, when, key="scheduled")("a", b="b")
+
+    await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with("a", b="b")
+
+
+async def test_two_workers_scan_fewer_times_than_they_check(
+    docket: Docket,
+    the_task: AsyncMock,
+    now: Callable[[], datetime],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two workers check the lease every tick, but the fleet scans less often.
+
+    Each worker attempts the lease on every scheduler tick; only the one that
+    wins scans the queue.  So the fleet runs strictly fewer scans than checks,
+    which is the whole point of the lease.  Every scheduled task still runs.
+    """
+    checks = 0
+    scans = 0
+    real_take_lease = worker_module.take_lease
+    real_stream_due = worker_module._stream_due_tasks  # pyright: ignore[reportPrivateUsage]
+
+    async def counting_take_lease(*args: object, **kwargs: object) -> bool:
+        nonlocal checks
+        checks += 1
+        return await real_take_lease(*args, **kwargs)  # type: ignore[arg-type]
+
+    async def counting_stream_due(*args: object, **kwargs: object) -> tuple[int, int]:
+        nonlocal scans
+        scans += 1
+        return await real_stream_due(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(worker_module, "take_lease", counting_take_lease)
+    monkeypatch.setattr(worker_module, "_stream_due_tasks", counting_stream_due)
+
+    for i in range(6):
+        when = now() + timedelta(milliseconds=40 * i)
+        await docket.add(the_task, when, key=f"scheduled-{i}")()
+
+    resolution = timedelta(milliseconds=20)
+    worker1 = Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=resolution,
+    )
+    worker2 = Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=resolution,
+    )
+    async with worker1, worker2:
+        run1 = asyncio.create_task(worker1.run_until_finished())
+        run2 = asyncio.create_task(worker2.run_until_finished())
+        await run1
+        await run2
+
+    assert the_task.await_count == 6
+    assert scans >= 1
+    assert scans < checks
+
+
+async def test_a_replacement_worker_takes_over_when_the_lease_holder_dies(
+    docket: Docket, the_task: AsyncMock, now: Callable[[], datetime]
+):
+    """A lease another worker holds only delays a scan, never blocks it.
+
+    Another worker holds the scheduler lease when this worker starts, so its
+    first ticks lose the lease and skip the scan.  The lease expires after one
+    scheduling resolution, well before the test times out, so this worker then
+    wins the lease, scans the queue, and runs the scheduled task.  The lease
+    paces the scan; it never drops a due task.
+    """
+    when = now() + timedelta(milliseconds=10)
+    await docket.add(the_task, when, key="scheduled")()
+
+    async with docket.redis() as redis:
+        await redis.set(docket.scheduler_lease_key, "other-worker", nx=True, px=100)
+
+    async with Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=timedelta(milliseconds=50),
+    ) as worker:
+        await worker.run_until_finished()
+
+    the_task.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    "resolution, expected_ttl_ms",
+    [
+        (timedelta(milliseconds=40), 40),
+        (timedelta(minutes=5), 1000),
+    ],
+)
+async def test_the_lease_follows_the_resolution_up_to_one_second(
+    docket: Docket,
+    monkeypatch: pytest.MonkeyPatch,
+    resolution: timedelta,
+    expected_ttl_ms: int,
+):
+    """The lease lasts one scheduling resolution, but never over a second.
+
+    Without the cap, a worker configured with a long resolution could win the
+    lease and pause the rest of the fleet's scanning for that long.
+    """
+    ttls: list[int] = []
+    real_take_lease = worker_module.take_lease
+
+    async def recording_take_lease(*args: object, **kwargs: object) -> bool:
+        ttls.append(args[3])  # type: ignore[arg-type]
+        return await real_take_lease(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(worker_module, "take_lease", recording_take_lease)
+
+    async with Worker(
+        docket,
+        minimum_check_interval=timedelta(milliseconds=5),
+        scheduling_resolution=resolution,
+    ) as worker:
+        await worker.run_until_finished()
+
+    assert set(ttls) == {expected_ttl_ms}
+
+
+async def test_the_scheduler_lease_expires_within_one_resolution(docket: Docket):
+    """The lease a worker takes expires within one scheduling resolution.
+
+    A short lease lets a live holder win again on its own next tick, and lets a
+    replacement start scanning within about one resolution after a holder dies.
+    """
+    resolution = timedelta(milliseconds=40)
+    ttl_ms = int(resolution.total_seconds() * 1000)
+    worker = Worker(docket, scheduling_resolution=resolution)
+
+    async with docket.redis() as redis:
+        won = await worker_module.take_lease(
+            redis, docket.scheduler_lease_key, worker.name, ttl_ms
+        )
+        assert won is True
+
+        deadline = datetime.now(timezone.utc) + timedelta(seconds=2)
+        while (
+            await worker_module.take_lease(
+                redis, docket.scheduler_lease_key, "replacement", ttl_ms
+            )
+            is False
+        ):
+            assert datetime.now(timezone.utc) < deadline, "lease never expired"
+            await asyncio.sleep(0.005)


### PR DESCRIPTION
Every worker runs the scheduler loop and scans the scheduled-tasks queue each
tick, so the scan cost grows with the fleet size. Only one worker needs to scan
per tick: the move is already atomic and idempotent, so two workers scanning at
once never double-schedule a task. The scan was pure redundant work.

Each tick a worker now takes a short fleet-wide lease, and only the winner scans
the queue; a loser skips the scan this tick and waits for its next tick. The
lease lasts one scheduling resolution, so a live holder's lease has expired by
its own next tick and it can win again, and a dead holder's scanning resumes
within about one resolution. If the lease briefly lapses and two workers both
scan in one tick, that is harmless. The scan is never delayed to enforce a
single scanner.

The redelivery sweep already used this exact pattern, so the lease now lives in
a shared `_lease.py` that both the sweep and the scheduler call.

## Compatibility

A new Redis key `{docket}:scheduler` appears: a short-lived lease string that
expires on its own. Old workers ignore it. During a mixed-version window old
workers still scan every tick, so the "one scanner" benefit is full only once
all workers are new. The scheduler move was already idempotent, so the lease
changes no scheduling outcome, only who does the scan. No change to task
payloads or to the stream/queue schema.

This is PR 6 (final) of the stack unbundling #463. It also factors the
fleet-wide lease into a shared `_lease.py` used by both the redelivery sweep and
the scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
