### PR TITLE
Allow --schedule-automatic-tasks to be disabled from the CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
 

--- a/loq.toml
+++ b/loq.toml
@@ -14,7 +14,7 @@ max_lines = 1424
 
 [[rules]]
 path = "src/docket/cli/__init__.py"
-max_lines = 968
+max_lines = 969
 
 [[rules]]
 path = "src/docket/execution.py"

--- a/src/docket/cli/__init__.py
+++ b/src/docket/cli/__init__.py
@@ -177,8 +177,9 @@ def worker(
     schedule_automatic_tasks: Annotated[
         bool,
         typer.Option(
-            "--schedule-automatic-tasks",
+            "--schedule-automatic-tasks/--no-schedule-automatic-tasks",
             help="Schedule automatic tasks",
+            envvar="DOCKET_WORKER_SCHEDULE_AUTOMATIC_TASKS",
         ),
     ] = True,
     enable_internal_instrumentation: Annotated[

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -75,6 +75,26 @@ def test_message_batch_option_reaches_the_worker(monkeypatch: pytest.MonkeyPatch
     assert passed["message_batch"] == 17
 
 
+def test_no_schedule_automatic_tasks_flag_reaches_the_worker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`--no-schedule-automatic-tasks` disables automatic task scheduling."""
+    from docket.cli import worker as worker_cli_command
+
+    passed: dict[str, object] = {}
+
+    class RecordingWorker:
+        @staticmethod
+        async def run(**kwargs: object) -> None:
+            passed.update(kwargs)
+
+    monkeypatch.setattr("docket.cli.Worker", RecordingWorker)
+
+    worker_cli_command(schedule_automatic_tasks=False)
+
+    assert passed["schedule_automatic_tasks"] is False
+
+
 async def test_message_batch_below_one_is_rejected():
     """The CLI fails at startup rather than running a worker that reads no
     messages."""
@@ -85,6 +105,20 @@ async def test_message_batch_below_one_is_rejected():
 
     assert result.exit_code != 0
     assert "--message-batch" in result.output
+
+
+async def test_no_schedule_automatic_tasks_flag_is_accepted(docket: Docket):
+    """`--no-schedule-automatic-tasks` should be a recognized CLI flag."""
+    result = await run_cli(
+        "worker",
+        "--until-finished",
+        "--no-schedule-automatic-tasks",
+        "--url",
+        docket.url,
+        "--docket",
+        docket.name,
+    )
+    assert result.exit_code == 0, result.output
 
 
 async def test_worker_command(


### PR DESCRIPTION
## Summary
- `docket worker --schedule-automatic-tasks` was a bare presence flag with no way to actually turn it off from the CLI, even though it's documented as a boolean defaulting to `True`.
- Adds a `--no-schedule-automatic-tasks` counterpart and a `DOCKET_WORKER_SCHEDULE_AUTOMATIC_TASKS` envvar, matching the existing pattern used for `--enable-internal-instrumentation`.
- Also renames the `ruff` pre-commit hook id to `ruff-check`, since `ruff-pre-commit` v0.14.14 deprecated the bare `ruff` id as a legacy alias.

Fixes #458

## Test plan
- [x] `test_no_schedule_automatic_tasks_flag_reaches_the_worker` — verifies the flag value is passed through to `Worker.run`
- [x] `test_no_schedule_automatic_tasks_flag_is_accepted` — verifies `--no-schedule-automatic-tasks` is accepted end-to-end via the CLI
- [x] Full `tests/cli/` suite passes (100 passed)
- [x] Full test suite passes (961 passed, 84 skipped), matching baseline coverage on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)